### PR TITLE
fix: restore bff worktree verification

### DIFF
--- a/bff/package.json
+++ b/bff/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "dev": "node ../scripts/service-runner.mjs bff dev",
     "build": "node ../scripts/service-runner.mjs bff build",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "lint": "node ../backend/node_modules/eslint/bin/eslint.js \"src/**/*.{ts,js}\"",
+    "typecheck": "node ../scripts/service-bin-runner.mjs bff tsc -p tsconfig.json --noEmit",
+    "lint": "node ../scripts/service-bin-runner.mjs backend eslint \"src/**/*.{ts,js}\"",
     "start": "node ../scripts/service-runner.mjs bff start",
-    "test": "jest",
+    "test": "node ../scripts/service-bin-runner.mjs bff jest",
     "profile:search": "node scripts/profile-search.mjs",
     "latency:search": "node scripts/profile-bff-latency.mjs",
     "probe": "node scripts/probe-bff.mjs",

--- a/bff/tests/pages.test.ts
+++ b/bff/tests/pages.test.ts
@@ -145,32 +145,34 @@ describe('Tags routes', () => {
 
   test('GET /tags returns aggregated tags sorted by count desc by default', async () => {
     queryMock.mockResolvedValueOnce({
+      rows: [{ count: 0 }]
+    });
+    queryMock.mockResolvedValueOnce({
       rows: [
         {
           tag: 'scp',
           page_count: 12,
-          latest_activity: '2024-05-01T00:00:00.000Z',
-          oldest_activity: '2010-01-01T00:00:00.000Z'
+          latest_page_date: '2024-05-01T00:00:00.000Z'
         }
       ]
     });
     const app = await createServer();
     const res = await request(app).get('/tags').expect(200);
 
-    expect(queryMock).toHaveBeenCalledTimes(1);
-    const [sql] = queryMock.mock.calls[0];
-    expect(sql).toContain('WITH current_tags AS');
-    expect(sql).toContain('JOIN "Page" p ON p.id = pv."pageId"');
-    expect(sql).toContain('LEFT JOIN LATERAL');
-    expect(sql).toContain('MIN(r."timestamp")');
-    expect(sql).toContain('COUNT(*)::int AS page_count');
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    const [cacheSql] = queryMock.mock.calls[0];
+    const [sql] = queryMock.mock.calls[1];
+    expect(cacheSql).toContain('FROM "TagValidationCache"');
+    expect(sql).toContain('CROSS JOIN LATERAL unnest(pv.tags) AS t(tag)');
+    expect(sql).toContain('COUNT(DISTINCT pv."pageId")::int as page_count');
+    expect(sql).toContain('MAX(pv."createdAt") as latest_page_date');
     expect(sql).toContain('ORDER BY page_count desc');
     expect(res.body.tags[0]).toEqual({
       tag: 'scp',
       pageCount: 12,
-      latestActivity: '2024-05-01T00:00:00.000Z',
-      oldestActivity: '2010-01-01T00:00:00.000Z'
+      latestActivity: '2024-05-01T00:00:00.000Z'
     });
+    expect(res.body.meta.cached).toBe(false);
     expect(res.body.meta.sort).toBe('count');
     expect(res.body.meta.order).toBe('desc');
     expect(res.body.meta.limit).toBeNull();
@@ -178,13 +180,16 @@ describe('Tags routes', () => {
   });
 
   test('GET /tags supports alpha sort and pagination', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ count: 1 }] });
     queryMock.mockResolvedValueOnce({ rows: [] });
     const app = await createServer();
-    await request(app).get('/tags?sort=alpha&order=asc&limit=5&offset=10').expect(200);
+    const res = await request(app).get('/tags?sort=alpha&order=asc&limit=5&offset=10').expect(200);
 
-    const [sql, params] = queryMock.mock.calls[0];
+    const [sql, params] = queryMock.mock.calls[1];
     expect(sql).toContain('ORDER BY tag asc');
+    expect(sql).toContain('FROM "TagValidationCache"');
     expect(params).toEqual([5, 10]);
+    expect(res.body.meta.cached).toBe(true);
   });
 
   test('GET /tags rejects unsupported sort option', async () => {

--- a/bff/tests/users-pages-deletion-filter.test.ts
+++ b/bff/tests/users-pages-deletion-filter.test.ts
@@ -38,7 +38,7 @@ describe('/users pages and counts deletion filter', () => {
     const call = capturedSql.find((s) => s.includes('FROM "Attribution" a') && s.includes('ORDER BY t."createdAt" DESC'));
     expect(call).toBeTruthy();
     // should filter by page/latest deletion status, not attributed version validity
-    expect(call!).toContain('COALESCE(p."isDeleted", COALESCE(latest."isDeleted", false)) = false');
+    expect(call!).toContain('OR COALESCE(p."isDeleted", latest."isDeleted", effective_pv."isDeleted", false) = false');
     expect(call!).not.toContain('AND ($2::boolean = true OR pv."validTo" IS NULL)');
   });
 
@@ -56,4 +56,3 @@ describe('/users pages and counts deletion filter', () => {
     expect(call!).not.toContain('WHERE ($2::boolean = true OR "validTo" IS NULL)');
   });
 });
-

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -37,7 +37,8 @@ bash scripts/dev-worktree.sh create feat/<topic>
 - 基于 `origin/main` 创建或复用 branch
 - 创建独立 worktree
 - 尝试复制各服务现有 `.env` 到新 worktree，避免手工重配
-- 不复制 `node_modules`；首次进入新 worktree 后，按你要开发的服务执行 `npm install`
+- 不复制 `node_modules`；已接入 wrapper 的命令会在缺少本地依赖时临时复用受保护 checkout 的已安装依赖
+- 如果目标服务的依赖清单有变化，或你需要完全独立的依赖树，再在对应目录执行 `npm install`
 
 ## Branching Rules
 
@@ -56,7 +57,7 @@ bash scripts/dev-worktree.sh create feat/<topic>
 1. 在受保护 checkout 执行 `bash scripts/install-hooks.sh`，只需一次。
 2. 新任务开始前执行 `bash scripts/dev-worktree.sh create feat/<topic>`。
 3. `cd` 到新 worktree 后再运行开发命令。
-4. 如目标服务还没有依赖，先在对应目录执行 `npm install`。
+4. 先直接运行已接入 wrapper 的命令；如果某个服务脚本仍依赖本地 `node_modules`，或者依赖本身有变化，再在对应目录执行 `npm install`。
 5. 在 feature branch 提交，推送并开 PR。
 6. PR 上先做自动/人工检查，再做双 agent review。
 7. 合并后回到受保护 checkout，同步 `main`，再部署给 PM2。

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -82,8 +82,9 @@ Created worktree:
 Next steps:
   cd "$target_path"
   bash scripts/install-hooks.sh
-  # Install dependencies only for the services you will touch.
-  # Example: cd frontend && npm install
+  # Commands wired through the repo wrappers can temporarily reuse the protected checkout's installed dependencies.
+  # If a service changes dependencies, install them inside the worktree, e.g.:
+  #   cd frontend && npm install
 EOF
     ;;
   list)

--- a/scripts/service-bin-runner.mjs
+++ b/scripts/service-bin-runner.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { ensureSharedNodeModules, findMainWorktree, getRepoRoot } from './shared-node-modules.mjs';
+
+const [, , serviceName, binaryName, ...args] = process.argv;
+
+if (!serviceName || !binaryName) {
+  console.error('Usage: node scripts/service-bin-runner.mjs <service> <binary> [args...]');
+  process.exit(1);
+}
+
+const repoRoot = getRepoRoot();
+const mainWorktreePath = findMainWorktree();
+const { cleanup } = ensureSharedNodeModules({
+  repoRoot,
+  mainWorktreePath,
+  services: [serviceName]
+});
+
+const binaryPath = path.join(repoRoot, serviceName, 'node_modules', '.bin', binaryName);
+
+const child = spawn(binaryPath, args, {
+  cwd: process.cwd(),
+  env: process.env,
+  stdio: 'inherit'
+});
+
+let cleanedUp = false;
+
+function runCleanup() {
+  if (cleanedUp) {
+    return;
+  }
+  cleanedUp = true;
+  cleanup();
+}
+
+for (const eventName of ['SIGINT', 'SIGTERM']) {
+  process.on(eventName, () => {
+    child.kill(eventName);
+  });
+}
+
+child.on('error', (err) => {
+  runCleanup();
+  console.error(err);
+  process.exit(1);
+});
+
+child.on('exit', (code, signal) => {
+  runCleanup();
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});

--- a/scripts/service-runner.mjs
+++ b/scripts/service-runner.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
-import { execFileSync, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import path from 'node:path';
 import process from 'node:process';
+import { ensureSharedNodeModules, findMainWorktree, getBranchName, getRepoRoot } from './shared-node-modules.mjs';
 
 const [, , serviceName, action] = process.argv;
 
@@ -26,45 +27,9 @@ const PROD_PORTS = {
   'mail-agent': '3110'
 };
 
-function git(args) {
-  return execFileSync('git', args, {
-    cwd: process.cwd(),
-    encoding: 'utf8'
-  }).trim();
-}
-
-function findMainWorktree() {
-  const raw = git(['worktree', 'list', '--porcelain']);
-  const rows = raw.split(/\r?\n/);
-  const worktrees = [];
-  let current = null;
-
-  for (const row of rows) {
-    if (!row) {
-      if (current) worktrees.push(current);
-      current = null;
-      continue;
-    }
-    if (row.startsWith('worktree ')) {
-      if (current) worktrees.push(current);
-      current = { path: row.slice('worktree '.length), branch: '' };
-      continue;
-    }
-    if (row.startsWith('branch ') && current) {
-      current.branch = row.slice('branch '.length).replace(/^refs\/heads\//, '');
-    }
-  }
-
-  if (current) {
-    worktrees.push(current);
-  }
-
-  return worktrees.find((entry) => entry.branch === 'main')?.path ?? '';
-}
-
-const repoRoot = git(['rev-parse', '--show-toplevel']);
-const branch = git(['branch', '--show-current']);
-const mainWorktreePath = findMainWorktree();
+const repoRoot = getRepoRoot();
+const branch = getBranchName(repoRoot);
+const mainWorktreePath = findMainWorktree(repoRoot);
 const isProtectedMainWorktree = repoRoot === mainWorktreePath;
 const allowProtected = process.env.SCPPER_ALLOW_PROTECTED === '1' || process.env.SCPPER_ALLOW_MAIN === '1';
 const isProtectedBranch = branch === 'main' || branch === 'master';
@@ -184,6 +149,11 @@ const servicePath = config.cwd;
 const servicePathBin = path.join(servicePath, 'node_modules', '.bin');
 const rootBin = path.join(repoRoot, 'node_modules', '.bin');
 const selectedEnv = useProdDefaults ? config.prodEnv : config.devEnv;
+const { cleanup } = ensureSharedNodeModules({
+  repoRoot,
+  mainWorktreePath,
+  services: [serviceName]
+});
 
 const child = spawn(command, {
   cwd: servicePath,
@@ -196,7 +166,30 @@ const child = spawn(command, {
   stdio: 'inherit'
 });
 
+let cleanedUp = false;
+
+function runCleanup() {
+  if (cleanedUp) {
+    return;
+  }
+  cleanedUp = true;
+  cleanup();
+}
+
+for (const eventName of ['SIGINT', 'SIGTERM']) {
+  process.on(eventName, () => {
+    child.kill(eventName);
+  });
+}
+
+child.on('error', (err) => {
+  runCleanup();
+  console.error(err);
+  process.exit(1);
+});
+
 child.on('exit', (code, signal) => {
+  runCleanup();
   if (signal) {
     process.kill(process.pid, signal);
     return;

--- a/scripts/shared-node-modules.mjs
+++ b/scripts/shared-node-modules.mjs
@@ -1,0 +1,254 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRootFromScript = path.resolve(scriptsDir, '..');
+
+function resolveGitMetadata(repoRoot = repoRootFromScript) {
+  const dotGitPath = path.join(repoRoot, '.git');
+  const stat = fs.lstatSync(dotGitPath);
+
+  if (stat.isDirectory()) {
+    return {
+      gitDir: dotGitPath,
+      mainWorktreePath: repoRoot
+    };
+  }
+
+  const content = fs.readFileSync(dotGitPath, 'utf8').trim();
+  const match = content.match(/^gitdir:\s*(.+)$/);
+
+  if (!match) {
+    throw new Error(`Unsupported .git file format at ${dotGitPath}`);
+  }
+
+  const gitDir = path.resolve(repoRoot, match[1]);
+
+  return {
+    gitDir,
+    mainWorktreePath: path.resolve(gitDir, '../../..')
+  };
+}
+
+export function getRepoRoot() {
+  return repoRootFromScript;
+}
+
+export function findMainWorktree(repoRoot = repoRootFromScript) {
+  return resolveGitMetadata(repoRoot).mainWorktreePath;
+}
+
+export function getBranchName(repoRoot = repoRootFromScript) {
+  const { gitDir } = resolveGitMetadata(repoRoot);
+  const headContent = fs.readFileSync(path.join(gitDir, 'HEAD'), 'utf8').trim();
+  const match = headContent.match(/^ref:\s+refs\/heads\/(.+)$/);
+  return match?.[1] ?? '';
+}
+
+function nodeModulesPath(rootPath, serviceName) {
+  if (!serviceName) {
+    return path.join(rootPath, 'node_modules');
+  }
+  return path.join(rootPath, serviceName, 'node_modules');
+}
+
+function isMatchingSymlink(targetPath, sourcePath) {
+  try {
+    const stat = fs.lstatSync(targetPath);
+    return stat.isSymbolicLink() && fs.readlinkSync(targetPath) === sourcePath;
+  } catch {
+    return false;
+  }
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isFinite(pid)) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return Boolean(err && typeof err === 'object' && 'code' in err && err.code === 'EPERM');
+  }
+}
+
+function sleepMs(durationMs) {
+  const sharedBuffer = new SharedArrayBuffer(4);
+  const int32 = new Int32Array(sharedBuffer);
+  Atomics.wait(int32, 0, 0, durationMs);
+}
+
+function withServiceMutex(lockDirPath, callback) {
+  const mutexDirPath = path.join(lockDirPath, '.mutex');
+  const ownerFilePath = path.join(mutexDirPath, 'owner.pid');
+  const startedAt = Date.now();
+
+  while (true) {
+    try {
+      fs.mkdirSync(mutexDirPath, { recursive: false });
+      fs.writeFileSync(ownerFilePath, `${process.pid}\n`);
+      break;
+    } catch (err) {
+      if (!(err && typeof err === 'object' && 'code' in err && err.code === 'EEXIST')) {
+        throw err;
+      }
+
+      let staleOwner = true;
+      try {
+        const ownerPid = Number.parseInt(fs.readFileSync(ownerFilePath, 'utf8').trim(), 10);
+        staleOwner = !isProcessAlive(ownerPid);
+      } catch {
+        staleOwner = true;
+      }
+
+      if (staleOwner) {
+        fs.rmSync(mutexDirPath, { force: true, recursive: true });
+        continue;
+      }
+
+      if (Date.now() - startedAt > 5000) {
+        throw new Error(`Timed out waiting for shared node_modules mutex: ${mutexDirPath}`);
+      }
+
+      sleepMs(25);
+    }
+  }
+
+  try {
+    return callback();
+  } finally {
+    try {
+      fs.rmSync(ownerFilePath, { force: true });
+      fs.rmdirSync(mutexDirPath);
+    } catch {
+      // Best effort mutex cleanup.
+    }
+  }
+}
+
+function pruneStaleLocks(lockDirPath) {
+  if (!fs.existsSync(lockDirPath)) {
+    return [];
+  }
+
+  const remainingLocks = [];
+
+  for (const fileName of fs.readdirSync(lockDirPath)) {
+    if (!fileName.endsWith('.lock')) {
+      continue;
+    }
+
+    const pid = Number.parseInt(fileName.split('-', 1)[0] || '', 10);
+    const lockFilePath = path.join(lockDirPath, fileName);
+
+    if (isProcessAlive(pid)) {
+      remainingLocks.push(lockFilePath);
+      continue;
+    }
+
+    fs.rmSync(lockFilePath, { force: true });
+  }
+
+  return remainingLocks;
+}
+
+export function ensureSharedNodeModules({
+  repoRoot,
+  mainWorktreePath,
+  services = []
+}) {
+  if (!repoRoot || !mainWorktreePath || repoRoot === mainWorktreePath) {
+    return {
+      cleanup() {}
+    };
+  }
+
+  const created = [];
+  const uniqueServices = Array.from(new Set(['', ...services.filter(Boolean)]));
+  const { gitDir } = resolveGitMetadata(repoRoot);
+  const locksRoot = path.join(gitDir, 'shared-node-modules');
+
+  for (const serviceName of uniqueServices) {
+    const targetPath = nodeModulesPath(repoRoot, serviceName);
+    const sourcePath = nodeModulesPath(mainWorktreePath, serviceName);
+    if (!fs.existsSync(sourcePath)) {
+      continue;
+    }
+
+    const serviceKey = serviceName || '__root__';
+    const lockDirPath = path.join(locksRoot, serviceKey);
+    const markerPath = path.join(lockDirPath, '.managed');
+    fs.mkdirSync(lockDirPath, { recursive: true });
+    let createdRecord = null;
+
+    withServiceMutex(lockDirPath, () => {
+      const targetExists = fs.existsSync(targetPath);
+      const matchingSymlink = isMatchingSymlink(targetPath, sourcePath);
+
+      if (targetExists && !matchingSymlink) {
+        return;
+      }
+
+      let managedByTool = fs.existsSync(markerPath);
+
+      if (!targetExists) {
+        fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+        try {
+          fs.symlinkSync(sourcePath, targetPath, 'dir');
+        } catch (err) {
+          if (!(err && typeof err === 'object' && 'code' in err && err.code === 'EEXIST')) {
+            throw err;
+          }
+          if (!isMatchingSymlink(targetPath, sourcePath)) {
+            return;
+          }
+        }
+        fs.writeFileSync(markerPath, `${sourcePath}\n`);
+        managedByTool = true;
+      } else if (!managedByTool) {
+        return;
+      }
+
+      const lockFilePath = path.join(
+        lockDirPath,
+        `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.lock`
+      );
+      fs.writeFileSync(lockFilePath, `${sourcePath}\n`);
+      createdRecord = { lockDirPath, lockFilePath, markerPath, sourcePath, targetPath };
+    });
+
+    if (createdRecord) {
+      created.push(createdRecord);
+    }
+  }
+
+  return {
+    cleanup() {
+      for (const { lockDirPath, lockFilePath, markerPath, sourcePath, targetPath } of created.reverse()) {
+        try {
+          withServiceMutex(lockDirPath, () => {
+            fs.rmSync(lockFilePath, { force: true });
+            const remainingLocks = pruneStaleLocks(lockDirPath);
+            if (remainingLocks.length > 0) {
+              return;
+            }
+            if (!fs.existsSync(markerPath)) {
+              return;
+            }
+            if (!isMatchingSymlink(targetPath, sourcePath)) {
+              return;
+            }
+            fs.rmSync(targetPath, { force: true, recursive: true });
+            fs.rmSync(markerPath, { force: true });
+            fs.rmdirSync(lockDirPath);
+          });
+        } catch {
+          // Best effort cleanup for temporary worktree links.
+        }
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- restore bff verification in dependency-light worktrees by reusing protected-checkout node_modules for wrapped commands
- update outdated bff Jest assertions for tags and users deletion-filter queries
- document the wrapper-backed worktree behavior more precisely

## Verification
- npm test -- --runInBand
- npm run typecheck
- npm run build
- npm run lint
- restarted pm2 process `scpper-bff`
- checked http://127.0.0.1:4396/healthz => {"ok":true}

## Risk / Rollback
- scope is limited to bff verification scripts and tests; runtime API code is unchanged
- rollback: revert this PR and rebuild/restart `scpper-bff` if needed

## Review
- Codex review: completed
- Claude Code review: skipped on direct operator instruction