### PR TITLE
fix: reduce gacha tick delay and correct cutoff dates

### DIFF
--- a/backend/src/cli/fixCategoryIndexVoteCutoffDate.ts
+++ b/backend/src/cli/fixCategoryIndexVoteCutoffDate.ts
@@ -1,0 +1,80 @@
+import { Prisma } from '@prisma/client';
+import { getPrismaClient } from '../utils/db-connection.js';
+
+const prisma = getPrismaClient();
+
+const FIX_EXPR = Prisma.sql`(("as_of_ts" + INTERVAL '8 hour')::date - 1)`;
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+
+  const [summaryRows, sampleRows] = await Promise.all([
+    prisma.$queryRaw<Array<{
+      affected_count: bigint;
+      min_as_of_ts: Date | null;
+      max_as_of_ts: Date | null;
+    }>>(Prisma.sql`
+      SELECT
+        COUNT(*)::bigint AS affected_count,
+        MIN("as_of_ts") AS min_as_of_ts,
+        MAX("as_of_ts") AS max_as_of_ts
+      FROM "CategoryIndexTick"
+      WHERE "vote_cutoff_date" <> ${FIX_EXPR}
+    `),
+    prisma.$queryRaw<Array<{
+      category: string;
+      as_of_ts: Date;
+      stored_vote_cutoff_date: string;
+      expected_vote_cutoff_date: string;
+    }>>(Prisma.sql`
+      SELECT
+        category,
+        "as_of_ts",
+        "vote_cutoff_date"::text AS stored_vote_cutoff_date,
+        ${FIX_EXPR}::text AS expected_vote_cutoff_date
+      FROM "CategoryIndexTick"
+      WHERE "vote_cutoff_date" <> ${FIX_EXPR}
+      ORDER BY "as_of_ts" DESC
+      LIMIT 12
+    `)
+  ]);
+
+  const summary = summaryRows[0];
+  const affectedCount = Number(summary?.affected_count ?? 0n);
+
+  console.log(JSON.stringify({
+    apply,
+    affectedCount,
+    minAsOfTs: summary?.min_as_of_ts?.toISOString() ?? null,
+    maxAsOfTs: summary?.max_as_of_ts?.toISOString() ?? null,
+    sampleRows: sampleRows.map((row) => ({
+      category: row.category,
+      asOfTs: row.as_of_ts.toISOString(),
+      storedVoteCutoffDate: row.stored_vote_cutoff_date,
+      expectedVoteCutoffDate: row.expected_vote_cutoff_date
+    }))
+  }, null, 2));
+
+  if (!apply || affectedCount === 0) {
+    return;
+  }
+
+  const updatedCount = await prisma.$executeRaw(Prisma.sql`
+    UPDATE "CategoryIndexTick"
+    SET "vote_cutoff_date" = ${FIX_EXPR}
+    WHERE "vote_cutoff_date" <> ${FIX_EXPR}
+  `);
+
+  console.log(JSON.stringify({
+    updatedCount
+  }, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/core/processors/PhaseAProcessor.ts
+++ b/backend/src/core/processors/PhaseAProcessor.ts
@@ -196,11 +196,14 @@ export class PhaseAProcessor {
           try {
             const currentVersion = await loadCurrentVersion();
             if (currentVersion) {
+              const nextAttributionCount = node.attributions.length;
               await this.attrService.importAttributions(currentVersion.id, node.attributions);
-              await this.store.prisma.pageVersion.update({
-                where: { id: currentVersion.id },
-                data: { attributionCount: node.attributions.length }
-              });
+              if (currentVersion.attributionCount !== nextAttributionCount) {
+                await this.store.prisma.pageVersion.update({
+                  where: { id: currentVersion.id },
+                  data: { attributionCount: nextAttributionCount }
+                });
+              }
             }
           } catch (e) {
             Logger.warn('Phase A attribution import failed', {
@@ -214,10 +217,11 @@ export class PhaseAProcessor {
         if (wikidotId != null && node.commentCount != null) {
           try {
             const currentVersion = await loadCurrentVersion();
-            if (currentVersion) {
+            const nextCommentCount = Number(node.commentCount);
+            if (currentVersion && currentVersion.commentCount !== nextCommentCount) {
               await this.store.prisma.pageVersion.update({
                 where: { id: currentVersion.id },
-                data: { commentCount: Number(node.commentCount) }
+                data: { commentCount: nextCommentCount }
               });
             }
           } catch (e) {

--- a/backend/src/jobs/CategoryIndexTickJob.ts
+++ b/backend/src/jobs/CategoryIndexTickJob.ts
@@ -146,6 +146,15 @@ function startOfUtc8Day(input: Date) {
   return removeUtc8Offset(shifted);
 }
 
+function utcDateOnlyFromUtc8Day(input: Date) {
+  const shifted = addUtc8Offset(input);
+  return new Date(Date.UTC(
+    shifted.getUTCFullYear(),
+    shifted.getUTCMonth(),
+    shifted.getUTCDate()
+  ));
+}
+
 function startOfUtc8Week(input: Date) {
   const shifted = addUtc8Offset(input);
   const day = shifted.getUTCDay();
@@ -461,7 +470,7 @@ export class CategoryIndexTickJob {
         const baseIndexMark = indexOpen * Math.exp(INDEX_K * scoreProvisional);
         const noise = this.deterministicNoise(category, asOfTs, NOISE_AMPLITUDE);
         const indexMark = Number((baseIndexMark * (1 + noise)).toFixed(6));
-        const voteCutoffDate = startOfUtc8Day(addUtc8Days(asOfTs, -1));
+        const voteCutoffDate = utcDateOnlyFromUtc8Day(startOfUtc8Day(addUtc8Days(asOfTs, -1)));
 
         try {
           await this.prisma.categoryIndexTick.create({

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -41,6 +41,10 @@ export class IncrementalAnalyzeJob {
         'user_social_analysis',
         'site_stats',
         'daily_aggregates',
+        // Tick depends on fresh daily aggregates; keep it early so market data is
+        // not blocked behind slower downstream reporting jobs.
+        'category_index_tick',
+        'category_index_forecast',
         'voting_time_series_cache',
         'materialized_views',
         'interesting_facts',
@@ -56,8 +60,6 @@ export class IncrementalAnalyzeJob {
         'page_metric_alerts',
         'user_follow_alerts',
         'user_collection_sanitizer',
-        'category_index_tick',
-        'category_index_forecast',
         // 新增：作者分类基准
         'category_benchmarks',
         // Wikidot 账号绑定验证

--- a/bff/src/web/routes/internal.ts
+++ b/bff/src/web/routes/internal.ts
@@ -10,7 +10,7 @@ export function internalRouter() {
     category: string;
     asOfTs: Date;
     watermarkTs: Date | null;
-    voteCutoffDate: Date;
+    voteCutoffDate: string;
     voteRuleVersion: string;
     indexMark: string;
     crowdDrag: string | null;
@@ -348,7 +348,7 @@ export function internalRouter() {
            category,
            ("as_of_ts" AT TIME ZONE 'UTC') AS "asOfTs",
            (CASE WHEN "watermark_ts" IS NULL THEN NULL ELSE ("watermark_ts" AT TIME ZONE 'UTC') END) AS "watermarkTs",
-           "vote_cutoff_date" AS "voteCutoffDate",
+           to_char("vote_cutoff_date", 'YYYY-MM-DD') AS "voteCutoffDate",
            "vote_rule_version" AS "voteRuleVersion",
            "index_mark"::text AS "indexMark",
            "crowd_drag"::text AS "crowdDrag",
@@ -369,7 +369,7 @@ export function internalRouter() {
           category: row.category,
           asOfTs: row.asOfTs.toISOString(),
           watermarkTs: row.watermarkTs ? row.watermarkTs.toISOString() : null,
-          voteCutoffDate: row.voteCutoffDate.toISOString().slice(0, 10),
+          voteCutoffDate: row.voteCutoffDate,
           voteRuleVersion: row.voteRuleVersion,
           indexMark: Number(row.indexMark || 0),
           crowdDrag: Number(row.crowdDrag || 0),
@@ -410,7 +410,7 @@ export function internalRouter() {
            category,
            ("as_of_ts" AT TIME ZONE 'UTC') AS "asOfTs",
            (CASE WHEN "watermark_ts" IS NULL THEN NULL ELSE ("watermark_ts" AT TIME ZONE 'UTC') END) AS "watermarkTs",
-           "vote_cutoff_date" AS "voteCutoffDate",
+           to_char("vote_cutoff_date", 'YYYY-MM-DD') AS "voteCutoffDate",
            "vote_rule_version" AS "voteRuleVersion",
            "index_mark"::text AS "indexMark",
            "crowd_drag"::text AS "crowdDrag",
@@ -432,7 +432,7 @@ export function internalRouter() {
           category: row.category,
           asOfTs: row.asOfTs.toISOString(),
           watermarkTs: row.watermarkTs ? row.watermarkTs.toISOString() : null,
-          voteCutoffDate: row.voteCutoffDate.toISOString().slice(0, 10),
+          voteCutoffDate: row.voteCutoffDate,
           voteRuleVersion: row.voteRuleVersion,
           indexMark: Number(row.indexMark || 0),
           crowdDrag: Number(row.crowdDrag || 0),


### PR DESCRIPTION
## Summary

- What changed:
  - avoid no-op `PageVersion` writes in Phase A so full scans stop dirtying almost every live page version
  - move `category_index_tick` and `category_index_forecast` earlier in incremental analysis, immediately after `daily_aggregates`
  - persist `voteCutoffDate` as the intended UTC+8 logical date and return it from BFF as a plain `YYYY-MM-DD` string
  - add a dry-run backfill CLI for historical `CategoryIndexTick.vote_cutoff_date`
- Why:
  - Tick generation was being delayed because incremental analysis saw ~33k false-positive `PageVersion.updatedAt` changes after Phase A
  - `voteCutoffDate` was stored/displayed one day early because a UTC+8 midnight instant was being truncated through `@db.Date` / JS `Date`

## Validation

- [x] Relevant lint / typecheck / tests were run
- [x] Manual verification steps are documented below
- [x] Config / migration / data risks are explained below

Manual verification:
- `cd backend && npm run lint`
- `cd backend && npm run typecheck`
- `cd bff && npm run typecheck`
- `cd bff && npm run build`
- `cd bff && npm test -- --runInBand`
- `cd backend && node --import tsx/esm src/cli/fixCategoryIndexVoteCutoffDate.ts`
  - dry-run reported `affectedCount: 4506` and did not modify data

## Review

- [ ] Codex review completed
- [ ] Claude Code review completed
- [ ] Review findings were resolved or explicitly accepted

## Deployment

- [ ] This change does not require deployment coordination
- [x] This change will be deployed from the protected `main` checkout
- [ ] PM2 target services are listed below if deployment is needed

PM2 target services if deployed:
- `scpper-sync`
- `scpper-bff`

## Notes

- Risk:
  - new ticks will be corrected after deploy, but historical `vote_cutoff_date` rows remain stale until the backfill script is run with `--apply`
  - Phase A still performs full scans; this change only suppresses no-op writes, so data coverage should be preserved
- Rollback:
  - revert this PR and redeploy protected `main`
  - do not run the backfill script with `--apply` if rollback is required before data migration
- Follow-up:
  - run Codex review and Claude Code review before merge
  - after deploy, run `node --import tsx/esm src/cli/fixCategoryIndexVoteCutoffDate.ts --apply` from the protected checkout if historical cutoff dates need correction
