### PR TITLE
fix: preserve attribution deltas in incremental analysis

### DIFF
--- a/backend/src/core/processors/PhaseAProcessor.ts
+++ b/backend/src/core/processors/PhaseAProcessor.ts
@@ -3,7 +3,11 @@ import { GraphQLClient } from '../client/GraphQLClient.js';
 import { CoreQueries } from '../graphql/CoreQueries.js';
 import { PointEstimator } from '../graphql/PointEstimator.js';
 import { DatabaseStore } from '../store/DatabaseStore.js';
-import { AttributionService } from '../store/AttributionService.js';
+import {
+  AttributionService,
+  buildDisplayNameAnonKey,
+  normalizeAttributionAnonKey
+} from '../store/AttributionService.js';
 import { Logger } from '../../utils/Logger.js';
 import { Progress } from '../../utils/Progress.js';
 import type { PageVersion } from '@prisma/client';
@@ -114,13 +118,17 @@ const normalizeIncomingAttributionSignature = (rawAttributions: unknown[]): stri
         : Number.parseInt(String(wikidotIdRaw ?? ''), 10);
       if (Number.isFinite(wikidotId)) {
         actorKey = `u:${wikidotId}`;
-      } else if (typeof userRecord.displayName === 'string' && userRecord.displayName.trim()) {
-        actorKey = `a:anon:${userRecord.displayName.trim()}`;
+      } else {
+        const anonKey = buildDisplayNameAnonKey(userRecord.displayName);
+        if (anonKey) {
+          actorKey = `a:${anonKey}`;
+        }
       }
     }
 
-    if (!actorKey && typeof attr.anonKey === 'string' && attr.anonKey.trim()) {
-      actorKey = `a:${attr.anonKey.trim()}`;
+    const normalizedAnonKey = normalizeAttributionAnonKey(attr.anonKey);
+    if (!actorKey && normalizedAnonKey) {
+      actorKey = `a:${normalizedAnonKey}`;
     }
 
     // Mirror AttributionService: entries without a stable actor are ignored.
@@ -137,10 +145,11 @@ const normalizeStoredAttributionSignature = (
   attributions: CurrentVersionAttributionSnapshot[]
 ): string[] => {
   const normalized = attributions.flatMap((attr) => {
+    const normalizedAnonKey = normalizeAttributionAnonKey(attr.anonKey);
     const actorKey = attr.user?.wikidotId != null
       ? `u:${attr.user.wikidotId}`
-      : attr.anonKey
-        ? `a:${attr.anonKey}`
+      : normalizedAnonKey
+        ? `a:${normalizedAnonKey}`
         : null;
     // Mirror incoming side: entries without a stable actor are excluded.
     if (!actorKey) return [];

--- a/backend/src/core/processors/PhaseAProcessor.ts
+++ b/backend/src/core/processors/PhaseAProcessor.ts
@@ -57,6 +57,20 @@ interface PhaseAResult {
   queueStats: QueueStats;
 }
 
+interface CurrentVersionAttributionSnapshot {
+  type: string;
+  order: number;
+  date: Date | null;
+  anonKey: string | null;
+  user: {
+    wikidotId: number | null;
+  } | null;
+}
+
+type CurrentVersionSnapshot = PageVersion & {
+  attributions: CurrentVersionAttributionSnapshot[];
+};
+
 const cq = new CoreQueries();
 
 const extractAlternateTitle = (node: PageNode): string | null => {
@@ -66,6 +80,84 @@ const extractAlternateTitle = (node: PageNode): string | null => {
       typeof entry?.title === 'string' && entry.title.trim().length > 0
   );
   return first ? first.title.trim() : null;
+};
+
+const normalizeAttributionDate = (value: unknown): string | null => {
+  if (value == null) return null;
+  const parsed = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+};
+
+const normalizeIncomingAttributionSignature = (rawAttributions: unknown[]): string[] => {
+  const normalized = rawAttributions.flatMap((raw) => {
+    if (!raw || typeof raw !== 'object') return [];
+
+    const attr = raw as Record<string, unknown>;
+    const type = typeof attr.type === 'string' && attr.type.trim()
+      ? attr.type.trim()
+      : 'unknown';
+    const order = typeof attr.order === 'number'
+      ? attr.order
+      : Number.parseInt(String(attr.order ?? 0), 10) || 0;
+
+    let userData = attr.user;
+    if (userData && typeof userData === 'object' && 'wikidotUser' in userData) {
+      userData = (userData as Record<string, unknown>).wikidotUser;
+    }
+
+    let actorKey: string | null = null;
+    if (userData && typeof userData === 'object') {
+      const userRecord = userData as Record<string, unknown>;
+      const wikidotIdRaw = userRecord.wikidotId;
+      const wikidotId = typeof wikidotIdRaw === 'number'
+        ? wikidotIdRaw
+        : Number.parseInt(String(wikidotIdRaw ?? ''), 10);
+      if (Number.isFinite(wikidotId)) {
+        actorKey = `u:${wikidotId}`;
+      } else if (typeof userRecord.displayName === 'string' && userRecord.displayName.trim()) {
+        actorKey = `a:anon:${userRecord.displayName.trim()}`;
+      }
+    }
+
+    if (!actorKey && typeof attr.anonKey === 'string' && attr.anonKey.trim()) {
+      actorKey = `a:${attr.anonKey.trim()}`;
+    }
+
+    // Mirror AttributionService: entries without a stable actor are ignored.
+    if (!actorKey) return [];
+
+    return [`${type}|${order}|${actorKey}|${normalizeAttributionDate(attr.date) ?? ''}`];
+  });
+
+  normalized.sort();
+  return normalized;
+};
+
+const normalizeStoredAttributionSignature = (
+  attributions: CurrentVersionAttributionSnapshot[]
+): string[] => {
+  const normalized = attributions.map((attr) => {
+    const actorKey = attr.user?.wikidotId != null
+      ? `u:${attr.user.wikidotId}`
+      : attr.anonKey
+        ? `a:${attr.anonKey}`
+        : 'a:';
+    return `${attr.type}|${attr.order}|${actorKey}|${normalizeAttributionDate(attr.date) ?? ''}`;
+  });
+  normalized.sort();
+  return normalized;
+};
+
+const attributionSignatureChanged = (
+  currentVersion: CurrentVersionSnapshot,
+  rawAttributions: unknown[]
+): boolean => {
+  const incoming = normalizeIncomingAttributionSignature(rawAttributions);
+  const stored = normalizeStoredAttributionSignature(currentVersion.attributions);
+  if (incoming.length !== stored.length) {
+    return true;
+  }
+  return incoming.some((value, index) => value !== stored[index]);
 };
 
 const PHASE_A_BATCHSIZE = 100;
@@ -125,10 +217,10 @@ export class PhaseAProcessor {
 
       // Process all pages in this batch (no skipping)
       for (const { node } of edges) {
-        let currentVersionCache: PageVersion | null | undefined;
+        let currentVersionCache: CurrentVersionSnapshot | null | undefined;
         let currentVersionLoaded = false;
 
-        const loadCurrentVersion = async (): Promise<PageVersion | null> => {
+        const loadCurrentVersion = async (): Promise<CurrentVersionSnapshot | null> => {
           if (currentVersionLoaded) return currentVersionCache ?? null;
           currentVersionLoaded = true;
 
@@ -147,11 +239,27 @@ export class PhaseAProcessor {
 
           const page = await this.store.prisma.page.findUnique({
             where: { wikidotId },
-            include: { versions: { where: { validTo: null }, take: 1 } }
+            include: {
+              versions: {
+                where: { validTo: null },
+                take: 1,
+                include: {
+                  attributions: {
+                    include: {
+                      user: {
+                        select: {
+                          wikidotId: true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           });
 
           currentVersionCache = page?.versions?.[0] ?? null;
-          return currentVersionCache;
+          return currentVersionCache ?? null;
         };
 
         // Estimate complete collection cost with more accurate parameters
@@ -197,11 +305,17 @@ export class PhaseAProcessor {
             const currentVersion = await loadCurrentVersion();
             if (currentVersion) {
               const nextAttributionCount = node.attributions.length;
+              const changed = attributionSignatureChanged(currentVersion, node.attributions);
               await this.attrService.importAttributions(currentVersion.id, node.attributions);
-              if (currentVersion.attributionCount !== nextAttributionCount) {
+              if (changed || currentVersion.attributionCount !== nextAttributionCount) {
                 await this.store.prisma.pageVersion.update({
                   where: { id: currentVersion.id },
-                  data: { attributionCount: nextAttributionCount }
+                  // Keep updatedAt moving when attribution rows change without a
+                  // count change so incremental analytics can see the delta.
+                  data: {
+                    attributionCount: nextAttributionCount,
+                    updatedAt: new Date()
+                  }
                 });
               }
             }

--- a/backend/src/core/processors/PhaseAProcessor.ts
+++ b/backend/src/core/processors/PhaseAProcessor.ts
@@ -136,13 +136,15 @@ const normalizeIncomingAttributionSignature = (rawAttributions: unknown[]): stri
 const normalizeStoredAttributionSignature = (
   attributions: CurrentVersionAttributionSnapshot[]
 ): string[] => {
-  const normalized = attributions.map((attr) => {
+  const normalized = attributions.flatMap((attr) => {
     const actorKey = attr.user?.wikidotId != null
       ? `u:${attr.user.wikidotId}`
       : attr.anonKey
         ? `a:${attr.anonKey}`
-        : 'a:';
-    return `${attr.type}|${attr.order}|${actorKey}|${normalizeAttributionDate(attr.date) ?? ''}`;
+        : null;
+    // Mirror incoming side: entries without a stable actor are excluded.
+    if (!actorKey) return [];
+    return [`${attr.type}|${attr.order}|${actorKey}|${normalizeAttributionDate(attr.date) ?? ''}`];
   });
   normalized.sort();
   return normalized;
@@ -441,10 +443,10 @@ export class PhaseAProcessor {
 
     // Process all pages in this test batch
     for (const { node } of edges) {
-      let currentVersionCache: PageVersion | null | undefined;
+      let currentVersionCache: CurrentVersionSnapshot | null | undefined;
       let currentVersionLoaded = false;
 
-      const loadCurrentVersion = async (): Promise<PageVersion | null> => {
+      const loadCurrentVersion = async (): Promise<CurrentVersionSnapshot | null> => {
         if (currentVersionLoaded) return currentVersionCache ?? null;
         currentVersionLoaded = true;
 
@@ -463,11 +465,27 @@ export class PhaseAProcessor {
 
         const page = await this.store.prisma.page.findUnique({
           where: { wikidotId },
-          include: { versions: { where: { validTo: null }, take: 1 } }
+          include: {
+            versions: {
+              where: { validTo: null },
+              take: 1,
+              include: {
+                attributions: {
+                  include: {
+                    user: {
+                      select: {
+                        wikidotId: true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         });
 
         currentVersionCache = page?.versions?.[0] ?? null;
-        return currentVersionCache;
+        return currentVersionCache ?? null;
       };
 
       // Estimate complete collection cost with more accurate parameters

--- a/backend/src/core/store/AttributionService.ts
+++ b/backend/src/core/store/AttributionService.ts
@@ -58,8 +58,7 @@ export class AttributionService {
             date
           });
         } else {
-          // Neither userId nor anonKey - ignore silently
-          stats.updated++;
+          // Neither userId nor anonKey - skip this entry
         }
       } catch (error) {
         stats.errors++;

--- a/backend/src/core/store/AttributionService.ts
+++ b/backend/src/core/store/AttributionService.ts
@@ -1,6 +1,17 @@
 import { PrismaClient } from '@prisma/client';
 import { Logger } from '../../utils/Logger.js';
 
+export const normalizeAttributionAnonKey = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export const buildDisplayNameAnonKey = (value: unknown): string | null => {
+  const normalized = normalizeAttributionAnonKey(value);
+  return normalized ? `anon:${normalized}` : null;
+};
+
 export class AttributionService {
   private prisma: PrismaClient;
 
@@ -17,11 +28,13 @@ export class AttributionService {
       order: number;
       date: Date | null;
     }> = [];
+    let canDeleteMissingRows = true;
 
     for (const attr of attributions) {
       try {
         let userId: number | null = null;
         let anonKey: string | null = null;
+        let userResolutionFailed = false;
 
         if (attr.user) {
           let userData = attr.user;
@@ -30,9 +43,14 @@ export class AttributionService {
           }
           if (userData.wikidotId) {
             const user = await this.upsertUser(userData);
-            userId = user?.id || null;
+            if (user?.id != null) {
+              userId = user.id;
+            } else {
+              userResolutionFailed = true;
+              canDeleteMissingRows = false;
+            }
           } else if (userData.displayName) {
-            anonKey = `anon:${userData.displayName}`;
+            anonKey = buildDisplayNameAnonKey(userData.displayName);
           }
         }
 
@@ -48,8 +66,11 @@ export class AttributionService {
             order,
             date
           });
-        } else if (anonKey || attr.anonKey) {
-          const finalAnonKey = anonKey || attr.anonKey;
+        } else if (!userResolutionFailed && (anonKey || attr.anonKey)) {
+          const finalAnonKey = anonKey || normalizeAttributionAnonKey(attr.anonKey);
+          if (!finalAnonKey) {
+            continue;
+          }
           normalizedEntries.push({
             userId: null,
             anonKey: finalAnonKey,
@@ -58,6 +79,14 @@ export class AttributionService {
             date
           });
         } else {
+          if (userResolutionFailed) {
+            Logger.warn('Attribution import skipped a Wikidot user entry; keeping existing rows to avoid destructive sync', {
+              pageVersionId,
+              type,
+              order,
+              wikidotId: attr?.user?.wikidotUser?.wikidotId ?? attr?.user?.wikidotId ?? null
+            });
+          }
           // Neither userId nor anonKey - skip this entry
         }
       } catch (error) {
@@ -91,25 +120,27 @@ export class AttributionService {
           anonKey: entry.anonKey!
         }));
 
-      await tx.attribution.deleteMany({
-        where: {
-          pageVerId: pageVersionId,
-          NOT: {
-            OR: [
-              ...keepUserKeys.map((entry) => ({
-                type: entry.type,
-                order: entry.order,
-                userId: entry.userId
-              })),
-              ...keepAnonKeys.map((entry) => ({
-                type: entry.type,
-                order: entry.order,
-                anonKey: entry.anonKey
-              }))
-            ]
+      if (canDeleteMissingRows) {
+        await tx.attribution.deleteMany({
+          where: {
+            pageVerId: pageVersionId,
+            NOT: {
+              OR: [
+                ...keepUserKeys.map((entry) => ({
+                  type: entry.type,
+                  order: entry.order,
+                  userId: entry.userId
+                })),
+                ...keepAnonKeys.map((entry) => ({
+                  type: entry.type,
+                  order: entry.order,
+                  anonKey: entry.anonKey
+                }))
+              ]
+            }
           }
-        }
-      });
+        });
+      }
 
       for (const entry of normalizedEntries) {
         if (entry.userId != null) {

--- a/backend/src/core/store/AttributionService.ts
+++ b/backend/src/core/store/AttributionService.ts
@@ -10,6 +10,14 @@ export class AttributionService {
 
   async importAttributions(pageVersionId: number, attributions: any[]): Promise<{ inserted: number; updated: number; errors: number }> {
     const stats = { inserted: 0, updated: 0, errors: 0 };
+    const normalizedEntries: Array<{
+      userId: number | null;
+      anonKey: string | null;
+      type: string;
+      order: number;
+      date: Date | null;
+    }> = [];
+
     for (const attr of attributions) {
       try {
         let userId: number | null = null;
@@ -33,46 +41,22 @@ export class AttributionService {
         const date = attr.date ? new Date(attr.date) : null;
 
         if (userId != null) {
-          await this.prisma.attribution.upsert({
-            where: {
-              Attribution_unique_constraint: {
-                pageVerId: pageVersionId,
-                type,
-                order,
-                userId
-              }
-            },
-            update: { date },
-            create: {
-              pageVerId: pageVersionId,
-              userId,
-              type,
-              order,
-              date
-            }
+          normalizedEntries.push({
+            userId,
+            anonKey: null,
+            type,
+            order,
+            date
           });
-          stats.inserted++;
         } else if (anonKey || attr.anonKey) {
           const finalAnonKey = anonKey || attr.anonKey;
-          await this.prisma.attribution.upsert({
-            where: {
-              Attribution_anon_unique_constraint: {
-                pageVerId: pageVersionId,
-                type,
-                order,
-                anonKey: finalAnonKey
-              }
-            },
-            update: { date },
-            create: {
-              pageVerId: pageVersionId,
-              anonKey: finalAnonKey,
-              type,
-              order,
-              date
-            }
+          normalizedEntries.push({
+            userId: null,
+            anonKey: finalAnonKey,
+            type,
+            order,
+            date
           });
-          stats.inserted++;
         } else {
           // Neither userId nor anonKey - ignore silently
           stats.updated++;
@@ -82,6 +66,99 @@ export class AttributionService {
         Logger.error('Attribution import error:', error);
       }
     }
+
+    if (normalizedEntries.length === 0) {
+      if (attributions.length === 0) {
+        await this.prisma.attribution.deleteMany({
+          where: { pageVerId: pageVersionId }
+        });
+      }
+      return stats;
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      const keepUserKeys = normalizedEntries
+        .filter((entry) => entry.userId != null)
+        .map((entry) => ({
+          type: entry.type,
+          order: entry.order,
+          userId: entry.userId!
+        }));
+      const keepAnonKeys = normalizedEntries
+        .filter((entry) => entry.anonKey)
+        .map((entry) => ({
+          type: entry.type,
+          order: entry.order,
+          anonKey: entry.anonKey!
+        }));
+
+      await tx.attribution.deleteMany({
+        where: {
+          pageVerId: pageVersionId,
+          NOT: {
+            OR: [
+              ...keepUserKeys.map((entry) => ({
+                type: entry.type,
+                order: entry.order,
+                userId: entry.userId
+              })),
+              ...keepAnonKeys.map((entry) => ({
+                type: entry.type,
+                order: entry.order,
+                anonKey: entry.anonKey
+              }))
+            ]
+          }
+        }
+      });
+
+      for (const entry of normalizedEntries) {
+        if (entry.userId != null) {
+          await tx.attribution.upsert({
+            where: {
+              Attribution_unique_constraint: {
+                pageVerId: pageVersionId,
+                type: entry.type,
+                order: entry.order,
+                userId: entry.userId
+              }
+            },
+            update: { date: entry.date },
+            create: {
+              pageVerId: pageVersionId,
+              userId: entry.userId,
+              type: entry.type,
+              order: entry.order,
+              date: entry.date
+            }
+          });
+          stats.inserted++;
+          continue;
+        }
+
+        if (!entry.anonKey) continue;
+
+        await tx.attribution.upsert({
+          where: {
+            Attribution_anon_unique_constraint: {
+              pageVerId: pageVersionId,
+              type: entry.type,
+              order: entry.order,
+              anonKey: entry.anonKey
+            }
+          },
+          update: { date: entry.date },
+          create: {
+            pageVerId: pageVersionId,
+            anonKey: entry.anonKey,
+            type: entry.type,
+            order: entry.order,
+            date: entry.date
+          }
+        });
+        stats.inserted++;
+      }
+    });
 
     return stats;
   }
@@ -110,5 +187,3 @@ export class AttributionService {
     }
   }
 }
-
-


### PR DESCRIPTION
## Summary

- What changed:
  - compare incoming Phase A attribution payloads against the current live `PageVersion` attribution signature instead of only comparing counts
  - when attribution rows actually change, bump `PageVersion.updatedAt` even if `attributionCount` stays the same
  - make `AttributionService.importAttributions()` reconcile the stored attribution set to the incoming full snapshot so stale rows do not linger after actor/date changes
  - address review follow-up by only deleting missing attribution rows when the incoming snapshot is complete; transient Wikidot user resolution failures now fall back to non-destructive upsert behavior
  - normalize anonymous attribution keys consistently on both persistence and comparison paths so whitespace-only differences do not cause perpetual false positives
- Why:
  - PR #11 intentionally stopped no-op `PageVersion` writes, but that exposed a latent dependency: incremental analysis only notices attribution changes via `Attribution.date` or `PageVersion.updatedAt`
  - same-count attribution edits with historical / null dates could now be skipped, leaving downstream analytics and alerts stale
  - the first hotfix revision still had two review risks: destructive sync on partial user-resolution failure, and inconsistent anon-key normalization

## Validation

- [x] Relevant lint / typecheck / tests were run
- [x] Manual verification steps are documented below
- [x] Config / migration / data risks are explained below

Manual verification:
- `cd backend && npm run lint`
- `cd backend && npm run typecheck`
- production data spot check:
  - `Attribution.total = 69264`
  - `Attribution.null_date = 19189`
  - `Attribution.pages_with_null_date = 15681`
  - live pages with attribution count > 0: `33696 / 33699`

## Review

- [ ] Codex review completed
- [ ] Claude Code review completed
- [ ] Review findings were resolved or explicitly accepted

## Deployment

- [ ] This change does not require deployment coordination
- [x] This change will be deployed from the protected `main` checkout
- [ ] PM2 target services are listed below if deployment is needed

PM2 target services if deployed:
- `scpper-sync`

## Notes

- Risk:
  - attribution sync now treats the GraphQL payload as a full snapshot when it can be trusted; if a Wikidot user attribution cannot be resolved locally, the import intentionally preserves unmatched existing rows instead of deleting them
- Rollback:
  - revert this PR and restart `scpper-sync`
- Follow-up:
  - run Codex review and Claude Code review before merge
  - after deploy, watch the next incremental cycle to confirm attribution-only edits now advance downstream jobs without returning to the old ~33k false-positive churn