### PR TITLE
fix: prevent card compression in buy-request detail dialog

### DIFF
--- a/frontend/components/gacha/GachaTradePanel.vue
+++ b/frontend/components/gacha/GachaTradePanel.vue
@@ -1768,7 +1768,7 @@ watch([brSortMode, brRarityFilter], () => {
                     >
                       正在加载你的可交付库存...
                     </p>
-                    <div v-else-if="buyRequestFulfillCandidates.length > 0" class="gacha-card-grid--mini">
+                    <div v-else-if="buyRequestFulfillCandidates.length > 0" class="br-fulfill-grid">
                       <button
                         v-for="item in buyRequestFulfillCandidates"
                         :key="`br-fulfill-candidate-${item.stackKey}`"
@@ -2542,6 +2542,33 @@ html.dark .br-match-chip {
 @media (min-width: 1440px) {
   .gacha-trade-item-grid {
     grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
+/* ── Buy-request fulfill candidates (inside narrow dialog) ── */
+
+.br-fulfill-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: stretch;
+}
+
+.br-fulfill-grid > * {
+  display: flex;
+  height: 100%;
+  width: 100%;
+  min-width: 0;
+}
+
+.br-fulfill-grid > * > * {
+  width: 100%;
+  height: 100%;
+}
+
+@media (min-width: 640px) {
+  .br-fulfill-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- 求购详情弹窗中「选择要提供的卡牌」候选列表使用了全局 `gacha-card-grid--mini` grid，其响应式列数（最多 8 列）基于视口宽度，在 `max-w-lg`（512px）弹窗的右列（~306px）内导致卡片被挤压至 31-55px 宽，完全不可辨认
- 替换为弹窗专用的 `br-fulfill-grid`，固定 2 列（mobile）→ 3 列（sm+），卡片宽度保持在 97-155px

## Test plan
- [ ] 在桌面端（≥1024px）打开求购详情弹窗，确认候选卡片显示为 3 列、尺寸可辨认
- [ ] 在移动端（<640px）打开求购详情弹窗，确认候选卡片显示为 2 列
- [ ] 确认其他使用 `gacha-card-grid--mini` 的位置（发布求购表单、挂牌选卡等）不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)