### PR TITLE
fix: 安全审计 Phase 1 — 令牌失效、内部API防护、登录限流、搜索限制

### DIFF
--- a/bff/.env.example
+++ b/bff/.env.example
@@ -19,6 +19,6 @@ ENABLE_CACHE=true
 # CORS allowed origins (comma-separated, leave empty to allow all in development)
 CORS_ALLOWED_ORIGINS="https://scpper.mer.run"
 
-# Internal API key for service-to-service auth
-INTERNAL_API_KEY="changeme-generate-a-secure-random-key"
+# Internal API key for service-to-service auth (required — /internal routes reject without it)
+BFF_INTERNAL_API_KEY="changeme-generate-a-secure-random-key"
 

--- a/bff/ecosystem.config.cjs
+++ b/bff/ecosystem.config.cjs
@@ -14,8 +14,8 @@ module.exports = {
         REDIS_URL: process.env.REDIS_URL,
         HTML_SNIPPET_PUBLIC_BASE: process.env.HTML_SNIPPET_PUBLIC_BASE || 'https://scpper.mer.run',
         CSS_PROXY_CACHE_CONTROL: process.env.CSS_PROXY_CACHE_CONTROL || 'public, max-age=3600, s-maxage=7200',
-        ENABLE_TRACKING_DEBUG: process.env.ENABLE_TRACKING_DEBUG || 'true',
-        TRACKING_DEBUG_SAMPLE_RATE: process.env.TRACKING_DEBUG_SAMPLE_RATE || '1'
+        ENABLE_TRACKING_DEBUG: process.env.ENABLE_TRACKING_DEBUG || 'false',
+        TRACKING_DEBUG_SAMPLE_RATE: process.env.TRACKING_DEBUG_SAMPLE_RATE || '0'
       }
     }
   ]

--- a/bff/src/web/router.ts
+++ b/bff/src/web/router.ts
@@ -43,12 +43,10 @@ export function buildRouter(pool: Pool, redis: RedisClientType | null) {
     if (expectedKey && providedKey && providedKey === expectedKey) {
       return next();
     }
-
-    // Only trust the actual socket address for unauthenticated internal access.
-    // `x-forwarded-for` can be spoofed when requests hit this service directly.
-    if (isLoopbackIp(req.socket.remoteAddress)) {
-      return next();
-    }
+    // Loopback IP alone is no longer sufficient — the Nuxt frontend proxy also
+    // originates from localhost, so a public user hitting /api/internal/** would
+    // pass a pure-loopback check.  Require a valid x-internal-key for all
+    // internal route access.
     return res.status(403).json({ error: 'internal_access_denied' });
   };
   router.use('/pages', pagesRouter(pool, redis));

--- a/bff/src/web/routes/search.ts
+++ b/bff/src/web/routes/search.ts
@@ -1343,7 +1343,7 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
           return res.status(400).json({ error: 'invalid_regex', message: validation.error });
         }
       }
-      const limitInt = Math.max(0, Number(limit) | 0) || 20;
+      const limitInt = Math.min(Math.max(0, Number(limit) | 0) || 20, 100);
       const offsetInt = Math.max(0, Number(offset) | 0);
       const includeTagsArray = tags
         ? (Array.isArray(tags) ? (tags as string[]) : [tags as string])
@@ -1605,7 +1605,7 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
       const totalLimit = Math.max(0, Number(limit) | 0);
       const totalOffset = Math.max(0, Number(offset) | 0);
       const defaultPageCap = Math.max(0, Math.min(totalLimit || 20, Math.ceil((totalLimit || 20) * 0.6)));
-      const pageCap = Math.max(0, Number(pageLimit ?? defaultPageCap) | 0);
+      const pageCap = Math.min(Math.max(0, Number(pageLimit ?? defaultPageCap) | 0), 100);
       const userCap = Math.max(0, Number(userLimit ?? ((totalLimit || 20) - pageCap)) | 0);
       const wantSnippet = String(includeSnippet).toLowerCase() === 'true';
       const wantDate = String(includeDate).toLowerCase() === 'true';

--- a/bff/src/web/routes/search.ts
+++ b/bff/src/web/routes/search.ts
@@ -1602,11 +1602,11 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
 
       const trimmedQuery = normalizedQuery.trim();
       const normalizedOrderBy = String(Array.isArray(orderBy) ? orderBy[0] : (orderBy || 'relevance'));
-      const totalLimit = Math.max(0, Number(limit) | 0);
+      const totalLimit = Math.min(Math.max(0, Number(limit) | 0), 200);
       const totalOffset = Math.max(0, Number(offset) | 0);
       const defaultPageCap = Math.max(0, Math.min(totalLimit || 20, Math.ceil((totalLimit || 20) * 0.6)));
       const pageCap = Math.min(Math.max(0, Number(pageLimit ?? defaultPageCap) | 0), 100);
-      const userCap = Math.max(0, Number(userLimit ?? ((totalLimit || 20) - pageCap)) | 0);
+      const userCap = Math.min(Math.max(0, Number(userLimit ?? ((totalLimit || 20) - pageCap)) | 0), 100);
       const wantSnippet = String(includeSnippet).toLowerCase() === 'true';
       const wantDate = String(includeDate).toLowerCase() === 'true';
 

--- a/frontend/server/middleware/deny-internal-api.ts
+++ b/frontend/server/middleware/deny-internal-api.ts
@@ -1,0 +1,13 @@
+/**
+ * Block public access to /api/internal/** at the Nuxt edge.
+ *
+ * The BFF already requires x-internal-key for /internal routes, but this
+ * middleware provides defense-in-depth by short-circuiting the request before
+ * it even reaches the proxy layer.
+ */
+export default defineEventHandler((event) => {
+  const path = event.path || getRequestURL(event).pathname;
+  if (path === '/api/internal' || path.startsWith('/api/internal/')) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' });
+  }
+});

--- a/mail-agent/src/server.mjs
+++ b/mail-agent/src/server.mjs
@@ -186,8 +186,13 @@ const server = http.createServer(async (req, res) => {
   }
 
   if (req.method === 'POST' && path === '/send') {
-    // Validate internal API key
+    // Validate internal API key — always required unless NODE_ENV=development
     const expectedKey = (process.env.MAIL_AGENT_API_KEY || '').trim();
+    if (!expectedKey && process.env.NODE_ENV !== 'development') {
+      logger.error('MAIL_AGENT_API_KEY is not set — rejecting /send request');
+      sendJson(res, 503, { error: 'Service misconfigured' });
+      return;
+    }
     if (expectedKey) {
       const provided = (req.headers['x-internal-key'] || '').trim();
       if (provided !== expectedKey) {

--- a/user-backend/src/app.ts
+++ b/user-backend/src/app.ts
@@ -12,6 +12,7 @@ import { wikidotBindingRouter, wikidotBindingInternalRouter } from './routes/wik
 export function createApp() {
   const app = express();
   app.disable('x-powered-by');
+  app.set('trust proxy', 1);
   app.use(helmet());
   const allowedOrigins = (process.env.CORS_ALLOWED_ORIGINS || '').split(',').map(s => s.trim()).filter(Boolean);
   app.use(cors({

--- a/user-backend/src/routes/auth.ts
+++ b/user-backend/src/routes/auth.ts
@@ -1,4 +1,4 @@
-import { Router, type Response } from 'express';
+import { Router, type Request, type Response } from 'express';
 import bcrypt from 'bcryptjs';
 import { z } from 'zod';
 import { config } from '../config.js';
@@ -7,6 +7,15 @@ import { issueAuthToken } from '../utils/auth-token.js';
 import { prisma } from '../db.js';
 import { requireAuth } from '../middleware/requireAuth.js';
 import { startPasswordReset, completePasswordReset } from '../services/passwordReset.js';
+import { SlidingWindowRateLimiter } from '../utils/rateLimiter.js';
+
+const loginLimiter = new SlidingWindowRateLimiter({ windowMs: 15 * 60 * 1000, maxHits: 20 });
+const registerStartLimiter = new SlidingWindowRateLimiter({ windowMs: 15 * 60 * 1000, maxHits: 5 });
+const resetStartLimiter = new SlidingWindowRateLimiter({ windowMs: 15 * 60 * 1000, maxHits: 5 });
+
+function getClientIp(req: Request): string {
+  return req.ip || req.socket.remoteAddress || 'unknown';
+}
 
 const startSchema = z.object({
   email: z.string().email('电子邮箱格式不正确'),
@@ -61,12 +70,37 @@ const resetCompleteSchema = z.object({
     .max(128, '密码长度过长')
 });
 
+// Known business error messages that are safe to expose to the client
+const SAFE_ERROR_MESSAGES = new Set([
+  '验证码请求过于频繁，请稍后再试',
+  '该邮箱已注册',
+  '该账号已被禁用',
+  '账号不存在，请先请求验证码',
+  '请先请求验证码',
+  '验证码已过期',
+  '验证码尝试次数过多，请重新请求',
+  '验证码不正确',
+  '验证码不正确或已过期',
+  '邮箱或密码错误',
+  '账号异常',
+  '当前密码不正确',
+  '未提供需要更新的内容',
+  '登录尝试过于频繁，请 15 分钟后再试',
+  '请求过于频繁，请稍后再试'
+]);
+
 function createErrorResponse(error: unknown) {
   if (error instanceof z.ZodError) {
     return { status: 400, body: { error: error.issues[0]?.message || '参数错误' } };
   }
-  if (error instanceof Error) {
+  if (error instanceof Error && SAFE_ERROR_MESSAGES.has(error.message)) {
     return { status: 400, body: { error: error.message } };
+  }
+  if (error instanceof Error) {
+    // Do not leak internal error messages (e.g. database errors)
+    // eslint-disable-next-line no-console
+    console.error('[auth] unexpected error:', error);
+    return { status: 500, body: { error: '服务器内部错误' } };
   }
   return { status: 500, body: { error: '未知错误' } };
 }
@@ -101,6 +135,10 @@ export function authRouter() {
 
   router.post('/register/start', async (req, res) => {
     try {
+      const ip = getClientIp(req);
+      if (!registerStartLimiter.hit(ip)) {
+        return res.status(429).json({ error: '请求过于频繁，请稍后再试' });
+      }
       const payload = startSchema.parse(req.body ?? {});
       const result = await startRegistration(payload.email, payload.displayName);
       res.json({ ok: true, expiresAt: result.expiresAt.toISOString() });
@@ -128,6 +166,10 @@ export function authRouter() {
 
   router.post('/login', async (req, res) => {
     try {
+      const ip = getClientIp(req);
+      if (!loginLimiter.hit(ip)) {
+        return res.status(429).json({ error: '登录尝试过于频繁，请 15 分钟后再试' });
+      }
       const payload = loginSchema.parse(req.body ?? {});
       const email = payload.email.trim().toLowerCase();
       const account = await prisma.userAccount.findUnique({ where: { email } });
@@ -177,6 +219,10 @@ export function authRouter() {
   // Request password reset code (always returns ok)
   router.post('/password/reset/start', async (req, res) => {
     try {
+      const ip = getClientIp(req);
+      if (!resetStartLimiter.hit(ip)) {
+        return res.status(429).json({ error: '请求过于频繁，请稍后再试' });
+      }
       const payload = resetStartSchema.parse(req.body ?? {});
       await startPasswordReset(payload.email);
       res.json({ ok: true });

--- a/user-backend/src/services/passwordReset.ts
+++ b/user-backend/src/services/passwordReset.ts
@@ -46,6 +46,16 @@ export async function startPasswordReset(email: string) {
     return { ok: true } as const;
   }
 
+  // Invalidate all previous unconsumed PASSWORD_RESET tokens for this user
+  await prisma.verificationToken.updateMany({
+    where: {
+      userId: account.id,
+      purpose: VERIFICATION_PURPOSE.PASSWORD_RESET,
+      consumedAt: null
+    },
+    data: { consumedAt: now }
+  });
+
   const code = generateNumericCode(config.verification.codeLength);
   const codeHash = hashVerificationCode(code);
   const expiresAt = new Date(now.getTime() + config.verification.ttlMinutes * 60 * 1000);
@@ -85,15 +95,13 @@ export async function completePasswordReset(email: string, code: string, passwor
       where: {
         userId: account.id,
         purpose: VERIFICATION_PURPOSE.PASSWORD_RESET,
-        consumedAt: null
+        consumedAt: null,
+        expiresAt: { gte: now }
       },
       orderBy: { createdAt: 'desc' }
     });
 
-    if (!token || token.expiresAt < now) {
-      if (token) {
-        await tx.verificationToken.update({ where: { id: token.id }, data: { attemptCount: token.attemptCount + 1 } });
-      }
+    if (!token) {
       throw new Error('验证码不正确或已过期');
     }
 
@@ -113,9 +121,19 @@ export async function completePasswordReset(email: string, code: string, passwor
       data: { passwordHash }
     });
 
+    // Consume the matched token and invalidate all remaining unconsumed tokens
     await tx.verificationToken.update({
       where: { id: token.id },
       data: { consumedAt: now, attemptCount: token.attemptCount + 1 }
+    });
+
+    await tx.verificationToken.updateMany({
+      where: {
+        userId: account.id,
+        purpose: VERIFICATION_PURPOSE.PASSWORD_RESET,
+        consumedAt: null
+      },
+      data: { consumedAt: now }
     });
   });
 

--- a/user-backend/src/services/registration.ts
+++ b/user-backend/src/services/registration.ts
@@ -67,6 +67,16 @@ export async function startRegistration(email: string, displayName?: string | nu
         }
       });
 
+  // Invalidate all previous unconsumed REGISTER tokens for this user
+  await prisma.verificationToken.updateMany({
+    where: {
+      userId: account.id,
+      purpose: VERIFICATION_PURPOSE.REGISTER,
+      consumedAt: null
+    },
+    data: { consumedAt: now }
+  });
+
   const code = generateNumericCode(config.verification.codeLength);
   const codeHash = hashVerificationCode(code);
   const expiresAt = new Date(now.getTime() + config.verification.ttlMinutes * 60 * 1000);
@@ -148,12 +158,22 @@ export async function completeRegistration(email: string, code: string, password
       }
     });
 
+    // Consume the matched token and invalidate all remaining unconsumed tokens
     await tx.verificationToken.update({
       where: { id: token.id },
       data: {
         consumedAt: now,
         attemptCount: token.attemptCount + 1
       }
+    });
+
+    await tx.verificationToken.updateMany({
+      where: {
+        userId: account.id,
+        purpose: VERIFICATION_PURPOSE.REGISTER,
+        consumedAt: null
+      },
+      data: { consumedAt: now }
     });
 
     return updatedAccount;

--- a/user-backend/src/utils/rateLimiter.ts
+++ b/user-backend/src/utils/rateLimiter.ts
@@ -1,0 +1,72 @@
+/**
+ * In-memory sliding-window rate limiter.
+ * Suitable for single-instance PM2 deployments.  For horizontal scaling,
+ * swap the backing store to Redis.
+ */
+
+interface WindowEntry {
+  timestamps: number[];
+}
+
+export class SlidingWindowRateLimiter {
+  private windowMs: number;
+  private maxHits: number;
+  private store = new Map<string, WindowEntry>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private sweepTimer: any;
+
+  constructor(opts: { windowMs: number; maxHits: number }) {
+    this.windowMs = opts.windowMs;
+    this.maxHits = opts.maxHits;
+    // Periodically evict cold keys to prevent unbounded memory growth
+    this.sweepTimer = setInterval(() => this.sweep(), this.windowMs * 2);
+    if (typeof this.sweepTimer?.unref === 'function') this.sweepTimer.unref();
+  }
+
+  /**
+   * Record a hit and return whether the request is allowed.
+   * @returns `true` if within limit, `false` if rate-limited.
+   */
+  hit(key: string): boolean {
+    const now = Date.now();
+    const cutoff = now - this.windowMs;
+    let entry = this.store.get(key);
+    if (!entry) {
+      entry = { timestamps: [] };
+      this.store.set(key, entry);
+    }
+    // Remove timestamps outside the window
+    entry.timestamps = entry.timestamps.filter(t => t > cutoff);
+    if (entry.timestamps.length >= this.maxHits) {
+      return false;
+    }
+    entry.timestamps.push(now);
+    return true;
+  }
+
+  /** Return remaining attempts for `key` within the current window. */
+  remaining(key: string): number {
+    const now = Date.now();
+    const cutoff = now - this.windowMs;
+    const entry = this.store.get(key);
+    if (!entry) return this.maxHits;
+    const active = entry.timestamps.filter(t => t > cutoff).length;
+    return Math.max(0, this.maxHits - active);
+  }
+
+  private sweep() {
+    const now = Date.now();
+    const cutoff = now - this.windowMs;
+    for (const [key, entry] of this.store) {
+      entry.timestamps = entry.timestamps.filter(t => t > cutoff);
+      if (entry.timestamps.length === 0) {
+        this.store.delete(key);
+      }
+    }
+  }
+
+  destroy() {
+    clearInterval(this.sweepTimer);
+    this.store.clear();
+  }
+}


### PR DESCRIPTION
## Summary

全仓库安全审计 Phase 1 修复，覆盖 7 项经交叉验证确认的安全问题：

- **C-1** 验证码/重置码发新码时批量作废旧码，完成后也批量消费剩余 token
- **C-2** BFF `/internal` 路由去除 loopback IP 放行，强制 `x-internal-key`；前端增加 server middleware 拦截 `/api/internal/**`
- **H-1** 登录/注册/密码重置端点增加 per-IP 滑动窗口限流
- **H-4** Mail Agent 非 dev 环境强制要求 `MAIL_AGENT_API_KEY`
- **H-6** 搜索接口 limit 硬上限 100（页面）/ 200（总量）/ 100（用户）
- **H-8** 生产 tracking debug 默认关闭（`false` / `0`）
- **M-15** `createErrorResponse` 区分业务异常白名单和系统异常，未知错误不再泄露 message

## 已知取舍

1. **验证码作废 vs 邮件发送失败**：新码发送前已作废旧码，如果邮件发送失败用户旧码也不可用。安全性优先于可用性。
2. **并发原子性**：`start*` 的 updateMany+create 不在事务内，极端并发下仍可能产生多条 token。当前单实例部署下风险极低，后续可通过数据库唯一约束彻底解决。
3. **IP 限流精度**：`trust proxy: 1` 信任直接上游（BFF），标准链路下可获取真实 IP。直连 user-backend 场景下 XFF 可被伪造，但 user-backend 应仅从 BFF 接收请求。

## Test plan

- [ ] 验证注册流程：请求验证码 → 再次请求 → 确认旧码不可用
- [ ] 验证密码重置：请求重置码 → 再次请求 → 确认旧码不可用
- [ ] 验证 `/api/internal/xxx` 从浏览器访问返回 403
- [ ] 验证内部服务（带 `x-internal-key`）仍可正常调用 BFF internal 接口
- [ ] 验证登录限流：连续 20+ 次登录尝试后返回 429
- [ ] 验证 mail-agent 无 API key 时拒绝 /send
- [ ] 验证搜索 `limit=9999` 被 cap 到 100
- [ ] 验证 tracking debug 日志不再默认写入