### PR TITLE
fix: 安全审计 Phase 2 — CORS加固、鉴权缓存失效、错误处理改善

### DIFF
--- a/backend/src/core/processors/PhaseCProcessor.ts
+++ b/backend/src/core/processors/PhaseCProcessor.ts
@@ -203,9 +203,15 @@ export class PhaseCProcessor {
     const collected: CollectedData = { url, wikidotId, revisions: [], votes: [] };
     let success = false;
 
+    const MAX_REQUESTS_PER_PAGE = 200;
+
     try {
       while (afterRev !== undefined || afterVote !== undefined) {
         requestCount++;
+        if (requestCount > MAX_REQUESTS_PER_PAGE) {
+          Logger.error('Phase C: Exceeded max request limit, aborting page', { url, wikidotId, requestCount });
+          break;
+        }
         
         const { query, variables } = this._buildQuery(url, afterRev, afterVote);
         const res = await this.client.request(query, variables);

--- a/bff/src/start.ts
+++ b/bff/src/start.ts
@@ -20,7 +20,7 @@ export async function createServer() {
           if (!origin || allowedOrigins.includes(origin)) cb(null, true);
           else cb(new Error('Not allowed by CORS'));
         }
-      : true,
+      : false,
     credentials: true
   }));
   app.use(express.json({ limit: '1mb' }));

--- a/bff/src/web/routes/html-snippets.ts
+++ b/bff/src/web/routes/html-snippets.ts
@@ -200,6 +200,15 @@ export const htmlSnippetsRouter = Router();
 function createPostHandler(routeBase: string) {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
+      // Require internal API key for write operations
+      const expectedKey = (process.env.BFF_INTERNAL_API_KEY || '').trim();
+      if (expectedKey) {
+        const providedKey = String(req.get('x-internal-key') || '').trim();
+        if (providedKey !== expectedKey) {
+          return res.status(403).json({ error: 'forbidden' });
+        }
+      }
+
       const rawHtml = typeof req.body?.html === 'string' ? req.body.html : req.body?.content;
       if (typeof rawHtml !== 'string' || rawHtml.trim().length === 0) {
         return res.status(400).json({ error: 'invalid_html' });

--- a/bff/src/web/routes/tracking.ts
+++ b/bff/src/web/routes/tracking.ts
@@ -67,15 +67,9 @@ function buildClientFingerprint(ip: string, userAgent: string): string {
 }
 
 function resolveClientIp(req: Request): string {
-  const forwarded = req.headers['x-forwarded-for'];
-  if (typeof forwarded === 'string' && forwarded.trim()) {
-    const [first] = forwarded.split(',');
-    if (first && first.trim()) return first.trim();
-  }
-  if (Array.isArray(forwarded) && forwarded.length > 0) {
-    const first = forwarded[0];
-    if (first && first.trim()) return first.trim();
-  }
+  // Use req.ip which honours Express trust-proxy setting,
+  // instead of directly trusting the spoofable x-forwarded-for header.
+  if (req.ip) return req.ip;
   const socketIp = req.socket?.remoteAddress;
   return typeof socketIp === 'string' ? socketIp : '';
 }

--- a/bff/src/web/utils/auth.ts
+++ b/bff/src/web/utils/auth.ts
@@ -20,7 +20,12 @@ export async function fetchAuthUser(req: Request): Promise<AuthUserPayload | nul
       method: 'GET',
       headers: { accept: 'application/json', cookie: req.headers.cookie ?? '' }
     });
-    if (response.status === 401 || !response.ok) return null;
+    if (response.status === 401) return null;
+    if (!response.ok) {
+      // eslint-disable-next-line no-console
+      console.warn(`[fetchAuthUser] user-backend returned ${response.status}`);
+      return null;
+    }
     const data = await response.json();
     if (!data?.ok || !data.user) return null;
     return {
@@ -30,7 +35,9 @@ export async function fetchAuthUser(req: Request): Promise<AuthUserPayload | nul
       linkedWikidotId: data.user.linkedWikidotId != null ? Number(data.user.linkedWikidotId) : null,
       lastLoginAt: data.user.lastLoginAt ?? null
     };
-  } catch {
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[fetchAuthUser] user-backend unreachable:', err instanceof Error ? err.message : err);
     return null;
   }
 }

--- a/user-backend/src/app.ts
+++ b/user-backend/src/app.ts
@@ -21,7 +21,7 @@ export function createApp() {
           if (!origin || allowedOrigins.includes(origin)) cb(null, true);
           else cb(new Error('Not allowed by CORS'));
         }
-      : true,
+      : false,
     credentials: true
   }));
   app.use(express.json({ limit: '1mb' }));

--- a/user-backend/src/middleware/requireAuth.ts
+++ b/user-backend/src/middleware/requireAuth.ts
@@ -85,6 +85,15 @@ async function fetchAndCacheUser(userId: string): Promise<CachedUser | null> {
   }
 }
 
+/**
+ * Immediately evict a user from the auth cache.
+ * Call after any operation that changes passwordHash, status, or linkedWikidotId.
+ */
+export function invalidateAuthCache(userId: string) {
+  userCache.delete(userId);
+  inflightLookups.delete(userId);
+}
+
 // Periodic cleanup to prevent memory leaks (every 60 seconds)
 setInterval(() => {
   const now = Date.now();

--- a/user-backend/src/routes/auth.ts
+++ b/user-backend/src/routes/auth.ts
@@ -5,7 +5,7 @@ import { config } from '../config.js';
 import { startRegistration, completeRegistration } from '../services/registration.js';
 import { issueAuthToken } from '../utils/auth-token.js';
 import { prisma } from '../db.js';
-import { requireAuth } from '../middleware/requireAuth.js';
+import { requireAuth, invalidateAuthCache } from '../middleware/requireAuth.js';
 import { startPasswordReset, completePasswordReset } from '../services/passwordReset.js';
 import { SlidingWindowRateLimiter } from '../utils/rateLimiter.js';
 
@@ -237,7 +237,8 @@ export function authRouter() {
   router.post('/password/reset/complete', async (req, res) => {
     try {
       const payload = resetCompleteSchema.parse(req.body ?? {});
-      await completePasswordReset(payload.email, payload.code, payload.password);
+      const result = await completePasswordReset(payload.email, payload.code, payload.password);
+      invalidateAuthCache(result.userId);
       res.json({ ok: true });
     } catch (error) {
       const { status, body } = createErrorResponse(error);
@@ -297,6 +298,7 @@ export function authRouter() {
         where: { id: account.id },
         data: { passwordHash: newHash }
       });
+      invalidateAuthCache(account.id);
       res.clearCookie(config.session.cookieName, {
         httpOnly: true,
         sameSite: config.session.sameSite,

--- a/user-backend/src/services/passwordReset.ts
+++ b/user-backend/src/services/passwordReset.ts
@@ -80,12 +80,12 @@ export async function startPasswordReset(email: string) {
   return { ok: true } as const;
 }
 
-export async function completePasswordReset(email: string, code: string, password: string) {
+export async function completePasswordReset(email: string, code: string, password: string): Promise<{ ok: true; userId: string }> {
   const normalizedEmail = normalizeEmail(email);
   const now = new Date();
   const hashedInput = hashVerificationCode(code);
 
-  await prisma.$transaction(async (tx) => {
+  const userId = await prisma.$transaction(async (tx) => {
     const account = await tx.userAccount.findUnique({ where: { email: normalizedEmail } });
     if (!account || account.status !== ACCOUNT_STATUS.ACTIVE) {
       throw new Error('验证码不正确或已过期');
@@ -135,8 +135,10 @@ export async function completePasswordReset(email: string, code: string, passwor
       },
       data: { consumedAt: now }
     });
+
+    return account.id;
   });
 
-  return { ok: true } as const;
+  return { ok: true, userId };
 }
 

--- a/user-backend/src/services/registration.ts
+++ b/user-backend/src/services/registration.ts
@@ -48,11 +48,10 @@ export async function startRegistration(email: string, displayName?: string | nu
     where: { email: normalizedEmail }
   });
 
-  if (existingAccount?.status === ACCOUNT_STATUS.ACTIVE) {
-    throw new Error('该邮箱已注册');
-  }
-  if (existingAccount?.status === ACCOUNT_STATUS.DISABLED) {
-    throw new Error('该账号已被禁用');
+  // Silently return success to prevent email enumeration (same pattern as password reset)
+  if (existingAccount?.status === ACCOUNT_STATUS.ACTIVE ||
+      existingAccount?.status === ACCOUNT_STATUS.DISABLED) {
+    return { expiresAt: new Date(now.getTime() + config.verification.ttlMinutes * 60 * 1000) };
   }
 
   const account = existingAccount

--- a/user-backend/src/services/wikidotBinding.ts
+++ b/user-backend/src/services/wikidotBinding.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { prisma } from '../db.js';
 import { WikidotBindingStatus } from '@prisma/client';
+import { invalidateAuthCache } from '../middleware/requireAuth.js';
 
 const VERIFICATION_CODE_CHARS = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'; // Excluding 0/O, 1/I/L
 const VERIFICATION_CODE_LENGTH = 6;
@@ -347,13 +348,13 @@ export async function completeBindingTask(
   revisionInfo?: { revisionId: number; timestamp: Date }
 ): Promise<boolean> {
   // Use interactive transaction to ensure atomicity of check + update
-  return await prisma.$transaction(async (tx) => {
+  const result = await prisma.$transaction(async (tx) => {
     const task = await tx.wikidotBindingTask.findUnique({
       where: { id: taskId }
     });
 
     if (!task || task.status !== WikidotBindingStatus.PENDING) {
-      return false;
+      return null;
     }
 
     // Check if wikidotId is still available (inside transaction)
@@ -368,7 +369,7 @@ export async function completeBindingTask(
           failureReason: '该 Wikidot 账号已被其他用户绑定'
         }
       });
-      return false;
+      return null;
     }
 
     // Complete the binding atomically
@@ -384,8 +385,14 @@ export async function completeBindingTask(
       }
     });
 
-    return true;
+    return task.userId;
   });
+
+  if (result) {
+    invalidateAuthCache(result);
+    return true;
+  }
+  return false;
 }
 
 export async function updateTaskCheckStatus(

--- a/user-backend/src/services/wikidotBinding.ts
+++ b/user-backend/src/services/wikidotBinding.ts
@@ -47,8 +47,10 @@ export async function resolveWikidotUser(username: string): Promise<ResolvedWiki
   let response: Response;
   try {
     response = await fetchBffInternal(`/internal/wikidot-user?username=${encodeURIComponent(username)}`);
-  } catch {
-    return null;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[wikidotBinding] BFF unreachable:', err instanceof Error ? err.message : err);
+    throw new Error('内部服务暂时不可用，请稍后再试');
   }
 
   const data = await response.json().catch(() => null) as unknown;
@@ -57,6 +59,11 @@ export async function resolveWikidotUser(username: string): Promise<ResolvedWiki
     const errorType = data && typeof data === 'object' ? (data as { error?: string }).error : undefined;
     if (response.status === 409 && errorType === 'ambiguous') {
       throw new Error('该用户名匹配多个 Wikidot 用户，请使用更精确的用户名或联系管理员处理');
+    }
+    if (response.status >= 500) {
+      // eslint-disable-next-line no-console
+      console.error(`[wikidotBinding] BFF returned ${response.status} for wikidot-user lookup`);
+      throw new Error('内部服务暂时不可用，请稍后再试');
     }
     return null;
   }
@@ -69,12 +76,19 @@ export async function resolveWikidotUserById(wikidotId: number): Promise<Resolve
   let response: Response;
   try {
     response = await fetchBffInternal(`/internal/wikidot-user?wikidotId=${encodeURIComponent(String(wikidotId))}`);
-  } catch {
-    return null;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[wikidotBinding] BFF unreachable:', err instanceof Error ? err.message : err);
+    throw new Error('内部服务暂时不可用，请稍后再试');
   }
 
   const data = await response.json().catch(() => null) as unknown;
   if (!response.ok) {
+    if (response.status >= 500) {
+      // eslint-disable-next-line no-console
+      console.error(`[wikidotBinding] BFF returned ${response.status} for wikidot-user-by-id lookup`);
+      throw new Error('内部服务暂时不可用，请稍后再试');
+    }
     return null;
   }
 
@@ -90,12 +104,21 @@ export async function searchWikidotUsers(query: string, limit: number = 8): Prom
     response = await fetchBffInternal(
       `/internal/wikidot-user-search?query=${encodeURIComponent(query)}&limit=${encodeURIComponent(String(normalizedLimit))}`
     );
-  } catch {
-    return [];
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[wikidotBinding] BFF unreachable:', err instanceof Error ? err.message : err);
+    throw new Error('内部服务暂时不可用，请稍后再试');
   }
 
   const data = await response.json().catch(() => null) as unknown;
-  if (!response.ok) return [];
+  if (!response.ok) {
+    if (response.status >= 500) {
+      // eslint-disable-next-line no-console
+      console.error(`[wikidotBinding] BFF returned ${response.status} for wikidot-user-search`);
+      throw new Error('内部服务暂时不可用，请稍后再试');
+    }
+    return [];
+  }
 
   const parsed = data as { ok?: boolean; users?: ResolvedWikidotUser[] };
   if (!parsed.ok || !Array.isArray(parsed.users)) return [];


### PR DESCRIPTION
## Summary

全仓库安全审计 Phase 2 修复，覆盖 8 项经交叉验证确认的健壮性问题：

- **H-2** CORS 默认从 `origin: true` 改为 `origin: false`（BFF + user-backend）
- **H-3** 导出 `invalidateAuthCache()`，在改密/重置密码/Wikidot 绑定后主动清除缓存
- **H-7** Tracking IP 解析使用 `req.ip` 替代直接信任 `x-forwarded-for`
- **H-12** 注册接口对已存在邮箱静默返回成功，防止枚举（与密码重置保持一致）
- **H-13** Phase C 分页循环上限 200 次请求
- **H-15** HTML Snippet POST 路由要求 `x-internal-key` 认证
- **M-1** `fetchAuthUser` 对非 401 上游错误增加日志（不再完全静默）
- **M-20** Wikidot 绑定对网络错误和 5xx 抛出明确异常，而非伪装为空结果

## Test plan

- [ ] 验证 CORS：浏览器直接跨域请求 BFF 应被拒绝
- [ ] 验证改密后旧 session 立即失效（不等 30 秒缓存）
- [ ] 验证注册已存在邮箱不再返回"该邮箱已注册"
- [ ] 验证 Tracking 像素使用 req.ip 而非 XFF
- [ ] 验证 Phase C 大页面不会无限循环
- [ ] 验证 HTML Snippet POST 无 key 时返回 403
- [ ] 验证 user-backend 日志中可观测到 BFF 故障