### PR TITLE
fix: 安全审计 Phase 3 — 缓存去重、集合事务、限制上限、代码清理

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -69,7 +69,6 @@
   },
   "dependencies": {
     "@prisma/client": "^5.20.0",
-    "@types/uuid": "^10.0.0",
     "@ukwhatn/wikidot": "^4.3.1",
     "chalk": "^5.6.0",
     "cli-progress": "^3.12.0",
@@ -84,8 +83,7 @@
     "pretty-ms": "^9.2.0",
     "table": "^6.9.0",
     "tsx": "^4.19.1",
-    "undici": "^7.22.0",
-    "uuid": "^11.1.0"
+    "undici": "^7.22.0"
   },
   "devDependencies": {
     "@types/node": "^22.5.4",

--- a/backend/src/core/processors/PhaseCProcessor.ts
+++ b/backend/src/core/processors/PhaseCProcessor.ts
@@ -168,14 +168,17 @@ export class PhaseCProcessor {
         }
       };
 
-      for (const page of pagesToProcess) {
-        await this.queue.add(() => this._processOne(
-          page.url, 
+      // Enqueue all pages without awaiting each — let the queue handle concurrency.
+      // Previously each `await queue.add()` serialized what should be concurrent work.
+      const tasks = pagesToProcess.map(page =>
+        this.queue.add(() => this._processOne(
+          page.url,
           page.wikidotId,
-          page.reasons, 
+          page.reasons,
           trackProgress
-        ));
-      }
+        ))
+      );
+      await Promise.all(tasks);
       
       await this.queue.drain();
       

--- a/bff/src/web/routes/collections.ts
+++ b/bff/src/web/routes/collections.ts
@@ -507,37 +507,49 @@ export function collectionsRouter(pool: Pool, _redis: RedisClientType | null) {
 
       const supportsTransforms = await ensureCoverTransformColumns(pool);
 
-      const result = await pool.query<any>(
-        supportsTransforms
-          ? `
-            INSERT INTO "UserCollection"
-            ("ownerId", title, slug, visibility, description, notes, "coverImageUrl", "coverImageOffsetX", "coverImageOffsetY", "coverImageScale", "isDefault", "publishedAt")
-            VALUES ($1, $2, $3, 'PRIVATE', $4, $5, $6, $7, $8, $9, $10, NULL)
-            RETURNING *
-          `
-          : `
-            INSERT INTO "UserCollection"
-            ("ownerId", title, slug, visibility, description, notes, "coverImageUrl", "isDefault", "publishedAt")
-            VALUES ($1, $2, $3, 'PRIVATE', $4, $5, $6, $7, NULL)
-            RETURNING *
-          `,
-        supportsTransforms
-          ? [ownerId, title, slug, description, notes, coverImageUrl, coverImageOffsetX, coverImageOffsetY, coverImageScale, isDefault]
-          : [ownerId, title, slug, description, notes, coverImageUrl, isDefault]
-      );
+      // Use a transaction to atomically insert + clear other defaults
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
 
-      if (isDefault) {
-        await pool.query(
-          `
-            UPDATE "UserCollection"
-            SET "isDefault" = FALSE
-            WHERE "ownerId" = $1 AND id <> $2 AND "isDefault" = TRUE
-          `,
-          [ownerId, result.rows[0].id]
+        const result = await client.query<any>(
+          supportsTransforms
+            ? `
+              INSERT INTO "UserCollection"
+              ("ownerId", title, slug, visibility, description, notes, "coverImageUrl", "coverImageOffsetX", "coverImageOffsetY", "coverImageScale", "isDefault", "publishedAt")
+              VALUES ($1, $2, $3, 'PRIVATE', $4, $5, $6, $7, $8, $9, $10, NULL)
+              RETURNING *
+            `
+            : `
+              INSERT INTO "UserCollection"
+              ("ownerId", title, slug, visibility, description, notes, "coverImageUrl", "isDefault", "publishedAt")
+              VALUES ($1, $2, $3, 'PRIVATE', $4, $5, $6, $7, NULL)
+              RETURNING *
+            `,
+          supportsTransforms
+            ? [ownerId, title, slug, description, notes, coverImageUrl, coverImageOffsetX, coverImageOffsetY, coverImageScale, isDefault]
+            : [ownerId, title, slug, description, notes, coverImageUrl, isDefault]
         );
-      }
 
-      res.status(201).json({ ok: true, collection: mapCollectionRow(result.rows[0]) });
+        if (isDefault) {
+          await client.query(
+            `
+              UPDATE "UserCollection"
+              SET "isDefault" = FALSE
+              WHERE "ownerId" = $1 AND id <> $2 AND "isDefault" = TRUE
+            `,
+            [ownerId, result.rows[0].id]
+          );
+        }
+
+        await client.query('COMMIT');
+        res.status(201).json({ ok: true, collection: mapCollectionRow(result.rows[0]) });
+      } catch (txErr) {
+        await client.query('ROLLBACK').catch(() => {});
+        throw txErr;
+      } finally {
+        client.release();
+      }
     } catch (error) {
       next(error);
     }

--- a/bff/src/web/routes/pages.ts
+++ b/bff/src/web/routes/pages.ts
@@ -706,8 +706,7 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
         ratingLte,
         createdAtGte,
         createdAtLte,
-        isHidden,
-        isUserPage,
+        // isHidden and isUserPage are accepted but not used in the query
         sortKey,
         sortOrder,
         limit = '20',
@@ -760,8 +759,8 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
         ratingLte || null,
         createdAtGte || null,
         createdAtLte || null,
-        limit,
-        offset
+        Math.min(Math.max(0, Number(limit) | 0) || 20, 200),
+        Math.max(0, Number(offset) | 0)
       ];
 
       const { rows } = await readPool.query(sql, params);

--- a/bff/src/web/routes/stats.ts
+++ b/bff/src/web/routes/stats.ts
@@ -154,6 +154,14 @@ export function statsRouter(pool: Pool, redis: RedisClientType | null) {
 	router.get('/site/overview/series', async (req, res, next) => {
 		try {
 			const { startDate, endDate, limit = '365', offset = '0' } = req.query as Record<string, string>;
+			// Validate date format to return 400 instead of letting PostgreSQL ::date cast fail with 500
+			const dateRe = /^\d{4}-\d{2}-\d{2}$/;
+			if (startDate && !dateRe.test(startDate.trim())) {
+				return res.status(400).json({ error: 'invalid startDate format, expected YYYY-MM-DD' });
+			}
+			if (endDate && !dateRe.test(endDate.trim())) {
+				return res.status(400).json({ error: 'invalid endDate format, expected YYYY-MM-DD' });
+			}
 			const defaultStart = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 			const effectiveStart = (startDate && startDate.trim()) ? startDate : defaultStart;
 			const cacheKey = `stats:site:overview:series:${effectiveStart || 'auto'}:${endDate || 'null'}:${limit}:${offset}`;

--- a/bff/src/web/utils/cache.ts
+++ b/bff/src/web/utils/cache.ts
@@ -47,6 +47,9 @@ function memorySet(key: string, value: unknown, ttlSeconds: number): void {
 }
 
 export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREFIX): CacheHandle {
+  // In-flight loader deduplication (singleflight) to prevent thundering herd
+  const inflight = new Map<string, Promise<unknown>>();
+
   if (!redis) {
     // Use in-memory cache as fallback when Redis is unavailable
     return {
@@ -56,12 +59,23 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
         const cached = memoryGet<T>(fullKey);
         if (cached !== null) return cached;
 
-        const result = await loader();
-        if (result === undefined) return result;
-        if (result === null && options?.cacheNull !== true) return result;
+        // Deduplicate concurrent loads for the same key
+        const existing = inflight.get(fullKey);
+        if (existing) return existing as Promise<T>;
 
-        memorySet(fullKey, result, ttl);
-        return result;
+        const promise = (async () => {
+          try {
+            const result = await loader();
+            if (result === undefined) return result;
+            if (result === null && options?.cacheNull !== true) return result;
+            memorySet(fullKey, result, ttl);
+            return result;
+          } finally {
+            inflight.delete(fullKey);
+          }
+        })();
+        inflight.set(fullKey, promise);
+        return promise as Promise<T>;
       },
       async getJSON<T>(key: string): Promise<T | null> {
         return memoryGet<T>(`${prefix}${key}`);
@@ -113,16 +127,23 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
       return cached;
     }
 
-    const result = await loader();
-    if (result === undefined) {
-      return result;
-    }
-    if ((result === null) && options?.cacheNull !== true) {
-      return result;
-    }
+    const fullKey = namespaced(key);
+    const existing = inflight.get(fullKey);
+    if (existing) return existing as Promise<T>;
 
-    await setJSON(key, result, ttlSeconds);
-    return result;
+    const promise = (async () => {
+      try {
+        const result = await loader();
+        if (result === undefined) return result;
+        if (result === null && options?.cacheNull !== true) return result;
+        await setJSON(key, result, ttlSeconds);
+        return result;
+      } finally {
+        inflight.delete(fullKey);
+      }
+    })();
+    inflight.set(fullKey, promise);
+    return promise as Promise<T>;
   }
 
   return {

--- a/bff/tests/integration/live-db.test.ts
+++ b/bff/tests/integration/live-db.test.ts
@@ -73,8 +73,9 @@ d('Live DB integration (requires DATABASE_URL)', () => {
 
 	test('Users endpoints using /users/by-rank for discovery', async () => {
 		const ranked = await request(app).get('/users/by-rank?limit=1').expect(200);
-		if (!ranked.body.length) return; // dataset may be empty
-		const user = ranked.body[0];
+		const items = ranked.body.items ?? ranked.body;
+		if (!items.length) return; // dataset may be empty
+		const user = items[0];
 		expect(user).toHaveProperty('id');
 		const id = String(user.id);
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "chartjs-adapter-date-fns": "^3.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "consola": "^3.4.0",
     "codemirror": "^5.65.16",
     "d3-force": "^3.0.0",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
## Summary

全仓库安全审计 Phase 3 修复，覆盖 9 项代码质量和性能改善：

- **M-2** Collections 创建+默认切换包入 BEGIN/COMMIT 事务
- **M-4** Pages 列表接口 limit 硬上限 200
- **M-7** Phase C 入队改为 `Promise.all`，正确利用 TaskQueue 并发
- **M-9** BFF 缓存层增加 singleflight（in-flight 去重），防止 thundering herd
- **M-10** Stats 日期参数格式校验（400 而非 500）
- **L-5** 前端显式声明 consola 依赖
- **L-7** 后端删除未使用的 uuid 依赖
- **L-8** Pages 路由移除未使用的 isHidden/isUserPage 参数解构
- **L-9** 修复 live-db 测试适配 `{total, items}` 响应格式

## Test plan

- [ ] 验证收藏夹创建设为默认时，其他收藏夹的默认标记被正确清除
- [ ] 验证搜索/列表大 limit 被正确 cap
- [ ] 验证缓存并发请求只触发一次 loader
- [ ] 验证 Phase C sync 正常运行（非串行）
- [ ] 验证 stats 日期格式错误返回 400