### PR TITLE
fix: resolve sync cascade failure and chart crash

### DIFF
--- a/backend/src/cli/sync.ts
+++ b/backend/src/cli/sync.ts
@@ -231,14 +231,22 @@ export async function sync({
     }
 
     // 只有在运行所有阶段或者明确指定 analyze 时才运行分析
+    // Analysis failures are non-fatal: Phase A/B/C data sync already succeeded,
+    // so we log the error but let sync() return normally to unblock downstream
+    // tasks (forum sync, gacha sync) in the hourly scheduler.
     if (phase === 'all' || phase === 'analyze') {
       const spinnerAnalyze = ora(full ? 'Analysis: full incremental...' : 'Analysis: incremental...').start();
-      if (full) {
-        await analyzeIncremental({ forceFullAnalysis: true });
-      } else {
-        await analyzeIncremental();
+      try {
+        if (full) {
+          await analyzeIncremental({ forceFullAnalysis: true });
+        } else {
+          await analyzeIncremental();
+        }
+        spinnerAnalyze.succeed('Analysis completed');
+      } catch (analyzeError) {
+        spinnerAnalyze.fail('Analysis completed with errors');
+        console.error('⚠️ Incremental analysis had failures (non-fatal for sync):', analyzeError instanceof Error ? analyzeError.message : analyzeError);
       }
-      spinnerAnalyze.succeed('Analysis completed');
     }
 
     const totalTime = (Date.now() - startTime) / 1000;

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -91,9 +91,22 @@ export class IncrementalAnalyzeJob {
         await this.cleanAnalysisData(tasksToRun);
       }
 
+      const failedTasks: Array<{ name: string; error: unknown }> = [];
+
       for (const taskName of tasksToRun) {
         console.log(`📊 Running task: ${taskName}`);
-        await this.runTask(taskName, options.forceFullAnalysis, { forceFullHistory });
+        try {
+          await this.runTask(taskName, options.forceFullAnalysis, { forceFullHistory });
+        } catch (taskError) {
+          console.error(`❌ Task ${taskName} failed:`, taskError);
+          failedTasks.push({ name: taskName, error: taskError });
+        }
+      }
+
+      if (failedTasks.length > 0) {
+        const names = failedTasks.map(t => t.name).join(', ');
+        console.error(`⚠️ Incremental analysis completed with ${failedTasks.length} failed task(s): ${names}`);
+        throw new Error(`${failedTasks.length} task(s) failed: ${names}`, { cause: failedTasks[0]!.error });
       }
 
       console.log('✅ Incremental analysis completed successfully!');

--- a/backend/src/jobs/WikidotBindingVerifyJob.ts
+++ b/backend/src/jobs/WikidotBindingVerifyJob.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 
 const USER_BACKEND_URL = process.env.USER_BACKEND_BASE_URL || 'http://127.0.0.1:4455';
+const INTERNAL_API_KEY = (process.env.INTERNAL_API_KEY || '').trim();
 const TARGET_PAGE_URL = '/andyblocker'; // The page where users add verification code (must end with /andyblocker)
 const USER_BACKEND_FETCH_TIMEOUT_MS = Math.max(
   1000,
@@ -67,12 +68,19 @@ export class WikidotBindingVerifyJob {
     }
   }
 
+  private internalHeaders(extra?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = { ...extra };
+    if (INTERNAL_API_KEY) headers['x-internal-key'] = INTERNAL_API_KEY;
+    return headers;
+  }
+
   private async fetchPendingTasks(): Promise<PendingTask[]> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), USER_BACKEND_FETCH_TIMEOUT_MS);
     try {
       const response = await fetch(`${USER_BACKEND_URL}/internal/wikidot-binding/pending`, {
         method: 'GET',
+        headers: this.internalHeaders(),
         signal: controller.signal
       });
 
@@ -180,7 +188,7 @@ export class WikidotBindingVerifyJob {
     try {
       await fetch(`${USER_BACKEND_URL}/internal/wikidot-binding/complete`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: this.internalHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({
           taskId,
           revisionId,
@@ -196,7 +204,7 @@ export class WikidotBindingVerifyJob {
     try {
       await fetch(`${USER_BACKEND_URL}/internal/wikidot-binding/update-check`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: this.internalHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ taskId })
       });
     } catch (error) {
@@ -208,7 +216,7 @@ export class WikidotBindingVerifyJob {
     try {
       await fetch(`${USER_BACKEND_URL}/internal/wikidot-binding/expire`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: this.internalHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ taskId })
       });
     } catch (error) {

--- a/backend/src/jobs/WikidotBindingVerifyJob.ts
+++ b/backend/src/jobs/WikidotBindingVerifyJob.ts
@@ -184,43 +184,32 @@ export class WikidotBindingVerifyJob {
     }
   }
 
-  private async completeTask(taskId: string, revisionId: number, timestamp: Date): Promise<void> {
+  private async postInternal(path: string, body: Record<string, unknown>, label: string): Promise<void> {
     try {
-      await fetch(`${USER_BACKEND_URL}/internal/wikidot-binding/complete`, {
+      const response = await fetch(`${USER_BACKEND_URL}${path}`, {
         method: 'POST',
         headers: this.internalHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({
-          taskId,
-          revisionId,
-          timestamp: timestamp.toISOString()
-        })
+        body: JSON.stringify(body)
       });
+      if (!response.ok) {
+        console.warn(`⚠️ ${label}: HTTP ${response.status}`);
+      }
     } catch (error) {
-      console.warn(`⚠️ Failed to complete task ${taskId}:`, error);
+      console.warn(`⚠️ ${label}:`, error);
     }
+  }
+
+  private async completeTask(taskId: string, revisionId: number, timestamp: Date): Promise<void> {
+    await this.postInternal('/internal/wikidot-binding/complete', {
+      taskId, revisionId, timestamp: timestamp.toISOString()
+    }, `Failed to complete task ${taskId}`);
   }
 
   private async updateTaskCheck(taskId: string): Promise<void> {
-    try {
-      await fetch(`${USER_BACKEND_URL}/internal/wikidot-binding/update-check`, {
-        method: 'POST',
-        headers: this.internalHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ taskId })
-      });
-    } catch (error) {
-      console.warn(`⚠️ Failed to update task check for ${taskId}:`, error);
-    }
+    await this.postInternal('/internal/wikidot-binding/update-check', { taskId }, `Failed to update task check for ${taskId}`);
   }
 
   private async expireTask(taskId: string): Promise<void> {
-    try {
-      await fetch(`${USER_BACKEND_URL}/internal/wikidot-binding/expire`, {
-        method: 'POST',
-        headers: this.internalHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ taskId })
-      });
-    } catch (error) {
-      console.warn(`⚠️ Failed to expire task ${taskId}:`, error);
-    }
+    await this.postInternal('/internal/wikidot-binding/expire', { taskId }, `Failed to expire task ${taskId}`);
   }
 }

--- a/frontend/components/gacha/MarketCandlestickChart.vue
+++ b/frontend/components/gacha/MarketCandlestickChart.vue
@@ -439,11 +439,15 @@ function updateChart() {
     areaMarkerApiRef.value?.setMarkers([])
   }
 
+  // lightweight-charts throws "Value is null" when setVisibleRange is called
+  // on a chart with no data points — guard against empty series
+  if (candleData.length === 0) return
+
   const asOf = parseUnixSeconds(props.asOfTs) ?? Math.floor(Date.now() / 1000)
   const windowFrom = asOf - timeframeHours(props.timeframe) * 60 * 60
   const bucketSeconds = timeframeBucketSeconds(props.timeframe)
-  const firstCandleTime = candleData.length > 0 ? Number(candleData[0]!.time) : windowFrom
-  const lastCandleTime = candleData.length > 0 ? Number(candleData[candleData.length - 1]!.time) : asOf
+  const firstCandleTime = Number(candleData[0]!.time)
+  const lastCandleTime = Number(candleData[candleData.length - 1]!.time)
   const from = Math.max(windowFrom, firstCandleTime - bucketSeconds)
   const to = Math.max(asOf, lastCandleTime)
 


### PR DESCRIPTION
## Summary

- **WikidotBindingVerifyJob 403 修复**：所有内部 API 调用（`/internal/wikidot-binding/*`）缺少 `x-internal-key` 请求头，导致 user-backend 返回 403 Forbidden。添加 `internalHeaders()` helper 统一注入 `INTERNAL_API_KEY`。
- **IncrementalAnalyzeJob 任务级容错**：此前单个任务失败会中断整个分析循环，导致 `sync()` 抛错 → forum sync 和 gacha sync 被跳过。现在每个任务独立 try-catch，失败的任务被记录但不阻塞后续任务执行。
- **MarketCandlestickChart 空数据崩溃**：当 candle 数据为空时调用 `setVisibleRange()` 会触发 lightweight-charts 内部 "Value is null" 断言错误。添加 `candleData.length === 0` 前置守卫。

## 根因分析

`wikidot_binding_verify` 是增量分析的最后一个任务。它调用 user-backend 的内部 API 时缺少认证头 → 403 → 任务抛错 → `analyzeIncremental()` 失败 → `sync()` 失败 → `sync-hourly.ts` 中排在 `sync()` 之后的 forum sync **永远不会执行** → forum 数据停止更新。

## Test plan

- [ ] 确认 `INTERNAL_API_KEY` 环境变量在 backend `.env` 中已设置
- [ ] 部署后观察 scpper-sync 日志：`wikidot_binding_verify` 不再 403
- [ ] 确认 forum sync 恢复执行（日志中出现 `Forum sync done`）
- [ ] 访问股市页面确认无 "Value is null" 控制台错误
- [ ] 可选：在 `INTERNAL_API_KEY` 未配置的情况下验证降级行为（503 而非 403）