### PR TITLE
fix: restore tag validation service and refresh pipeline

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -51,6 +51,7 @@
     "tags:sync": "node --import tsx/esm src/cli/index.ts tags --sync --force",
     "tags:check": "node --import tsx/esm src/cli/index.ts tags --check",
     "tags:stats": "node --import tsx/esm src/cli/index.ts tags --stats",
+    "tags:refresh-cache": "node --import tsx/esm src/cli/index.ts tags --refresh-cache",
     "analyze:text": "node --import tsx/esm scripts/text-analysis-pipeline.ts",
     "analyze:page": "node --import tsx/esm scripts/analyze-single-page.ts",
     "check:ranking": "node --import tsx/esm scripts/check-ranking-totals.ts",

--- a/backend/prisma/migrations/20260118000000_add_tag_validation_cache/migration.sql
+++ b/backend/prisma/migrations/20260118000000_add_tag_validation_cache/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable (already exists in production, this migration is recorded for schema consistency)
+CREATE TABLE IF NOT EXISTS "TagValidationCache" (
+    "id" SERIAL NOT NULL,
+    "tag" TEXT NOT NULL,
+    "pageCount" INTEGER NOT NULL DEFAULT 0,
+    "samplePages" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "validationType" TEXT NOT NULL DEFAULT 'invalid',
+    "computedAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "latestPageDate" TIMESTAMPTZ,
+
+    CONSTRAINT "TagValidationCache_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "TagValidationCache_tag_validationType_key" ON "TagValidationCache"("tag", "validationType");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "idx_tag_validation_type" ON "TagValidationCache"("validationType");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "idx_tag_validation_computed" ON "TagValidationCache"("computedAt");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "idx_tag_validation_latest" ON "TagValidationCache"("latestPageDate" DESC NULLS LAST);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -914,6 +914,22 @@ model TagDefinition {
   @@index([category])
 }
 
+/// 标签验证缓存表 - 存储预计算的标签统计数据
+model TagValidationCache {
+  id             Int       @id @default(autoincrement())
+  tag            String
+  pageCount      Int       @default(0)
+  samplePages    String[]  @default([])
+  validationType String    @default("invalid") // 'all', 'invalid', 'untranslated'
+  computedAt     DateTime  @default(now())
+  latestPageDate DateTime?
+
+  @@unique([tag, validationType])
+  @@index([validationType], map: "idx_tag_validation_type")
+  @@index([computedAt], map: "idx_tag_validation_computed")
+  @@index([latestPageDate(sort: Desc)], map: "idx_tag_validation_latest")
+}
+
 /// 标签指导页面同步状态跟踪
 model TagGuideSync {
   id              Int       @id @default(autoincrement())

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -1010,18 +1010,22 @@ program
           }
         }
 
-        // 同步后自动刷新缓存
-        Logger.info('📦 计算并缓存所有标签...');
-        const allTagsCount = await service.computeAndCacheAllTags();
-        Logger.info(`✅ 已缓存 ${allTagsCount} 个标签`);
+        // 同步后自动刷新缓存（仅在无错误时）
+        if (result.errors.length > 0) {
+          Logger.warn('⚠️ 同步存在错误，跳过缓存刷新以避免产生误判');
+        } else {
+          Logger.info('📦 计算并缓存所有标签...');
+          const allTagsCount = await service.computeAndCacheAllTags();
+          Logger.info(`✅ 已缓存 ${allTagsCount} 个标签`);
 
-        Logger.info('📦 计算并缓存无效标签...');
-        const invalidCount = await service.computeAndCacheInvalidTags();
-        Logger.info(`✅ 已缓存 ${invalidCount} 个无效标签`);
+          Logger.info('📦 计算并缓存无效标签...');
+          const invalidCount = await service.computeAndCacheInvalidTags();
+          Logger.info(`✅ 已缓存 ${invalidCount} 个无效标签`);
 
-        Logger.info('📦 计算并缓存未翻译标签...');
-        const untranslatedCount = await service.computeAndCacheUntranslatedTags();
-        Logger.info(`✅ 已缓存 ${untranslatedCount} 个未翻译标签`);
+          Logger.info('📦 计算并缓存未翻译标签...');
+          const untranslatedCount = await service.computeAndCacheUntranslatedTags();
+          Logger.info(`✅ 已缓存 ${untranslatedCount} 个未翻译标签`);
+        }
       }
 
       if (options.refreshCache) {

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -18,6 +18,7 @@ import { showImagesProgress } from './images-progress.js';
 import { countComponentIncludeUsage } from './include-usage.js';
 import { checkRecentAlerts } from './alerts.js';
 import { syncGachaPool } from './gacha-sync.js';
+import { TagDefinitionService } from '../services/TagDefinitionService.js';
 import { backfillGachaPageImageRefs } from './gacha-backfill-page-image-refs.js';
 import { repairGachaCardImageMapping } from './gacha-repair-card-image-mapping.js';
 import { repairGachaGhostCards } from './gacha-repair-ghost-cards.js';
@@ -976,9 +977,190 @@ program
 
 program
   .command('tags')
-  .description('标签定义功能已暂时停用')
-  .action(() => {
-    Logger.warn('⚠️ 标签定义功能暂时停用，请稍后再试。');
+  .description('标签定义同步和验证工具')
+  .option('--sync', '从标签指导页面同步标签定义')
+  .option('--force', '强制同步（忽略版本检查）')
+  .option('--check', '检查无效标签（不在官方定义中的标签）')
+  .option('--untranslated', '显示未翻译的标签（只有中文没有英文）')
+  .option('--stats', '显示标签定义统计信息')
+  .option('--status', '显示标签指导页面同步状态')
+  .option('--refresh-cache', '仅刷新 TagValidationCache（不同步定义）')
+  .option('--json', '以 JSON 格式输出')
+  .option('--limit <number>', '限制输出数量', '100')
+  .action(async (options) => {
+    const prisma = getPrismaClient();
+    const service = new TagDefinitionService(prisma);
+    const jsonOutput = Boolean(options.json);
+
+    try {
+      if (options.sync) {
+        Logger.info('📦 开始同步标签定义...');
+        const result = await service.syncTagDefinitions(Boolean(options.force));
+
+        if (jsonOutput) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          Logger.info(`✅ 同步完成:`);
+          Logger.info(`   - 处理页面: ${result.pagesProcessed}`);
+          Logger.info(`   - 新增标签: ${result.tagsAdded}`);
+          Logger.info(`   - 更新标签: ${result.tagsUpdated}`);
+          if (result.errors.length > 0) {
+            Logger.warn(`   - 错误: ${result.errors.length}`);
+            result.errors.forEach(err => Logger.warn(`     ${err}`));
+          }
+        }
+
+        // 同步后自动刷新缓存
+        Logger.info('📦 计算并缓存所有标签...');
+        const allTagsCount = await service.computeAndCacheAllTags();
+        Logger.info(`✅ 已缓存 ${allTagsCount} 个标签`);
+
+        Logger.info('📦 计算并缓存无效标签...');
+        const invalidCount = await service.computeAndCacheInvalidTags();
+        Logger.info(`✅ 已缓存 ${invalidCount} 个无效标签`);
+
+        Logger.info('📦 计算并缓存未翻译标签...');
+        const untranslatedCount = await service.computeAndCacheUntranslatedTags();
+        Logger.info(`✅ 已缓存 ${untranslatedCount} 个未翻译标签`);
+      }
+
+      if (options.refreshCache) {
+        Logger.info('📦 刷新 TagValidationCache...');
+
+        Logger.info('  计算所有标签...');
+        const allTagsCount = await service.computeAndCacheAllTags();
+        Logger.info(`  ✅ 已缓存 ${allTagsCount} 个标签`);
+
+        Logger.info('  计算无效标签...');
+        const invalidCount = await service.computeAndCacheInvalidTags();
+        Logger.info(`  ✅ 已缓存 ${invalidCount} 个无效标签`);
+
+        Logger.info('  计算未翻译标签...');
+        const untranslatedCount = await service.computeAndCacheUntranslatedTags();
+        Logger.info(`  ✅ 已缓存 ${untranslatedCount} 个未翻译标签`);
+
+        Logger.info('✅ 缓存刷新完成');
+      }
+
+      if (options.check) {
+        const limit = Number.parseInt(String(options.limit ?? '100'), 10) || 100;
+        Logger.info(`🔍 获取无效标签（从缓存，限制 ${limit} 条）...`);
+        const invalidTags = await service.getInvalidTags(limit);
+
+        if (jsonOutput) {
+          console.log(JSON.stringify({ invalidTags }, null, 2));
+        } else if (invalidTags.length === 0) {
+          Logger.info('✅ 未发现无效标签');
+        } else {
+          Logger.warn(`⚠️ 发现 ${invalidTags.length} 个疑似无效标签:`);
+          console.log('');
+          console.log('标签'.padEnd(20) + '页面数'.padStart(8) + '  示例页面');
+          console.log('-'.repeat(80));
+          for (const tag of invalidTags) {
+            const samples = tag.samplePages.slice(0, 2).map(url => {
+              const parts = url.split('/');
+              return parts[parts.length - 1];
+            }).join(', ');
+            console.log(
+              tag.tag.padEnd(20) +
+              String(tag.pageCount).padStart(8) +
+              '  ' + samples
+            );
+          }
+        }
+      }
+
+      if (options.untranslated) {
+        Logger.info('🔍 获取未翻译标签...');
+        const untranslated = await service.getUntranslatedTags();
+
+        if (jsonOutput) {
+          console.log(JSON.stringify({ untranslatedTags: untranslated }, null, 2));
+        } else if (untranslated.length === 0) {
+          Logger.info('✅ 所有标签都已翻译');
+        } else {
+          Logger.info(`📝 发现 ${untranslated.length} 个未翻译标签:`);
+          console.log('');
+          console.log('标签'.padEnd(20) + '来源'.padEnd(30) + '类别');
+          console.log('-'.repeat(70));
+          for (const tag of untranslated) {
+            const source = tag.sourcePageUrl.split('/').pop() || tag.sourcePageUrl;
+            console.log(
+              tag.tagChinese.padEnd(20) +
+              source.padEnd(30) +
+              (tag.category || '')
+            );
+          }
+        }
+      }
+
+      if (options.stats) {
+        Logger.info('📊 标签定义统计:');
+        const stats = await service.getStats();
+
+        if (jsonOutput) {
+          console.log(JSON.stringify(stats, null, 2));
+        } else {
+          console.log(`  总数: ${stats.total}`);
+          console.log(`  有翻译: ${stats.withTranslation}`);
+          console.log(`  无翻译: ${stats.withoutTranslation}`);
+          console.log('  分类:');
+          for (const cat of stats.byCategory) {
+            console.log(`    ${cat.category}: ${cat.count}`);
+          }
+        }
+      }
+
+      if (options.status) {
+        Logger.info('📋 标签指导页面同步状态:');
+        const statuses = await service.getSyncStatus();
+
+        if (jsonOutput) {
+          console.log(JSON.stringify({ syncStatus: statuses }, null, 2));
+        } else if (statuses.length === 0) {
+          Logger.info('  暂无同步记录');
+        } else {
+          console.log('');
+          console.log('页面URL'.padEnd(30) + '状态'.padEnd(10) + '提取标签数'.padStart(8) + '  最后同步时间');
+          console.log('-'.repeat(80));
+          for (const s of statuses) {
+            const pageUrl = s.pageUrl.length > 28 ? s.pageUrl.slice(0, 28) + '..' : s.pageUrl;
+            const syncTime = s.lastSyncedAt ? new Date(s.lastSyncedAt).toLocaleString('zh-CN') : '未同步';
+            console.log(
+              pageUrl.padEnd(30) +
+              s.syncStatus.padEnd(10) +
+              String(s.tagsExtracted).padStart(8) +
+              '  ' + syncTime
+            );
+          }
+        }
+      }
+
+      // 如果没有指定任何选项，显示帮助
+      const hasOption = options.sync || options.check || options.untranslated ||
+                        options.stats || options.status || options.refreshCache;
+      if (!hasOption) {
+        Logger.info('标签定义同步和验证工具');
+        Logger.info('');
+        console.log('可用选项:');
+        console.log('  --sync              从标签指导页面同步标签定义（同步后自动刷新缓存）');
+        console.log('  --force             强制同步（忽略版本检查）');
+        console.log('  --check             检查无效标签');
+        console.log('  --untranslated      显示未翻译的标签');
+        console.log('  --stats             显示标签定义统计');
+        console.log('  --status            显示同步状态');
+        console.log('  --refresh-cache     仅刷新缓存（不同步定义）');
+        console.log('  --json              JSON 格式输出');
+        console.log('  --limit <number>    限制输出数量');
+        console.log('');
+        console.log('示例:');
+        console.log('  npm run tags -- --sync --force    强制同步标签定义');
+        console.log('  npm run tags -- --check           检查无效标签');
+        console.log('  npm run tags -- --refresh-cache   仅刷新缓存');
+      }
+    } finally {
+      await disconnectPrisma();
+    }
   });
 
 // Global error handlers for robust CLI processes

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -1055,11 +1055,20 @@ program
 
       if (options.check) {
         const limit = Number.parseInt(String(options.limit ?? '100'), 10) || 100;
+
+        // 检查缓存是否存在
+        const cacheCount = await prisma.$queryRaw<[{ count: number }]>`
+          SELECT COUNT(*)::int as count FROM "TagValidationCache" WHERE "validationType" = 'invalid'
+        `;
+        if (cacheCount[0].count === 0) {
+          Logger.warn('⚠️ 无效标签缓存为空，请先运行 --sync 或 --refresh-cache 生成缓存');
+        }
+
         Logger.info(`🔍 获取无效标签（从缓存，限制 ${limit} 条）...`);
         const invalidTags = await service.getInvalidTags(limit);
 
         if (jsonOutput) {
-          console.log(JSON.stringify({ invalidTags }, null, 2));
+          console.log(JSON.stringify({ invalidTags, cached: cacheCount[0].count > 0 }, null, 2));
         } else if (invalidTags.length === 0) {
           Logger.info('✅ 未发现无效标签');
         } else {

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -1035,13 +1035,19 @@ program
         const allTagsCount = await service.computeAndCacheAllTags();
         Logger.info(`  ✅ 已缓存 ${allTagsCount} 个标签`);
 
-        Logger.info('  计算无效标签...');
-        const invalidCount = await service.computeAndCacheInvalidTags();
-        Logger.info(`  ✅ 已缓存 ${invalidCount} 个无效标签`);
+        // invalid 和 untranslated 依赖 TagDefinition，空表时跳过避免误判
+        const defCount = await prisma.tagDefinition.count();
+        if (defCount === 0) {
+          Logger.warn('⚠️ TagDefinition 表为空，跳过 invalid/untranslated 缓存。请先运行 --sync');
+        } else {
+          Logger.info('  计算无效标签...');
+          const invalidCount = await service.computeAndCacheInvalidTags();
+          Logger.info(`  ✅ 已缓存 ${invalidCount} 个无效标签`);
 
-        Logger.info('  计算未翻译标签...');
-        const untranslatedCount = await service.computeAndCacheUntranslatedTags();
-        Logger.info(`  ✅ 已缓存 ${untranslatedCount} 个未翻译标签`);
+          Logger.info('  计算未翻译标签...');
+          const untranslatedCount = await service.computeAndCacheUntranslatedTags();
+          Logger.info(`  ✅ 已缓存 ${untranslatedCount} 个未翻译标签`);
+        }
 
         Logger.info('✅ 缓存刷新完成');
       }

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -1038,7 +1038,8 @@ program
         // invalid 和 untranslated 依赖 TagDefinition，空表时跳过避免误判
         const defCount = await prisma.tagDefinition.count();
         if (defCount === 0) {
-          Logger.warn('⚠️ TagDefinition 表为空，跳过 invalid/untranslated 缓存。请先运行 --sync');
+          Logger.warn('⚠️ TagDefinition 表为空，清除旧的 invalid/untranslated 缓存。请先运行 --sync');
+          await prisma.$executeRaw`DELETE FROM "TagValidationCache" WHERE "validationType" IN ('invalid', 'untranslated')`;
         } else {
           Logger.info('  计算无效标签...');
           const invalidCount = await service.computeAndCacheInvalidTags();

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -8,6 +8,7 @@ import { PageMetricMonitorJob } from './PageMetricMonitorJob';
 import { UserFollowActivityJob } from './UserFollowActivityJob';
 import { UserCollectionService } from '../services/UserCollectionService.js';
 import { WikidotBindingVerifyJob } from './WikidotBindingVerifyJob.js';
+import { TagDefinitionService } from '../services/TagDefinitionService.js';
 import { runCategoryIndexTickJob } from './CategoryIndexTickJob.js';
 import { runCategoryIndexForecastJob } from './CategoryIndexForecastJob.js';
 // @ts-ignore - importing from scripts folder
@@ -62,6 +63,8 @@ export class IncrementalAnalyzeJob {
         'user_collection_sanitizer',
         // 新增：作者分类基准
         'category_benchmarks',
+        // 标签验证缓存刷新
+        'tag_validation_cache',
         // Wikidot 账号绑定验证
         'wikidot_binding_verify'
       ];
@@ -224,6 +227,10 @@ export class IncrementalAnalyzeJob {
             await (this.prisma as any).categoryIndexForecastTick?.deleteMany?.({});
             console.log('  ✓ Category index forecast ticks cleared');
             break;
+          case 'tag_validation_cache':
+            await this.prisma.$executeRaw`DELETE FROM "TagValidationCache"`;
+            console.log('  ✓ TagValidationCache cleared');
+            break;
           case 'materialized_views':
             // 物化视图需要先DROP再重建，这里只记录日志
             console.log('  ⚠️ Materialized views will be refreshed (not dropped)');
@@ -271,7 +278,8 @@ export class IncrementalAnalyzeJob {
           'series_stats',
           'trending_stats',
           'page_metric_alerts',
-          'wikidot_binding_verify'
+          'wikidot_binding_verify',
+          'tag_validation_cache'
         ]);
         if (taskName === 'site_stats') {
           await this.refreshSiteStatsTimestamp();
@@ -398,6 +406,10 @@ export class IncrementalAnalyzeJob {
         case 'user_collection_sanitizer': {
           const service = new UserCollectionService(this.prisma);
           await service.pruneInvalidItems();
+          break;
+        }
+        case 'tag_validation_cache': {
+          await this.refreshTagValidationCache();
           break;
         }
         case 'wikidot_binding_verify': {
@@ -2105,6 +2117,25 @@ export class IncrementalAnalyzeJob {
     ]);
     
     console.log('✅ Tag records updated');
+  }
+
+  /**
+   * 刷新 TagValidationCache（all + invalid + untranslated）
+   */
+  private async refreshTagValidationCache() {
+    console.log('🏷️ Refreshing TagValidationCache...');
+    const service = new TagDefinitionService(this.prisma);
+
+    const allCount = await service.computeAndCacheAllTags();
+    console.log(`  ✅ all: ${allCount} tags`);
+
+    const invalidCount = await service.computeAndCacheInvalidTags();
+    console.log(`  ✅ invalid: ${invalidCount} tags`);
+
+    const untranslatedCount = await service.computeAndCacheUntranslatedTags();
+    console.log(`  ✅ untranslated: ${untranslatedCount} tags`);
+
+    console.log('✅ TagValidationCache refreshed');
   }
 
   /**

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -2124,16 +2124,27 @@ export class IncrementalAnalyzeJob {
    */
   private async refreshTagValidationCache() {
     console.log('🏷️ Refreshing TagValidationCache...');
+
+    // 检查 TagDefinition 表是否有数据，避免空定义表导致所有标签被误判为 invalid
+    const defCount = await this.prisma.tagDefinition.count();
+    if (defCount === 0) {
+      console.log('⏭️ TagDefinition table is empty — skipping invalid/untranslated cache to avoid false positives. Run "npm run tags -- --sync" first.');
+    }
+
     const service = new TagDefinitionService(this.prisma);
 
+    // all 标签缓存不依赖 TagDefinition，始终可以安全刷新
     const allCount = await service.computeAndCacheAllTags();
     console.log(`  ✅ all: ${allCount} tags`);
 
-    const invalidCount = await service.computeAndCacheInvalidTags();
-    console.log(`  ✅ invalid: ${invalidCount} tags`);
+    // invalid 和 untranslated 依赖 TagDefinition，仅在有定义数据时刷新
+    if (defCount > 0) {
+      const invalidCount = await service.computeAndCacheInvalidTags();
+      console.log(`  ✅ invalid: ${invalidCount} tags`);
 
-    const untranslatedCount = await service.computeAndCacheUntranslatedTags();
-    console.log(`  ✅ untranslated: ${untranslatedCount} tags`);
+      const untranslatedCount = await service.computeAndCacheUntranslatedTags();
+      console.log(`  ✅ untranslated: ${untranslatedCount} tags`);
+    }
 
     console.log('✅ TagValidationCache refreshed');
   }

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -278,8 +278,7 @@ export class IncrementalAnalyzeJob {
           'series_stats',
           'trending_stats',
           'page_metric_alerts',
-          'wikidot_binding_verify',
-          'tag_validation_cache'
+          'wikidot_binding_verify'
         ]);
         if (taskName === 'site_stats') {
           await this.refreshSiteStatsTimestamp();
@@ -2128,7 +2127,8 @@ export class IncrementalAnalyzeJob {
     // 检查 TagDefinition 表是否有数据，避免空定义表导致所有标签被误判为 invalid
     const defCount = await this.prisma.tagDefinition.count();
     if (defCount === 0) {
-      console.log('⏭️ TagDefinition table is empty — skipping invalid/untranslated cache to avoid false positives. Run "npm run tags -- --sync" first.');
+      console.log('⏭️ TagDefinition table is empty — clearing stale invalid/untranslated cache. Run "npm run tags -- --sync" first.');
+      await this.prisma.$executeRaw`DELETE FROM "TagValidationCache" WHERE "validationType" IN ('invalid', 'untranslated')`;
     }
 
     const service = new TagDefinitionService(this.prisma);

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -228,8 +228,12 @@ export class IncrementalAnalyzeJob {
             console.log('  ✓ Category index forecast ticks cleared');
             break;
           case 'tag_validation_cache':
-            await this.prisma.$executeRaw`DELETE FROM "TagValidationCache"`;
-            console.log('  ✓ TagValidationCache cleared');
+            try {
+              await this.prisma.$executeRaw`DELETE FROM "TagValidationCache"`;
+              console.log('  ✓ TagValidationCache cleared');
+            } catch {
+              console.log('  ⚠️ TagValidationCache table not found, skipping');
+            }
             break;
           case 'materialized_views':
             // 物化视图需要先DROP再重建，这里只记录日志

--- a/backend/src/services/TagDefinitionService.ts
+++ b/backend/src/services/TagDefinitionService.ts
@@ -1,0 +1,510 @@
+import { PrismaClient } from '@prisma/client';
+import { Logger } from '../utils/Logger.js';
+
+const logger = Logger;
+
+// 标签指导页面配置
+const TAG_GUIDE_PAGES = [
+  { urlPattern: '/tag-guide', category: '通用标签' },
+  { urlPattern: '/tale-tagging-guide', category: '体裁标签' },
+  { urlPattern: '/art-tagging-guide', category: '艺作标签' },
+  { urlPattern: 'wanderers:tagging-guide', category: '流浪者图书馆标签' },
+];
+
+interface TagDef {
+  tagChinese: string;
+  tagEnglish: string | null;
+  description: string | null;
+  sourcePageUrl: string;
+  category: string;
+}
+
+interface SyncResult {
+  pagesProcessed: number;
+  tagsAdded: number;
+  tagsUpdated: number;
+  errors: string[];
+}
+
+interface CachedTag {
+  tag: string;
+  pageCount: number;
+  samplePages: string[];
+}
+
+interface UsedTagRow {
+  tag: string;
+  page_count: number;
+  sample_pages: string[] | null;
+  latest_page_date: Date | null;
+}
+
+interface UntranslatedRow {
+  tag_chinese: string;
+  source_page_url: string | null;
+  category: string | null;
+  usage_count: number;
+}
+
+export class TagDefinitionService {
+  private prisma: PrismaClient;
+
+  constructor(prisma: PrismaClient) {
+    this.prisma = prisma;
+  }
+
+  /**
+   * 从 source 中提取标签定义
+   */
+  extractTagDefinitions(source: string, sourcePageUrl: string, category: string): TagDef[] {
+    const definitions = new Map<string, TagDef>();
+
+    // 格式1: tag-guide 标准格式（有中英文对照，英文是链接）
+    // **[*/system:page-tags/tag/中文 中文]** **//([*https://www.scpwiki.com/system:page-tags/tag/英文 英文])//**
+    const pattern1 = /\*\*\[\*?\/system:page-tags\/tag\/([^\s\]]+)\s+[^\]]+\]\*\*\s*\*\*\/\/\(\[\*https?:\/\/[^\s]+\/system:page-tags\/tag\/([^\s\]]+)\s+[^\]]+\]\)\/\/\*\*/g;
+
+    // 格式2: tale-tagging-guide 格式（中文圆括号）
+    // **[https://scp-wiki-cn.wikidot.com/system:page-tags/tag/中文 中文]（[https://scp-wiki.wikidot.com/system:page-tags/tag/英文 英文]）**
+    const pattern2 = /\*\*\[https?:\/\/[^\s]+\/system:page-tags\/tag\/([^\s\]]+)\s+[^\]]+\]（\[https?:\/\/[^\s]+\/system:page-tags\/tag\/([^\s\]]+)\s+[^\]]+\]）\*\*/g;
+
+    // 格式3: tag-guide 简化格式（英文不是链接，只是斜体）
+    // **[/system:page-tags/tag/无定形 无定形] //(amorphous)//**
+    const pattern3 = /\*\*\[\/?system:page-tags\/tag\/([^\s\]]+)\s+[^\]]+\]\s*\/\/\(([^)]+)\)\/\/\*\*/g;
+
+    // 格式4: 仅中文标签（后面不跟英文）
+    // **[*/system:page-tags/tag/中文 中文]**
+    const pattern4 = /\*\*\[\*?\/system:page-tags\/tag\/([^\s\]]+)\s+[^\]]+\]\*\*(?!\s*\*\*\/\/|\s*\/\/\()/g;
+
+    // 格式5: 另一种仅中文格式（tale-tagging-guide中的）
+    // **[https://scp-wiki-cn.wikidot.com/system:page-tags/tag/中文 中文]** 后面不跟（
+    const pattern5 = /\*\*\[https?:\/\/scp-wiki-cn\.wikidot\.com\/system:page-tags\/tag\/([^\s\]]+)\s+[^\]]+\]\*\*(?!\s*（)/g;
+
+    let match: RegExpExecArray | null;
+
+    // 匹配格式1
+    while ((match = pattern1.exec(source)) !== null) {
+      const chinese = match[1];
+      const english = match[2];
+      if (!definitions.has(chinese)) {
+        definitions.set(chinese, {
+          tagChinese: chinese,
+          tagEnglish: english !== chinese ? english : null,
+          description: null,
+          sourcePageUrl,
+          category,
+        });
+      }
+    }
+
+    // 匹配格式2
+    while ((match = pattern2.exec(source)) !== null) {
+      const chinese = match[1];
+      const english = match[2];
+      if (!definitions.has(chinese)) {
+        definitions.set(chinese, {
+          tagChinese: chinese,
+          tagEnglish: english !== chinese ? english : null,
+          description: null,
+          sourcePageUrl,
+          category,
+        });
+      }
+    }
+
+    // 匹配格式3 (简化格式，英文在斜体括号内)
+    while ((match = pattern3.exec(source)) !== null) {
+      const chinese = match[1];
+      const english = match[2];
+      if (!definitions.has(chinese)) {
+        definitions.set(chinese, {
+          tagChinese: chinese,
+          tagEnglish: english !== chinese ? english : null,
+          description: null,
+          sourcePageUrl,
+          category,
+        });
+      }
+    }
+
+    // 匹配格式4 (仅中文)
+    while ((match = pattern4.exec(source)) !== null) {
+      const chinese = match[1];
+      if (!definitions.has(chinese)) {
+        definitions.set(chinese, {
+          tagChinese: chinese,
+          tagEnglish: null,
+          description: null,
+          sourcePageUrl,
+          category,
+        });
+      }
+    }
+
+    // 匹配格式5 (仅中文，tale-tagging-guide)
+    while ((match = pattern5.exec(source)) !== null) {
+      const chinese = match[1];
+      if (!definitions.has(chinese)) {
+        definitions.set(chinese, {
+          tagChinese: chinese,
+          tagEnglish: null,
+          description: null,
+          sourcePageUrl,
+          category,
+        });
+      }
+    }
+
+    return Array.from(definitions.values());
+  }
+
+  /**
+   * 同步标签定义
+   */
+  async syncTagDefinitions(force = false): Promise<SyncResult> {
+    const result: SyncResult = {
+      pagesProcessed: 0,
+      tagsAdded: 0,
+      tagsUpdated: 0,
+      errors: [],
+    };
+
+    for (const guide of TAG_GUIDE_PAGES) {
+      try {
+        // 查找页面
+        const page = await this.prisma.page.findFirst({
+          where: {
+            url: { contains: guide.urlPattern },
+            isDeleted: false,
+          },
+          include: {
+            versions: {
+              where: { validTo: null },
+              take: 1,
+            },
+          },
+        });
+
+        if (!page) {
+          logger.warn(`未找到标签指导页面: ${guide.urlPattern}`);
+          continue;
+        }
+
+        const version = page.versions[0];
+        if (!version?.source) {
+          logger.warn(`页面无source内容: ${page.url}`);
+          continue;
+        }
+
+        // 检查是否需要更新
+        const syncStatus = await this.prisma.tagGuideSync.findUnique({
+          where: { pageUrl: page.url },
+        });
+
+        if (!force && syncStatus?.pageVersionId === version.id) {
+          logger.info(`页面未变化，跳过: ${page.url}`);
+          continue;
+        }
+
+        // 提取标签定义
+        const definitions = this.extractTagDefinitions(version.source, page.url, guide.category);
+        logger.info(`从 ${page.url} 提取到 ${definitions.length} 个标签定义`);
+
+        // 批量upsert
+        for (const def of definitions) {
+          const existing = await this.prisma.tagDefinition.findUnique({
+            where: { tagChinese: def.tagChinese },
+          });
+
+          if (existing) {
+            await this.prisma.tagDefinition.update({
+              where: { tagChinese: def.tagChinese },
+              data: {
+                tagEnglish: def.tagEnglish,
+                sourcePageUrl: def.sourcePageUrl,
+                category: def.category,
+                updatedAt: new Date(),
+              },
+            });
+            result.tagsUpdated++;
+          } else {
+            await this.prisma.tagDefinition.create({
+              data: {
+                tagChinese: def.tagChinese,
+                tagEnglish: def.tagEnglish,
+                description: def.description,
+                sourcePageUrl: def.sourcePageUrl,
+                category: def.category,
+                isOfficial: true,
+              },
+            });
+            result.tagsAdded++;
+          }
+        }
+
+        // 更新同步状态
+        await this.prisma.tagGuideSync.upsert({
+          where: { pageUrl: page.url },
+          create: {
+            pageUrl: page.url,
+            pageVersionId: version.id,
+            tagsExtracted: definitions.length,
+            lastSyncedAt: new Date(),
+            syncStatus: 'synced',
+          },
+          update: {
+            pageVersionId: version.id,
+            tagsExtracted: definitions.length,
+            lastSyncedAt: new Date(),
+            syncStatus: 'synced',
+            errorMessage: null,
+          },
+        });
+
+        result.pagesProcessed++;
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        result.errors.push(`${guide.urlPattern}: ${errMsg}`);
+        logger.error(`处理页面失败 ${guide.urlPattern}: ${errMsg}`);
+
+        // 记录失败状态
+        try {
+          const page = await this.prisma.page.findFirst({
+            where: { url: { contains: guide.urlPattern } },
+          });
+          if (page) {
+            await this.prisma.tagGuideSync.upsert({
+              where: { pageUrl: page.url },
+              create: {
+                pageUrl: page.url,
+                syncStatus: 'failed',
+                errorMessage: errMsg,
+              },
+              update: {
+                syncStatus: 'failed',
+                errorMessage: errMsg,
+              },
+            });
+          }
+        } catch { /* ignore nested error */ }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * 获取无效标签（从缓存读取）
+   */
+  async getInvalidTags(limit = 100): Promise<CachedTag[]> {
+    const cached = await this.prisma.$queryRaw<CachedTag[]>`
+      SELECT tag, "pageCount", "samplePages"
+      FROM "TagValidationCache"
+      WHERE "validationType" = 'invalid'
+      ORDER BY "pageCount" DESC
+      LIMIT ${limit}
+    `;
+    return cached.map(c => ({
+      tag: c.tag,
+      pageCount: c.pageCount,
+      samplePages: c.samplePages || [],
+    }));
+  }
+
+  /**
+   * 计算并缓存无效标签（离线计算）
+   */
+  async computeAndCacheInvalidTags(): Promise<number> {
+    logger.info('开始计算无效标签...');
+
+    // 获取所有官方标签
+    const officialTags = await this.prisma.tagDefinition.findMany({
+      select: { tagChinese: true, tagEnglish: true },
+    });
+    const officialSet = new Set<string>();
+    for (const tag of officialTags) {
+      officialSet.add(tag.tagChinese);
+      if (tag.tagEnglish) {
+        officialSet.add(tag.tagEnglish);
+      }
+    }
+
+    // 系统标签前缀
+    const systemPrefixes = ['crom:', '_', 'system:', 'admin:'];
+    const isSystemTag = (tag: string) => {
+      return systemPrefixes.some(prefix => tag.startsWith(prefix));
+    };
+
+    // 一次性获取所有使用中的标签、示例页面wikidotId和最近活跃时间
+    const usedTagsWithPages = await this.prisma.$queryRaw<UsedTagRow[]>`
+      WITH tag_pages AS (
+        SELECT
+          t.tag,
+          p."wikidotId"::text as wikidot_id,
+          pv."createdAt" as page_date,
+          ROW_NUMBER() OVER (PARTITION BY t.tag ORDER BY p."wikidotId") as rn
+        FROM "PageVersion" pv
+        CROSS JOIN LATERAL unnest(pv.tags) AS t(tag)
+        JOIN "Page" p ON pv."pageId" = p.id
+        WHERE pv."validTo" IS NULL AND NOT pv."isDeleted" AND p."wikidotId" IS NOT NULL
+      )
+      SELECT
+        tag,
+        COUNT(DISTINCT wikidot_id)::int as page_count,
+        ARRAY_AGG(wikidot_id) FILTER (WHERE rn <= 5) as sample_pages,
+        MAX(page_date) as latest_page_date
+      FROM tag_pages
+      GROUP BY tag
+      ORDER BY page_count DESC
+    `;
+
+    // 过滤出无效标签
+    const invalidTags = usedTagsWithPages.filter(
+      t => !isSystemTag(t.tag) && !officialSet.has(t.tag)
+    );
+
+    // 清空旧缓存
+    await this.prisma.$executeRaw`DELETE FROM "TagValidationCache" WHERE "validationType" = 'invalid'`;
+
+    // 批量插入新缓存
+    if (invalidTags.length > 0) {
+      const now = new Date();
+      for (const t of invalidTags) {
+        await this.prisma.$executeRaw`
+          INSERT INTO "TagValidationCache" (tag, "pageCount", "samplePages", "validationType", "computedAt", "latestPageDate")
+          VALUES (${t.tag}, ${t.page_count}, ${t.sample_pages || []}, 'invalid', ${now}, ${t.latest_page_date})
+        `;
+      }
+    }
+
+    logger.info(`缓存了 ${invalidTags.length} 个无效标签`);
+    return invalidTags.length;
+  }
+
+  /**
+   * 计算并缓存所有使用中的标签（离线计算）
+   */
+  async computeAndCacheAllTags(): Promise<number> {
+    logger.info('开始计算所有标签...');
+
+    const allTagsWithStats = await this.prisma.$queryRaw<UsedTagRow[]>`
+      SELECT
+        t.tag,
+        COUNT(DISTINCT pv."pageId")::int as page_count,
+        MAX(pv."createdAt") as latest_page_date
+      FROM "PageVersion" pv
+      CROSS JOIN LATERAL unnest(pv.tags) AS t(tag)
+      WHERE pv."validTo" IS NULL AND NOT pv."isDeleted"
+        AND t.tag IS NOT NULL AND btrim(t.tag) <> ''
+      GROUP BY t.tag
+      ORDER BY page_count DESC
+    `;
+
+    // 清空旧缓存
+    await this.prisma.$executeRaw`DELETE FROM "TagValidationCache" WHERE "validationType" = 'all'`;
+
+    // 批量插入新缓存
+    if (allTagsWithStats.length > 0) {
+      const now = new Date();
+      for (const t of allTagsWithStats) {
+        await this.prisma.$executeRaw`
+          INSERT INTO "TagValidationCache" (tag, "pageCount", "samplePages", "validationType", "computedAt", "latestPageDate")
+          VALUES (${t.tag}, ${t.page_count}, '{}', 'all', ${now}, ${t.latest_page_date})
+        `;
+      }
+    }
+
+    logger.info(`缓存了 ${allTagsWithStats.length} 个标签`);
+    return allTagsWithStats.length;
+  }
+
+  /**
+   * 计算并缓存未翻译标签的使用统计（离线计算）
+   */
+  async computeAndCacheUntranslatedTags(): Promise<number> {
+    logger.info('开始计算未翻译标签...');
+
+    const untranslatedWithUsage = await this.prisma.$queryRaw<UntranslatedRow[]>`
+      WITH tag_usage AS (
+        SELECT tag, COUNT(DISTINCT pv."pageId")::int as usage_count
+        FROM "PageVersion" pv
+        CROSS JOIN LATERAL unnest(pv.tags) AS t(tag)
+        WHERE pv."validTo" IS NULL AND NOT pv."isDeleted"
+        GROUP BY tag
+      )
+      SELECT td."tagChinese" as tag_chinese, td."sourcePageUrl" as source_page_url, td.category,
+             COALESCE(tu.usage_count, 0)::int as usage_count
+      FROM "TagDefinition" td
+      LEFT JOIN tag_usage tu ON td."tagChinese" = tu.tag
+      WHERE td."tagEnglish" IS NULL
+      ORDER BY usage_count DESC
+    `;
+
+    // 清空旧缓存
+    await this.prisma.$executeRaw`DELETE FROM "TagValidationCache" WHERE "validationType" = 'untranslated'`;
+
+    // 批量插入新缓存
+    if (untranslatedWithUsage.length > 0) {
+      const now = new Date();
+      for (const t of untranslatedWithUsage) {
+        // 使用 samplePages 存储 category 和 sourcePageUrl
+        const metadata = [t.source_page_url || '', t.category || ''];
+        await this.prisma.$executeRaw`
+          INSERT INTO "TagValidationCache" (tag, "pageCount", "samplePages", "validationType", "computedAt")
+          VALUES (${t.tag_chinese}, ${t.usage_count}, ${metadata}, 'untranslated', ${now})
+        `;
+      }
+    }
+
+    logger.info(`缓存了 ${untranslatedWithUsage.length} 个未翻译标签`);
+    return untranslatedWithUsage.length;
+  }
+
+  /**
+   * 获取未翻译的标签（只有中文没有英文）
+   */
+  async getUntranslatedTags() {
+    const tags = await this.prisma.tagDefinition.findMany({
+      where: { tagEnglish: null },
+      orderBy: { tagChinese: 'asc' },
+    });
+    return tags.map(t => ({
+      tagChinese: t.tagChinese,
+      tagEnglish: t.tagEnglish,
+      description: t.description,
+      sourcePageUrl: t.sourcePageUrl,
+      category: t.category,
+    }));
+  }
+
+  /**
+   * 获取同步状态
+   */
+  async getSyncStatus() {
+    return this.prisma.tagGuideSync.findMany({
+      orderBy: { lastSyncedAt: 'desc' },
+    });
+  }
+
+  /**
+   * 获取统计信息
+   */
+  async getStats() {
+    const total = await this.prisma.tagDefinition.count();
+    const withTranslation = await this.prisma.tagDefinition.count({
+      where: { tagEnglish: { not: null } },
+    });
+    const byCategory = await this.prisma.tagDefinition.groupBy({
+      by: ['category'],
+      _count: { id: true },
+    });
+    return {
+      total,
+      withTranslation,
+      withoutTranslation: total - withTranslation,
+      byCategory: byCategory.map(c => ({
+        category: c.category || '未分类',
+        count: c._count.id,
+      })),
+    };
+  }
+}

--- a/backend/src/services/TagDefinitionService.ts
+++ b/backend/src/services/TagDefinitionService.ts
@@ -409,6 +409,7 @@ export class TagDefinitionService {
         CROSS JOIN LATERAL unnest(pv.tags) AS t(tag)
         JOIN "Page" p ON pv."pageId" = p.id
         WHERE pv."validTo" IS NULL AND NOT pv."isDeleted" AND p."wikidotId" IS NOT NULL
+          AND t.tag IS NOT NULL AND btrim(t.tag) <> ''
       )
       SELECT
         tag,

--- a/backend/src/services/TagDefinitionService.ts
+++ b/backend/src/services/TagDefinitionService.ts
@@ -362,19 +362,19 @@ export class TagDefinitionService {
       t => !isSystemTag(t.tag) && !officialSet.has(t.tag)
     );
 
-    // 清空旧缓存
-    await this.prisma.$executeRaw`DELETE FROM "TagValidationCache" WHERE "validationType" = 'invalid'`;
-
-    // 批量插入新缓存
-    if (invalidTags.length > 0) {
-      const now = new Date();
-      for (const t of invalidTags) {
-        await this.prisma.$executeRaw`
-          INSERT INTO "TagValidationCache" (tag, "pageCount", "samplePages", "validationType", "computedAt", "latestPageDate")
-          VALUES (${t.tag}, ${t.page_count}, ${t.sample_pages || []}, 'invalid', ${now}, ${t.latest_page_date})
-        `;
+    // 在事务内原子替换，避免 BFF 读到中间状态
+    await this.prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`DELETE FROM "TagValidationCache" WHERE "validationType" = 'invalid'`;
+      if (invalidTags.length > 0) {
+        const now = new Date();
+        for (const t of invalidTags) {
+          await tx.$executeRaw`
+            INSERT INTO "TagValidationCache" (tag, "pageCount", "samplePages", "validationType", "computedAt", "latestPageDate")
+            VALUES (${t.tag}, ${t.page_count}, ${t.sample_pages || []}, 'invalid', ${now}, ${t.latest_page_date})
+          `;
+        }
       }
-    }
+    });
 
     logger.info(`缓存了 ${invalidTags.length} 个无效标签`);
     return invalidTags.length;
@@ -399,19 +399,19 @@ export class TagDefinitionService {
       ORDER BY page_count DESC
     `;
 
-    // 清空旧缓存
-    await this.prisma.$executeRaw`DELETE FROM "TagValidationCache" WHERE "validationType" = 'all'`;
-
-    // 批量插入新缓存
-    if (allTagsWithStats.length > 0) {
-      const now = new Date();
-      for (const t of allTagsWithStats) {
-        await this.prisma.$executeRaw`
-          INSERT INTO "TagValidationCache" (tag, "pageCount", "samplePages", "validationType", "computedAt", "latestPageDate")
-          VALUES (${t.tag}, ${t.page_count}, '{}', 'all', ${now}, ${t.latest_page_date})
-        `;
+    // 在事务内原子替换，避免 BFF 读到中间状态
+    await this.prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`DELETE FROM "TagValidationCache" WHERE "validationType" = 'all'`;
+      if (allTagsWithStats.length > 0) {
+        const now = new Date();
+        for (const t of allTagsWithStats) {
+          await tx.$executeRaw`
+            INSERT INTO "TagValidationCache" (tag, "pageCount", "samplePages", "validationType", "computedAt", "latestPageDate")
+            VALUES (${t.tag}, ${t.page_count}, '{}', 'all', ${now}, ${t.latest_page_date})
+          `;
+        }
       }
-    }
+    });
 
     logger.info(`缓存了 ${allTagsWithStats.length} 个标签`);
     return allTagsWithStats.length;
@@ -439,21 +439,21 @@ export class TagDefinitionService {
       ORDER BY usage_count DESC
     `;
 
-    // 清空旧缓存
-    await this.prisma.$executeRaw`DELETE FROM "TagValidationCache" WHERE "validationType" = 'untranslated'`;
-
-    // 批量插入新缓存
-    if (untranslatedWithUsage.length > 0) {
-      const now = new Date();
-      for (const t of untranslatedWithUsage) {
-        // 使用 samplePages 存储 category 和 sourcePageUrl
-        const metadata = [t.source_page_url || '', t.category || ''];
-        await this.prisma.$executeRaw`
-          INSERT INTO "TagValidationCache" (tag, "pageCount", "samplePages", "validationType", "computedAt")
-          VALUES (${t.tag_chinese}, ${t.usage_count}, ${metadata}, 'untranslated', ${now})
-        `;
+    // 在事务内原子替换，避免 BFF 读到中间状态
+    await this.prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`DELETE FROM "TagValidationCache" WHERE "validationType" = 'untranslated'`;
+      if (untranslatedWithUsage.length > 0) {
+        const now = new Date();
+        for (const t of untranslatedWithUsage) {
+          // 使用 samplePages 存储 category 和 sourcePageUrl
+          const metadata = [t.source_page_url || '', t.category || ''];
+          await tx.$executeRaw`
+            INSERT INTO "TagValidationCache" (tag, "pageCount", "samplePages", "validationType", "computedAt")
+            VALUES (${t.tag_chinese}, ${t.usage_count}, ${metadata}, 'untranslated', ${now})
+          `;
+        }
       }
-    }
+    });
 
     logger.info(`缓存了 ${untranslatedWithUsage.length} 个未翻译标签`);
     return untranslatedWithUsage.length;

--- a/backend/src/services/TagDefinitionService.ts
+++ b/backend/src/services/TagDefinitionService.ts
@@ -185,13 +185,17 @@ export class TagDefinitionService {
         });
 
         if (!page) {
-          logger.warn(`未找到标签指导页面: ${guide.urlPattern}`);
+          const errMsg = `未找到标签指导页面: ${guide.urlPattern}`;
+          logger.warn(errMsg);
+          result.errors.push(errMsg);
           continue;
         }
 
         const version = page.versions[0];
         if (!version?.source) {
-          logger.warn(`页面无source内容: ${page.url}`);
+          const errMsg = `页面无source内容: ${page.url}`;
+          logger.warn(errMsg);
+          result.errors.push(errMsg);
           continue;
         }
 

--- a/backend/src/services/TagDefinitionService.ts
+++ b/backend/src/services/TagDefinitionService.ts
@@ -4,12 +4,13 @@ import { Logger } from '../utils/Logger.js';
 const logger = Logger;
 
 // 标签指导页面配置
+// optional: true 表示该页面可能尚未被同步到数据库，缺失时不视为错误
 const TAG_GUIDE_PAGES = [
   { urlPattern: '/tag-guide', category: '通用标签' },
   { urlPattern: '/tale-tagging-guide', category: '体裁标签' },
   { urlPattern: '/art-tagging-guide', category: '艺作标签' },
-  { urlPattern: 'wanderers:tagging-guide', category: '流浪者图书馆标签' },
-];
+  { urlPattern: 'wanderers:tagging-guide', category: '流浪者图书馆标签', optional: true },
+] as const;
 
 interface TagDef {
   tagChinese: string;
@@ -185,17 +186,25 @@ export class TagDefinitionService {
         });
 
         if (!page) {
-          const errMsg = `未找到标签指导页面: ${guide.urlPattern}`;
-          logger.warn(errMsg);
-          result.errors.push(errMsg);
+          const msg = `未找到标签指导页面: ${guide.urlPattern}`;
+          if ('optional' in guide && guide.optional) {
+            logger.info(`${msg}（可选页面，跳过）`);
+          } else {
+            logger.warn(msg);
+            result.errors.push(msg);
+          }
           continue;
         }
 
         const version = page.versions[0];
         if (!version?.source) {
-          const errMsg = `页面无source内容: ${page.url}`;
-          logger.warn(errMsg);
-          result.errors.push(errMsg);
+          const msg = `页面无source内容: ${page.url}`;
+          if ('optional' in guide && guide.optional) {
+            logger.info(`${msg}（可选页面，跳过）`);
+          } else {
+            logger.warn(msg);
+            result.errors.push(msg);
+          }
           continue;
         }
 

--- a/backend/src/services/TagDefinitionService.ts
+++ b/backend/src/services/TagDefinitionService.ts
@@ -234,76 +234,86 @@ export class TagDefinitionService {
           continue;
         }
 
-        // 记录本次从该页面提取到的标签集合，用于清理已删除的标签
+        // 在事务内完成 upsert + 旧标签清理 + 同步状态更新，避免中途失败导致半更新
         const extractedTagSet = new Set(definitions.map(d => d.tagChinese));
+        let added = 0;
+        let updated = 0;
+        let deleted = 0;
 
-        // 批量upsert
-        for (const def of definitions) {
-          const existing = await this.prisma.tagDefinition.findUnique({
-            where: { tagChinese: def.tagChinese },
-          });
-
-          if (existing) {
-            await this.prisma.tagDefinition.update({
+        await this.prisma.$transaction(async (tx) => {
+          // 批量upsert
+          for (const def of definitions) {
+            const existing = await tx.tagDefinition.findUnique({
               where: { tagChinese: def.tagChinese },
-              data: {
-                tagEnglish: def.tagEnglish,
-                sourcePageUrl: def.sourcePageUrl,
-                category: def.category,
-                updatedAt: new Date(),
-              },
             });
-            result.tagsUpdated++;
-          } else {
-            await this.prisma.tagDefinition.create({
-              data: {
-                tagChinese: def.tagChinese,
-                tagEnglish: def.tagEnglish,
-                description: def.description,
-                sourcePageUrl: def.sourcePageUrl,
-                category: def.category,
-                isOfficial: true,
-              },
-            });
-            result.tagsAdded++;
-          }
-        }
 
-        // P2: 清理该页面来源下已不存在的旧标签
-        const staleTags = await this.prisma.tagDefinition.findMany({
-          where: { sourcePageUrl: page.url },
-          select: { tagChinese: true },
-        });
-        const tagsToDelete = staleTags.filter(t => !extractedTagSet.has(t.tagChinese));
-        if (tagsToDelete.length > 0) {
-          await this.prisma.tagDefinition.deleteMany({
-            where: {
-              tagChinese: { in: tagsToDelete.map(t => t.tagChinese) },
-              sourcePageUrl: page.url,
+            if (existing) {
+              await tx.tagDefinition.update({
+                where: { tagChinese: def.tagChinese },
+                data: {
+                  tagEnglish: def.tagEnglish,
+                  sourcePageUrl: def.sourcePageUrl,
+                  category: def.category,
+                  updatedAt: new Date(),
+                },
+              });
+              updated++;
+            } else {
+              await tx.tagDefinition.create({
+                data: {
+                  tagChinese: def.tagChinese,
+                  tagEnglish: def.tagEnglish,
+                  description: def.description,
+                  sourcePageUrl: def.sourcePageUrl,
+                  category: def.category,
+                  isOfficial: true,
+                },
+              });
+              added++;
+            }
+          }
+
+          // 清理该页面来源下已不存在的旧标签
+          const staleTags = await tx.tagDefinition.findMany({
+            where: { sourcePageUrl: page.url },
+            select: { tagChinese: true },
+          });
+          const tagsToDelete = staleTags.filter(t => !extractedTagSet.has(t.tagChinese));
+          if (tagsToDelete.length > 0) {
+            await tx.tagDefinition.deleteMany({
+              where: {
+                tagChinese: { in: tagsToDelete.map(t => t.tagChinese) },
+                sourcePageUrl: page.url,
+              },
+            });
+            deleted = tagsToDelete.length;
+          }
+
+          // 更新同步状态
+          await tx.tagGuideSync.upsert({
+            where: { pageUrl: page.url },
+            create: {
+              pageUrl: page.url,
+              pageVersionId: version.id,
+              tagsExtracted: definitions.length,
+              lastSyncedAt: new Date(),
+              syncStatus: 'synced',
+            },
+            update: {
+              pageVersionId: version.id,
+              tagsExtracted: definitions.length,
+              lastSyncedAt: new Date(),
+              syncStatus: 'synced',
+              errorMessage: null,
             },
           });
-          logger.info(`  清理了 ${tagsToDelete.length} 个已从 ${page.url} 移除的旧标签`);
-        }
-
-        // 更新同步状态
-        await this.prisma.tagGuideSync.upsert({
-          where: { pageUrl: page.url },
-          create: {
-            pageUrl: page.url,
-            pageVersionId: version.id,
-            tagsExtracted: definitions.length,
-            lastSyncedAt: new Date(),
-            syncStatus: 'synced',
-          },
-          update: {
-            pageVersionId: version.id,
-            tagsExtracted: definitions.length,
-            lastSyncedAt: new Date(),
-            syncStatus: 'synced',
-            errorMessage: null,
-          },
         });
 
+        result.tagsAdded += added;
+        result.tagsUpdated += updated;
+        if (deleted > 0) {
+          logger.info(`  清理了 ${deleted} 个已从 ${page.url} 移除的旧标签`);
+        }
         result.pagesProcessed++;
       } catch (error) {
         const errMsg = error instanceof Error ? error.message : String(error);

--- a/backend/src/services/TagDefinitionService.ts
+++ b/backend/src/services/TagDefinitionService.ts
@@ -209,6 +209,30 @@ export class TagDefinitionService {
         const definitions = this.extractTagDefinitions(version.source, page.url, guide.category);
         logger.info(`从 ${page.url} 提取到 ${definitions.length} 个标签定义`);
 
+        // P1: 零标签提取保护 — markup 格式变化可能导致正则全部失配
+        if (definitions.length === 0) {
+          const errMsg = `从 ${page.url} 提取到 0 个标签，疑似 markup 格式变化导致正则失配`;
+          result.errors.push(errMsg);
+          logger.error(errMsg);
+
+          await this.prisma.tagGuideSync.upsert({
+            where: { pageUrl: page.url },
+            create: {
+              pageUrl: page.url,
+              syncStatus: 'failed',
+              errorMessage: errMsg,
+            },
+            update: {
+              syncStatus: 'failed',
+              errorMessage: errMsg,
+            },
+          });
+          continue;
+        }
+
+        // 记录本次从该页面提取到的标签集合，用于清理已删除的标签
+        const extractedTagSet = new Set(definitions.map(d => d.tagChinese));
+
         // 批量upsert
         for (const def of definitions) {
           const existing = await this.prisma.tagDefinition.findUnique({
@@ -239,6 +263,22 @@ export class TagDefinitionService {
             });
             result.tagsAdded++;
           }
+        }
+
+        // P2: 清理该页面来源下已不存在的旧标签
+        const staleTags = await this.prisma.tagDefinition.findMany({
+          where: { sourcePageUrl: page.url },
+          select: { tagChinese: true },
+        });
+        const tagsToDelete = staleTags.filter(t => !extractedTagSet.has(t.tagChinese));
+        if (tagsToDelete.length > 0) {
+          await this.prisma.tagDefinition.deleteMany({
+            where: {
+              tagChinese: { in: tagsToDelete.map(t => t.tagChinese) },
+              sourcePageUrl: page.url,
+            },
+          });
+          logger.info(`  清理了 ${tagsToDelete.length} 个已从 ${page.url} 移除的旧标签`);
         }
 
         // 更新同步状态

--- a/bff/src/web/routes/tags.ts
+++ b/bff/src/web/routes/tags.ts
@@ -177,8 +177,8 @@ export function tagsRouter(pool: Pool, _redis: RedisClientType | null) {
         sql += ` AND category = $${params.length}`;
       }
 
-      // Count total
-      const countSql = sql.replace(/SELECT .* FROM/, 'SELECT COUNT(*)::int as total FROM');
+      // Count total — use [\s\S] instead of . to match across newlines in the SQL string
+      const countSql = sql.replace(/SELECT[\s\S]*?FROM/, 'SELECT COUNT(*)::int as total FROM');
       const { rows: countRows } = await readPool.query(countSql, params);
       const total = countRows[0]?.total || 0;
 


### PR DESCRIPTION
## Summary

- **恢复 `TagDefinitionService.ts`**：从 `dist/` 中的编译产物反推还原完整 TypeScript 源文件，包含标签定义同步、无效标签检测、未翻译标签统计、缓存刷新等全部方法
- **恢复 CLI `tags` 命令**：将 stub 替换为完整实现，支持 `--sync`/`--check`/`--untranslated`/`--stats`/`--status` 选项，新增 `--refresh-cache` 选项用于仅刷新缓存而不重新同步定义
- **补齐 `TagValidationCache` Prisma model**：添加 model 定义和 `CREATE TABLE IF NOT EXISTS` 迁移文件（表在数据库中已存在，迁移用于 schema 一致性）
- **修复 BFF `/definitions` total 计数 bug**：`sql.replace(/SELECT .* FROM/)` 无法匹配多行 SQL，改用 `[\s\S]*?` 跨行匹配
- **添加 `tags:refresh-cache` npm script**：快速刷新缓存数据而无需重新同步标签定义

## 背景

`TagValidationCache` 中的数据最后更新于 2026-01-08，已过期超过 2 个月。BFF 端点优先读取缓存，导致前端标签统计页面展示过期数据。源文件 `TagDefinitionService.ts` 在某次代码整理中被意外删除，CLI 命令被 stub 化。

## Test plan

- [ ] 在 worktree 中 `npm run tags` 确认帮助信息正确输出
- [ ] `npm run tags -- --refresh-cache` 刷新 TagValidationCache 数据
- [ ] `npm run tags -- --check` 验证无效标签检测正常
- [ ] `npm run tags -- --stats` 验证统计信息正确
- [ ] 访问 `/tag-analytics` 页面确认标签分布数据已更新
- [ ] 验证 BFF `/api/tags/definitions` 的 total 返回正确值