### PR TITLE
fix: add tag_validation_cache to incremental sync

### DIFF
--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -282,6 +282,7 @@ export class IncrementalAnalyzeJob {
           'series_stats',
           'trending_stats',
           'page_metric_alerts',
+          'tag_validation_cache',
           'wikidot_binding_verify'
         ]);
         if (taskName === 'site_stats') {

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -283,7 +283,7 @@ export class IncrementalAnalyzeJob {
           'trending_stats',
           'page_metric_alerts',
           'tag_validation_cache',
-          'wikidot_binding_verify'
+          'wikidot_binding_verify',
         ]);
         if (taskName === 'site_stats') {
           await this.refreshSiteStatsTimestamp();
@@ -2127,6 +2127,17 @@ export class IncrementalAnalyzeJob {
    * 刷新 TagValidationCache（all + invalid + untranslated）
    */
   private async refreshTagValidationCache() {
+    // Throttle: skip if cache was refreshed within the last 6 hours
+    const STALE_THRESHOLD_MS = 6 * 60 * 60 * 1000;
+    const latest = await this.prisma.$queryRaw<Array<{ latest: Date | null }>>`
+      SELECT MAX("computedAt") as latest FROM "TagValidationCache"
+    `;
+    const lastComputedAt = latest[0]?.latest;
+    if (lastComputedAt && (Date.now() - new Date(lastComputedAt).getTime()) < STALE_THRESHOLD_MS) {
+      console.log(`⏭️ TagValidationCache still fresh (computed ${lastComputedAt.toISOString()}), skipping`);
+      return;
+    }
+
     console.log('🏷️ Refreshing TagValidationCache...');
 
     // 检查 TagDefinition 表是否有数据，避免空定义表导致所有标签被误判为 invalid

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -413,7 +413,7 @@ export class IncrementalAnalyzeJob {
           break;
         }
         case 'tag_validation_cache': {
-          await this.refreshTagValidationCache();
+          await this.refreshTagValidationCache(changeSet.length > 0);
           break;
         }
         case 'wikidot_binding_verify': {
@@ -2126,16 +2126,19 @@ export class IncrementalAnalyzeJob {
   /**
    * 刷新 TagValidationCache（all + invalid + untranslated）
    */
-  private async refreshTagValidationCache() {
-    // Throttle: skip if cache was refreshed within the last 6 hours
-    const STALE_THRESHOLD_MS = 6 * 60 * 60 * 1000;
-    const latest = await this.prisma.$queryRaw<Array<{ latest: Date | null }>>`
-      SELECT MAX("computedAt") as latest FROM "TagValidationCache"
-    `;
-    const lastComputedAt = latest[0]?.latest;
-    if (lastComputedAt && (Date.now() - new Date(lastComputedAt).getTime()) < STALE_THRESHOLD_MS) {
-      console.log(`⏭️ TagValidationCache still fresh (computed ${lastComputedAt.toISOString()}), skipping`);
-      return;
+  private async refreshTagValidationCache(hasChanges = false) {
+    // Throttle: on idle cycles (no changeSet), skip if cache was refreshed
+    // within the last 6 hours. When real changes exist, always rebuild.
+    if (!hasChanges) {
+      const STALE_THRESHOLD_MS = 6 * 60 * 60 * 1000;
+      const latest = await this.prisma.$queryRaw<Array<{ latest: Date | null }>>`
+        SELECT MAX("computedAt") as latest FROM "TagValidationCache"
+      `;
+      const lastComputedAt = latest[0]?.latest;
+      if (lastComputedAt && (Date.now() - new Date(lastComputedAt).getTime()) < STALE_THRESHOLD_MS) {
+        console.log(`⏭️ TagValidationCache still fresh (computed ${lastComputedAt.toISOString()}), skipping`);
+        return;
+      }
     }
 
     console.log('🏷️ Refreshing TagValidationCache...');


### PR DESCRIPTION
## Summary
- `tag_validation_cache` 任务之前不在 `alwaysRunTasks` 集合中，导致每小时增量 sync 时被 watermark 机制跳过（最后更新停留在 3 月 18 日）
- 该任务的计算逻辑是全表扫描当前所有页面标签，不依赖 changeSet，因此不应被 watermark 门控
- 将其加入 `alwaysRunTasks`，使其在每次增量分析时都执行

## Test plan
- [ ] 手动运行 `npm run analyze:incremental` 确认 `tag_validation_cache` 不再被跳过
- [ ] 验证 `TagValidationCache` 表的 `computedAt` 在 sync 后更新