### PR TITLE
fix: 修复 4 处 XSS 安全漏洞

### DIFF
--- a/bff/src/web/routes/page-preview.ts
+++ b/bff/src/web/routes/page-preview.ts
@@ -54,7 +54,7 @@ export function pagePreviewRouter(mainPool: pg.Pool) {
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.setHeader('Cache-Control', 'private, max-age=300');
       res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-      res.removeHeader('Content-Security-Policy');
+      res.setHeader('Content-Security-Policy', "script-src 'none'; style-src 'self' 'unsafe-inline'; img-src * data:; frame-ancestors 'self'; default-src 'none'");
       return res.send(contentResult.rows[0].full_page_html);
     } catch (err) {
       next(err);

--- a/frontend/components/PageCard.vue
+++ b/frontend/components/PageCard.vue
@@ -188,7 +188,7 @@
           <div class="h-[32px] overflow-hidden flex items-center">
             <div v-if="snippetHtml"
                  class="text-[12px] leading-4 text-neutral-600 dark:text-neutral-400 clamp-2"
-                 v-html="snippetHtml"></div>
+                 v-html="sanitizeSnippetHtml(snippetHtml)"></div>
           </div>
         </div>
   

--- a/frontend/components/tools/CalendarTool.vue
+++ b/frontend/components/tools/CalendarTool.vue
@@ -195,6 +195,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue';
+import DOMPurify from 'isomorphic-dompurify';
 import LucideIcon from '~/components/LucideIcon.vue';
 import {
   addMonths,
@@ -577,7 +578,7 @@ async function onSegmentClick(seg: Segment) {
       detailTitle.value = seg.title;
       detailSummary.value = seg.summary ?? null;
       detailColor.value = seg.color;
-      detailHtml.value = md.render(String(seg.localDetails));
+      detailHtml.value = DOMPurify.sanitize(md.render(String(seg.localDetails)));
       detailDateRange.value = formatRange(seg.startsAt, seg.endsAt);
       detailVisible.value = true;
       return;
@@ -586,7 +587,7 @@ async function onSegmentClick(seg: Segment) {
     detailTitle.value = res.title || '';
     detailSummary.value = res.summary ?? null;
     detailColor.value = res.color ?? null;
-    detailHtml.value = res.detailsMd ? md.render(String(res.detailsMd)) : '';
+    detailHtml.value = res.detailsMd ? DOMPurify.sanitize(md.render(String(res.detailsMd))) : '';
     detailDateRange.value = formatRange(res.startsAt, res.endsAt);
     detailVisible.value = true;
   } catch (err) {

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -106,7 +106,7 @@
                           <div
                             v-if="entry.item.snippet"
                             class="mt-1 text-xs leading-relaxed text-[rgb(var(--muted)_/_0.85)]"
-                            v-html="entry.item.snippet"
+                            v-html="sanitizeSnippetHtml(entry.item.snippet)"
                           ></div>
                         </div>
                         <span class="ml-2 shrink-0 rounded-full border border-[var(--g-accent-strong)] bg-[var(--g-accent-soft)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[rgb(var(--accent-strong))]">
@@ -377,7 +377,7 @@
                         <div
                           v-if="entry.item.snippet"
                           class="mt-1 text-xs leading-relaxed text-[rgb(var(--muted)_/_0.85)]"
-                          v-html="entry.item.snippet"
+                          v-html="sanitizeSnippetHtml(entry.item.snippet)"
                         ></div>
                       </div>
                       <span class="ml-2 shrink-0 rounded-full border border-[var(--g-accent-strong)] bg-[var(--g-accent-soft)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[rgb(var(--accent-strong))]">

--- a/frontend/utils/sanitizeSnippetHtml.ts
+++ b/frontend/utils/sanitizeSnippetHtml.ts
@@ -1,0 +1,14 @@
+import DOMPurify from 'isomorphic-dompurify'
+
+/**
+ * 对搜索 snippet HTML 进行安全过滤。
+ * 只允许安全的内联格式化标签，移除所有脚本、事件属性等。
+ */
+export function sanitizeSnippetHtml(html: string | null | undefined): string {
+  if (!html) return ''
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: ['mark', 'b', 'em', 'span', 'strong', 'i'],
+    ALLOWED_ATTR: ['class'],
+    ALLOW_DATA_ATTR: false,
+  })
+}

--- a/mail-agent/src/lib/templates.mjs
+++ b/mail-agent/src/lib/templates.mjs
@@ -76,28 +76,49 @@ const MAIL_SAFE_ATTRS = new Set([
   'width', 'height', 'colspan', 'rowspan', 'target', 'rel',
 ]);
 
+/** 安全 URL 协议白名单 */
+const SAFE_URL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
+
 /**
- * 解码 HTML 实体，用于在协议校验前还原属性值的真实内容。
- * 覆盖 &#xHH;、&#DDD;、以及常见命名实体。
+ * 粗略解码 HTML 实体，将属性值还原为真实文本，
+ * 用于在协议校验前消除各种实体编码绕过。
  */
 function decodeHtmlEntities(str) {
-  return str
-    .replace(/&#x([0-9a-f]+);?/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);?/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&apos;/gi, "'")
-    .replace(/&nbsp;/gi, ' ');
+  // 数字实体（十六进制和十进制）
+  let decoded = str.replace(/&#x([0-9a-f]+);?/gi, (_, hex) => {
+    try { return String.fromCodePoint(parseInt(hex, 16)); } catch { return ''; }
+  });
+  decoded = decoded.replace(/&#(\d+);?/g, (_, dec) => {
+    try { return String.fromCodePoint(parseInt(dec, 10)); } catch { return ''; }
+  });
+  // 命名实体：替换为对应字符（覆盖常见攻击向量）
+  const namedEntities = {
+    '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&apos;': "'",
+    '&nbsp;': ' ', '&colon;': ':', '&tab;': '\t', '&newline;': '\n',
+    '&lpar;': '(', '&rpar;': ')', '&sol;': '/', '&bsol;': '\\',
+    '&comma;': ',', '&semi;': ';', '&equals;': '=', '&num;': '#',
+    '&period;': '.', '&excl;': '!', '&quest;': '?', '&plus;': '+',
+  };
+  decoded = decoded.replace(/&[a-z]+;/gi, (entity) => {
+    return namedEntities[entity.toLowerCase()] ?? '';
+  });
+  return decoded;
 }
 
 /**
- * 检查 URL 是否使用危险协议（解码实体后校验）。
+ * 检查 URL 是否安全（白名单协议策略）。
+ * 只允许 http:, https:, mailto: 和相对路径；其余一律拒绝。
  */
-function hasDangerousProtocol(rawVal) {
-  const decoded = decodeHtmlEntities(rawVal).replace(/[\s\x00-\x1f]+/g, '').toLowerCase();
-  return /^(javascript|vbscript|data):/i.test(decoded);
+function isSafeUrl(rawVal) {
+  const decoded = decodeHtmlEntities(rawVal).replace(/[\s\x00-\x1f]+/g, '').trim();
+  if (!decoded) return false;
+  // 相对路径和锚点链接视为安全
+  if (decoded.startsWith('/') || decoded.startsWith('#') || decoded.startsWith('?')) return true;
+  // 提取协议部分
+  const colonIdx = decoded.indexOf(':');
+  if (colonIdx === -1) return true; // 无协议的相对路径
+  const protocol = decoded.slice(0, colonIdx + 1).toLowerCase();
+  return SAFE_URL_PROTOCOLS.has(protocol);
 }
 
 /**
@@ -123,8 +144,8 @@ function sanitizeMailHtml(raw) {
       const attrName = m[1].toLowerCase();
       const attrVal = m[2] ?? m[3] ?? m[4] ?? '';
       if (!MAIL_SAFE_ATTRS.has(attrName)) continue;
-      // 解码实体后检查危险协议（javascript:, vbscript:, data:）
-      if ((attrName === 'href' || attrName === 'src') && hasDangerousProtocol(attrVal)) continue;
+      // 白名单协议校验：只允许 http/https/mailto 和相对路径
+      if ((attrName === 'href' || attrName === 'src') && !isSafeUrl(attrVal)) continue;
       safeAttrs.push(`${attrName}="${attrVal.replace(/"/g, '&quot;')}"`);
     }
     const attrStr = safeAttrs.length > 0 ? ' ' + safeAttrs.join(' ') : '';

--- a/mail-agent/src/lib/templates.mjs
+++ b/mail-agent/src/lib/templates.mjs
@@ -77,6 +77,30 @@ const MAIL_SAFE_ATTRS = new Set([
 ]);
 
 /**
+ * 解码 HTML 实体，用于在协议校验前还原属性值的真实内容。
+ * 覆盖 &#xHH;、&#DDD;、以及常见命名实体。
+ */
+function decodeHtmlEntities(str) {
+  return str
+    .replace(/&#x([0-9a-f]+);?/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);?/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;/gi, "'")
+    .replace(/&nbsp;/gi, ' ');
+}
+
+/**
+ * 检查 URL 是否使用危险协议（解码实体后校验）。
+ */
+function hasDangerousProtocol(rawVal) {
+  const decoded = decodeHtmlEntities(rawVal).replace(/[\s\x00-\x1f]+/g, '').toLowerCase();
+  return /^(javascript|vbscript|data):/i.test(decoded);
+}
+
+/**
  * 简易 HTML 过滤：只保留白名单中的标签和属性，
  * 移除 script、iframe、事件处理器等危险内容。
  */
@@ -99,8 +123,8 @@ function sanitizeMailHtml(raw) {
       const attrName = m[1].toLowerCase();
       const attrVal = m[2] ?? m[3] ?? m[4] ?? '';
       if (!MAIL_SAFE_ATTRS.has(attrName)) continue;
-      // 阻止 javascript: 协议
-      if ((attrName === 'href' || attrName === 'src') && /^\s*javascript:/i.test(attrVal)) continue;
+      // 解码实体后检查危险协议（javascript:, vbscript:, data:）
+      if ((attrName === 'href' || attrName === 'src') && hasDangerousProtocol(attrVal)) continue;
       safeAttrs.push(`${attrName}="${attrVal.replace(/"/g, '&quot;')}"`);
     }
     const attrStr = safeAttrs.length > 0 ? ' ' + safeAttrs.join(' ') : '';

--- a/mail-agent/src/lib/templates.mjs
+++ b/mail-agent/src/lib/templates.mjs
@@ -61,13 +61,66 @@ function buildVerificationTemplate(payload, context) {
   return { subject, text, html };
 }
 
+// 邮件 HTML 安全标签白名单
+const MAIL_SAFE_TAGS = new Set([
+  'p', 'div', 'br', 'hr', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'strong', 'b', 'em', 'i', 'u', 's', 'del', 'small', 'mark',
+  'span', 'a', 'ul', 'ol', 'li', 'blockquote', 'pre', 'code',
+  'table', 'thead', 'tbody', 'tr', 'td', 'th',
+  'img',
+]);
+
+// 邮件 HTML 安全属性白名单
+const MAIL_SAFE_ATTRS = new Set([
+  'href', 'src', 'alt', 'title', 'style', 'class',
+  'width', 'height', 'colspan', 'rowspan', 'target', 'rel',
+]);
+
+/**
+ * 简易 HTML 过滤：只保留白名单中的标签和属性，
+ * 移除 script、iframe、事件处理器等危险内容。
+ */
+function sanitizeMailHtml(raw) {
+  if (!raw) return '';
+  // 移除 script/style/iframe 等危险标签及其内容
+  let html = raw.replace(/<(script|style|iframe|object|embed|form|input|textarea|select|button)\b[^]*?<\/\1\s*>/gi, '');
+  // 移除未闭合的危险标签
+  html = html.replace(/<\/?(script|style|iframe|object|embed|form|input|textarea|select|button)\b[^>]*>/gi, '');
+  // 过滤剩余标签：只保留白名单标签和属性
+  html = html.replace(/<\/?([a-z][a-z0-9]*)\b([^>]*)?\/?>/gi, (match, tag, attrs) => {
+    const lowerTag = tag.toLowerCase();
+    if (!MAIL_SAFE_TAGS.has(lowerTag)) return '';
+    if (!attrs || !attrs.trim()) return match.startsWith('</') ? `</${lowerTag}>` : `<${lowerTag}>`;
+    // 过滤属性
+    const safeAttrs = [];
+    const attrRe = /([a-z][a-z0-9-]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+))/gi;
+    let m;
+    while ((m = attrRe.exec(attrs)) !== null) {
+      const attrName = m[1].toLowerCase();
+      const attrVal = m[2] ?? m[3] ?? m[4] ?? '';
+      if (!MAIL_SAFE_ATTRS.has(attrName)) continue;
+      // 阻止 javascript: 协议
+      if ((attrName === 'href' || attrName === 'src') && /^\s*javascript:/i.test(attrVal)) continue;
+      safeAttrs.push(`${attrName}="${attrVal.replace(/"/g, '&quot;')}"`);
+    }
+    const attrStr = safeAttrs.length > 0 ? ' ' + safeAttrs.join(' ') : '';
+    if (match.startsWith('</')) return `</${lowerTag}>`;
+    const selfClose = match.trimEnd().endsWith('/>') ? ' /' : '';
+    return `<${lowerTag}${attrStr}${selfClose}>`;
+  });
+  // 移除所有事件属性 (on*)
+  html = html.replace(/\son[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|\S+)/gi, '');
+  return html;
+}
+
 function buildGenericTemplate(payload) {
   const subject = ensureString(payload?.subject).trim();
   if (!subject) {
     throw new Error('消息主题不能为空');
   }
   const text = ensureString(payload?.text).trim();
-  const html = ensureString(payload?.html).trim() || undefined;
+  const rawHtml = ensureString(payload?.html).trim() || undefined;
+  const html = rawHtml ? sanitizeMailHtml(rawHtml) : undefined;
   if (!text && !html) {
     throw new Error('消息内容必须包含 text 或 html');
   }

--- a/mail-agent/src/lib/templates.mjs
+++ b/mail-agent/src/lib/templates.mjs
@@ -45,7 +45,7 @@ function buildVerificationTemplate(payload, context) {
 <html lang="zh-CN">
   <head>
     <meta charset="utf-8" />
-    <title>${subject}</title>
+    <title>${escapeHtml(subject)}</title>
   </head>
   <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f9fafb; padding: 24px; color: #111827;">
     <div style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 12px; padding: 24px; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);">
@@ -72,7 +72,7 @@ const MAIL_SAFE_TAGS = new Set([
 
 // 邮件 HTML 安全属性白名单
 const MAIL_SAFE_ATTRS = new Set([
-  'href', 'src', 'alt', 'title', 'style', 'class',
+  'href', 'src', 'alt', 'title', 'class',
   'width', 'height', 'colspan', 'rowspan', 'target', 'rel',
 ]);
 
@@ -112,6 +112,8 @@ function decodeHtmlEntities(str) {
 function isSafeUrl(rawVal) {
   const decoded = decodeHtmlEntities(rawVal).replace(/[\s\x00-\x1f]+/g, '').trim();
   if (!decoded) return false;
+  // 协议相对 URL（//host）不允许，可能加载外部资源
+  if (decoded.startsWith('//')) return false;
   // 相对路径和锚点链接视为安全
   if (decoded.startsWith('/') || decoded.startsWith('#') || decoded.startsWith('?')) return true;
   // 提取协议部分


### PR DESCRIPTION
## Summary

- **page-preview.ts**: 用限制性 CSP (`script-src 'none'` 等) 替代 `removeHeader('Content-Security-Policy')`，阻止预览页面执行任何脚本
- **搜索 snippet v-html**: 新增 `sanitizeSnippetHtml()` 工具函数（基于 DOMPurify），在 `default.vue` 和 `PageCard.vue` 中过滤 snippet HTML，只允许 `<mark>`/`<b>`/`<em>`/`<span>` 等安全标签
- **CalendarTool markdown**: 对 `md.render()` 输出用 DOMPurify 做防御性过滤（markdown-it 已配置 `html: false`，此为纵深防御）
- **mail-agent generic 模板**: 对传入的 HTML 内容进行标签/属性白名单过滤，移除 `<script>`/`<iframe>` 等危险标签和 `javascript:` 协议

## Test plan

- [ ] 验证 BFF 构建通过 (`cd bff && npm run build`)
- [ ] 验证前端构建通过 (`cd frontend && npm run build`)
- [ ] 访问页面预览确认 CSS 样式正常显示、脚本被 CSP 阻止
- [ ] 搜索页面确认 snippet 高亮标记正常渲染
- [ ] 活动月历详情弹窗 markdown 内容正常显示
- [ ] 验证邮件发送功能正常（generic 模板）