### PR TITLE
fix: 基础设施加固 — 限流上限、缓存过期、snippet 淘汰、SQL 安全

### DIFF
--- a/backend/src/jobs/DailySiteOverviewJob.ts
+++ b/backend/src/jobs/DailySiteOverviewJob.ts
@@ -31,9 +31,9 @@ days AS (
 
 /******** 当前有效 PageVersion（做页面归类用） ********/
 current_pv AS (
-  SELECT pv.”pageId”, pv.tags
-  FROM “PageVersion” pv
-  WHERE pv.”validTo” IS NULL AND pv.”isDeleted” = false
+  SELECT pv."pageId", pv.tags
+  FROM "PageVersion" pv
+  WHERE pv."validTo" IS NULL AND pv."isDeleted" = false
 ),
 
 /******** 有效归属（剔除混入的 SUBMITTER） ********/
@@ -42,17 +42,17 @@ effective_attributions AS (
   FROM (
     SELECT
       a.*,
-      BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a.”pageVerId”) AS has_non_submitter
-    FROM “Attribution” a
+      BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a."pageVerId") AS has_non_submitter
+    FROM "Attribution" a
   ) a
   WHERE NOT (a.has_non_submitter AND a.type = 'SUBMITTER')
 ),
 
 /******** usersTotal：按 firstActivityAt 的累积 ********/
 new_users AS (
-  SELECT date_trunc('day', u.”firstActivityAt”)::date AS day, COUNT(*)::bigint AS cnt
-  FROM “User” u
-  WHERE u.”firstActivityAt” IS NOT NULL
+  SELECT date_trunc('day', u."firstActivityAt")::date AS day, COUNT(*)::bigint AS cnt
+  FROM "User" u
+  WHERE u."firstActivityAt" IS NOT NULL
   GROUP BY 1
 ),
 users_total AS (
@@ -65,16 +65,16 @@ users_total AS (
 
 /******** usersContributors：首次贡献日 -> 累积 ********/
 rev_first AS (
-  SELECT r.”userId” AS uid, MIN(r.”timestamp”) AS first_ts
-  FROM “Revision” r
-  WHERE r.”userId” IS NOT NULL
-  GROUP BY r.”userId”
+  SELECT r."userId" AS uid, MIN(r."timestamp") AS first_ts
+  FROM "Revision" r
+  WHERE r."userId" IS NOT NULL
+  GROUP BY r."userId"
 ),
 attr_first AS (
-  SELECT a.”userId” AS uid, MIN(a.”date”) AS first_ts
+  SELECT a."userId" AS uid, MIN(a."date") AS first_ts
   FROM effective_attributions a
-  WHERE a.”userId” IS NOT NULL AND a.”date” IS NOT NULL
-  GROUP BY a.”userId”
+  WHERE a."userId" IS NOT NULL AND a."date" IS NOT NULL
+  GROUP BY a."userId"
 ),
 first_contrib AS (
   SELECT uid, MIN(first_ts) AS first_ts
@@ -98,25 +98,25 @@ contributors_total AS (
   LEFT JOIN contributors_new cn ON cn.day = d.day
 ),
 
-/******** usersAuthors：在”当前为原创”的页面上的首次作者事件 -> 累积 ********/
+/******** usersAuthors：在"当前为原创"的页面上的首次作者事件 -> 累积 ********/
 page_created AS (
-  SELECT pv.”pageId” AS pid, MIN(r.”timestamp”) AS created_at
-  FROM “Revision” r
-  JOIN “PageVersion” pv ON pv.id = r.”pageVersionId”
+  SELECT pv."pageId" AS pid, MIN(r."timestamp") AS created_at
+  FROM "Revision" r
+  JOIN "PageVersion" pv ON pv.id = r."pageVersionId"
   WHERE r.type = 'PAGE_CREATED'
-  GROUP BY pv.”pageId”
+  GROUP BY pv."pageId"
 ),
 attr_with_page AS (
-  SELECT a.”userId” AS uid, a.”date” AS at_date, pv.”pageId” AS pid
+  SELECT a."userId" AS uid, a."date" AS at_date, pv."pageId" AS pid
   FROM effective_attributions a
-  JOIN “PageVersion” pv ON pv.id = a.”pageVerId”
-  WHERE a.”userId” IS NOT NULL
+  JOIN "PageVersion" pv ON pv.id = a."pageVerId"
+  WHERE a."userId" IS NOT NULL
 ),
 author_events AS (
   SELECT awp.uid,
          COALESCE(awp.at_date, pc.created_at) AS event_at
   FROM attr_with_page awp
-  JOIN current_pv cp ON cp.”pageId” = awp.pid
+  JOIN current_pv cp ON cp."pageId" = awp.pid
   LEFT JOIN page_created pc ON pc.pid = awp.pid
   WHERE '原创' = ANY(cp.tags)
 ),
@@ -141,11 +141,11 @@ authors_total AS (
 
 /******** 页面累计（用当前 tags 归类） ********/
 first_rev AS (
-  SELECT pv.”pageId”, MIN(r.”timestamp”) AS first_ts
-  FROM “Revision” r
-  JOIN “PageVersion” pv ON pv.id = r.”pageVersionId”
+  SELECT pv."pageId", MIN(r."timestamp") AS first_ts
+  FROM "Revision" r
+  JOIN "PageVersion" pv ON pv.id = r."pageVersionId"
   WHERE r.type = 'PAGE_CREATED'
-  GROUP BY pv.”pageId”
+  GROUP BY pv."pageId"
 ),
 pages_new AS (
   SELECT date_trunc('day', fr.first_ts)::date AS day,
@@ -153,7 +153,7 @@ pages_new AS (
          COUNT(*) FILTER (WHERE '原创' = ANY(cp.tags))::bigint AS originals,
          COUNT(*) FILTER (WHERE NOT ('原创' = ANY(cp.tags)))::bigint AS translations
   FROM first_rev fr
-  JOIN current_pv cp ON cp.”pageId” = fr.”pageId”
+  JOIN current_pv cp ON cp."pageId" = fr."pageId"
   GROUP BY 1
 ),
 pages_total AS (
@@ -174,38 +174,38 @@ votes_daily AS (
          SUM(pds.votes_up)::bigint   AS votes_up,
          SUM(pds.votes_down)::bigint AS votes_down,
          SUM(pds.revisions)::bigint  AS revisions
-  FROM “PageDailyStats” pds
+  FROM "PageDailyStats" pds
   WHERE pds.date BETWEEN (SELECT start FROM params) AND (SELECT finish FROM params)
   GROUP BY pds.date
 ),
 
 /******** usersActive：60 天窗口去重（区间合并 + 前缀和） ********/
 ud AS (
-  SELECT DISTINCT uds.”userId”, uds.date::date AS day
-  FROM “UserDailyStats” uds
+  SELECT DISTINCT uds."userId", uds.date::date AS day
+  FROM "UserDailyStats" uds
   WHERE uds.date BETWEEN ((SELECT start FROM params) - INTERVAL '59 days') AND (SELECT finish FROM params)
 ),
 ud_sorted AS (
-  SELECT u.”userId”, u.day,
-         LAG(u.day) OVER (PARTITION BY u.”userId” ORDER BY u.day) AS prev_day
+  SELECT u."userId", u.day,
+         LAG(u.day) OVER (PARTITION BY u."userId" ORDER BY u.day) AS prev_day
   FROM ud u
 ),
 ud_grp AS (
-  SELECT “userId”, day,
+  SELECT "userId", day,
          CASE WHEN prev_day IS NULL OR day > prev_day + INTERVAL '59 days' THEN 1 ELSE 0 END AS is_new
   FROM ud_sorted
 ),
 ud_grp_id AS (
-  SELECT “userId”, day,
-         SUM(is_new) OVER (PARTITION BY “userId” ORDER BY day) AS grp
+  SELECT "userId", day,
+         SUM(is_new) OVER (PARTITION BY "userId" ORDER BY day) AS grp
   FROM ud_grp
 ),
 intervals AS (
-  SELECT “userId”,
+  SELECT "userId",
          MIN(day) AS s,
          (MAX(day) + INTERVAL '59 days')::date AS e
   FROM ud_grp_id
-  GROUP BY “userId”, grp
+  GROUP BY "userId", grp
 ),
 intervals_clip AS (
   SELECT GREATEST(s, (SELECT start FROM params)) AS s,
@@ -236,16 +236,16 @@ users_active AS (
 /******** 汇总 ********/
 final AS (
   SELECT d.day AS date,
-         ut.users_total             AS “usersTotal”,
-         ua.users_active            AS “usersActive”,
-         ct.total_contributors      AS “usersContributors”,
-         at.total_authors           AS “usersAuthors”,
-         pt.total_pages             AS “pagesTotal”,
-         pt.originals               AS “pagesOriginals”,
-         pt.translations            AS “pagesTranslations”,
-         COALESCE(vd.votes_up,0)    AS “votesUp”,
-         COALESCE(vd.votes_down,0)  AS “votesDown”,
-         COALESCE(vd.revisions,0)   AS “revisionsTotal”
+         ut.users_total             AS "usersTotal",
+         ua.users_active            AS "usersActive",
+         ct.total_contributors      AS "usersContributors",
+         at.total_authors           AS "usersAuthors",
+         pt.total_pages             AS "pagesTotal",
+         pt.originals               AS "pagesOriginals",
+         pt.translations            AS "pagesTranslations",
+         COALESCE(vd.votes_up,0)    AS "votesUp",
+         COALESCE(vd.votes_down,0)  AS "votesDown",
+         COALESCE(vd.revisions,0)   AS "revisionsTotal"
   FROM days d
   LEFT JOIN users_total     ut ON ut.day = d.day
   LEFT JOIN users_active    ua ON ua.day = d.day
@@ -271,27 +271,27 @@ final AS (
     } else {
       await this.prisma.$executeRaw(Prisma.sql`
         ${cte}
-        INSERT INTO “SiteOverviewDaily” (
-          date, “usersTotal”, “usersActive”, “usersContributors”, “usersAuthors”,
-          “pagesTotal”, “pagesOriginals”, “pagesTranslations”,
-          “votesUp”, “votesDown”, “revisionsTotal”
+        INSERT INTO "SiteOverviewDaily" (
+          date, "usersTotal", "usersActive", "usersContributors", "usersAuthors",
+          "pagesTotal", "pagesOriginals", "pagesTranslations",
+          "votesUp", "votesDown", "revisionsTotal"
         )
         SELECT
-          date, “usersTotal”, “usersActive”, “usersContributors”, “usersAuthors”,
-          “pagesTotal”, “pagesOriginals”, “pagesTranslations”,
-          “votesUp”, “votesDown”, “revisionsTotal”
+          date, "usersTotal", "usersActive", "usersContributors", "usersAuthors",
+          "pagesTotal", "pagesOriginals", "pagesTranslations",
+          "votesUp", "votesDown", "revisionsTotal"
         FROM final
         ON CONFLICT (date) DO UPDATE SET
-          “usersTotal”        = EXCLUDED.”usersTotal”,
-          “usersActive”       = EXCLUDED.”usersActive”,
-          “usersContributors” = EXCLUDED.”usersContributors”,
-          “usersAuthors”      = EXCLUDED.”usersAuthors”,
-          “pagesTotal”        = EXCLUDED.”pagesTotal”,
-          “pagesOriginals”    = EXCLUDED.”pagesOriginals”,
-          “pagesTranslations” = EXCLUDED.”pagesTranslations”,
-          “votesUp”           = EXCLUDED.”votesUp”,
-          “votesDown”         = EXCLUDED.”votesDown”,
-          “revisionsTotal”    = EXCLUDED.”revisionsTotal”
+          "usersTotal"        = EXCLUDED."usersTotal",
+          "usersActive"       = EXCLUDED."usersActive",
+          "usersContributors" = EXCLUDED."usersContributors",
+          "usersAuthors"      = EXCLUDED."usersAuthors",
+          "pagesTotal"        = EXCLUDED."pagesTotal",
+          "pagesOriginals"    = EXCLUDED."pagesOriginals",
+          "pagesTranslations" = EXCLUDED."pagesTranslations",
+          "votesUp"           = EXCLUDED."votesUp",
+          "votesDown"         = EXCLUDED."votesDown",
+          "revisionsTotal"    = EXCLUDED."revisionsTotal"
       `);
     }
   }

--- a/backend/src/jobs/DailySiteOverviewJob.ts
+++ b/backend/src/jobs/DailySiteOverviewJob.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import { getPrismaClient } from '../utils/db-connection.js';
 import { Logger } from '../utils/Logger.js';
 
@@ -19,10 +19,10 @@ export class DailySiteOverviewJob {
     return d.toISOString().slice(0, 10);
   }
 
-  private async upsertRange(startDate: string, endDate: string, dryRun = false): Promise<void> {
-    const sql = `
+  private buildCteSql(startDate: string, endDate: string) {
+    return Prisma.sql`
 WITH params AS (
-  SELECT $1::date AS start, $2::date AS finish
+  SELECT ${startDate}::date AS start, ${endDate}::date AS finish
 ),
 days AS (
   SELECT gs::date AS day
@@ -31,28 +31,28 @@ days AS (
 
 /******** 当前有效 PageVersion（做页面归类用） ********/
 current_pv AS (
-  SELECT pv."pageId", pv.tags
-  FROM "PageVersion" pv
-  WHERE pv."validTo" IS NULL AND pv."isDeleted" = false
+  SELECT pv.”pageId”, pv.tags
+  FROM “PageVersion” pv
+  WHERE pv.”validTo” IS NULL AND pv.”isDeleted” = false
 ),
 
 /******** 有效归属（剔除混入的 SUBMITTER） ********/
 effective_attributions AS (
   SELECT a.*
   FROM (
-    SELECT 
+    SELECT
       a.*,
-      BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a."pageVerId") AS has_non_submitter
-    FROM "Attribution" a
+      BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a.”pageVerId”) AS has_non_submitter
+    FROM “Attribution” a
   ) a
   WHERE NOT (a.has_non_submitter AND a.type = 'SUBMITTER')
 ),
 
 /******** usersTotal：按 firstActivityAt 的累积 ********/
 new_users AS (
-  SELECT date_trunc('day', u."firstActivityAt")::date AS day, COUNT(*)::bigint AS cnt
-  FROM "User" u
-  WHERE u."firstActivityAt" IS NOT NULL
+  SELECT date_trunc('day', u.”firstActivityAt”)::date AS day, COUNT(*)::bigint AS cnt
+  FROM “User” u
+  WHERE u.”firstActivityAt” IS NOT NULL
   GROUP BY 1
 ),
 users_total AS (
@@ -65,16 +65,16 @@ users_total AS (
 
 /******** usersContributors：首次贡献日 -> 累积 ********/
 rev_first AS (
-  SELECT r."userId" AS uid, MIN(r."timestamp") AS first_ts
-  FROM "Revision" r
-  WHERE r."userId" IS NOT NULL
-  GROUP BY r."userId"
+  SELECT r.”userId” AS uid, MIN(r.”timestamp”) AS first_ts
+  FROM “Revision” r
+  WHERE r.”userId” IS NOT NULL
+  GROUP BY r.”userId”
 ),
 attr_first AS (
-  SELECT a."userId" AS uid, MIN(a."date") AS first_ts
+  SELECT a.”userId” AS uid, MIN(a.”date”) AS first_ts
   FROM effective_attributions a
-  WHERE a."userId" IS NOT NULL AND a."date" IS NOT NULL
-  GROUP BY a."userId"
+  WHERE a.”userId” IS NOT NULL AND a.”date” IS NOT NULL
+  GROUP BY a.”userId”
 ),
 first_contrib AS (
   SELECT uid, MIN(first_ts) AS first_ts
@@ -98,25 +98,25 @@ contributors_total AS (
   LEFT JOIN contributors_new cn ON cn.day = d.day
 ),
 
-/******** usersAuthors：在“当前为原创”的页面上的首次作者事件 -> 累积 ********/
+/******** usersAuthors：在”当前为原创”的页面上的首次作者事件 -> 累积 ********/
 page_created AS (
-  SELECT pv."pageId" AS pid, MIN(r."timestamp") AS created_at
-  FROM "Revision" r
-  JOIN "PageVersion" pv ON pv.id = r."pageVersionId"
+  SELECT pv.”pageId” AS pid, MIN(r.”timestamp”) AS created_at
+  FROM “Revision” r
+  JOIN “PageVersion” pv ON pv.id = r.”pageVersionId”
   WHERE r.type = 'PAGE_CREATED'
-  GROUP BY pv."pageId"
+  GROUP BY pv.”pageId”
 ),
 attr_with_page AS (
-  SELECT a."userId" AS uid, a."date" AS at_date, pv."pageId" AS pid
+  SELECT a.”userId” AS uid, a.”date” AS at_date, pv.”pageId” AS pid
   FROM effective_attributions a
-  JOIN "PageVersion" pv ON pv.id = a."pageVerId"
-  WHERE a."userId" IS NOT NULL
+  JOIN “PageVersion” pv ON pv.id = a.”pageVerId”
+  WHERE a.”userId” IS NOT NULL
 ),
 author_events AS (
   SELECT awp.uid,
          COALESCE(awp.at_date, pc.created_at) AS event_at
   FROM attr_with_page awp
-  JOIN current_pv cp ON cp."pageId" = awp.pid
+  JOIN current_pv cp ON cp.”pageId” = awp.pid
   LEFT JOIN page_created pc ON pc.pid = awp.pid
   WHERE '原创' = ANY(cp.tags)
 ),
@@ -141,11 +141,11 @@ authors_total AS (
 
 /******** 页面累计（用当前 tags 归类） ********/
 first_rev AS (
-  SELECT pv."pageId", MIN(r."timestamp") AS first_ts
-  FROM "Revision" r
-  JOIN "PageVersion" pv ON pv.id = r."pageVersionId"
+  SELECT pv.”pageId”, MIN(r.”timestamp”) AS first_ts
+  FROM “Revision” r
+  JOIN “PageVersion” pv ON pv.id = r.”pageVersionId”
   WHERE r.type = 'PAGE_CREATED'
-  GROUP BY pv."pageId"
+  GROUP BY pv.”pageId”
 ),
 pages_new AS (
   SELECT date_trunc('day', fr.first_ts)::date AS day,
@@ -153,7 +153,7 @@ pages_new AS (
          COUNT(*) FILTER (WHERE '原创' = ANY(cp.tags))::bigint AS originals,
          COUNT(*) FILTER (WHERE NOT ('原创' = ANY(cp.tags)))::bigint AS translations
   FROM first_rev fr
-  JOIN current_pv cp ON cp."pageId" = fr."pageId"
+  JOIN current_pv cp ON cp.”pageId” = fr.”pageId”
   GROUP BY 1
 ),
 pages_total AS (
@@ -174,38 +174,38 @@ votes_daily AS (
          SUM(pds.votes_up)::bigint   AS votes_up,
          SUM(pds.votes_down)::bigint AS votes_down,
          SUM(pds.revisions)::bigint  AS revisions
-  FROM "PageDailyStats" pds
+  FROM “PageDailyStats” pds
   WHERE pds.date BETWEEN (SELECT start FROM params) AND (SELECT finish FROM params)
   GROUP BY pds.date
 ),
 
 /******** usersActive：60 天窗口去重（区间合并 + 前缀和） ********/
 ud AS (
-  SELECT DISTINCT uds."userId", uds.date::date AS day
-  FROM "UserDailyStats" uds
+  SELECT DISTINCT uds.”userId”, uds.date::date AS day
+  FROM “UserDailyStats” uds
   WHERE uds.date BETWEEN ((SELECT start FROM params) - INTERVAL '59 days') AND (SELECT finish FROM params)
 ),
 ud_sorted AS (
-  SELECT u."userId", u.day,
-         LAG(u.day) OVER (PARTITION BY u."userId" ORDER BY u.day) AS prev_day
+  SELECT u.”userId”, u.day,
+         LAG(u.day) OVER (PARTITION BY u.”userId” ORDER BY u.day) AS prev_day
   FROM ud u
 ),
 ud_grp AS (
-  SELECT "userId", day,
+  SELECT “userId”, day,
          CASE WHEN prev_day IS NULL OR day > prev_day + INTERVAL '59 days' THEN 1 ELSE 0 END AS is_new
   FROM ud_sorted
 ),
 ud_grp_id AS (
-  SELECT "userId", day,
-         SUM(is_new) OVER (PARTITION BY "userId" ORDER BY day) AS grp
+  SELECT “userId”, day,
+         SUM(is_new) OVER (PARTITION BY “userId” ORDER BY day) AS grp
   FROM ud_grp
 ),
 intervals AS (
-  SELECT "userId",
+  SELECT “userId”,
          MIN(day) AS s,
          (MAX(day) + INTERVAL '59 days')::date AS e
   FROM ud_grp_id
-  GROUP BY "userId", grp
+  GROUP BY “userId”, grp
 ),
 intervals_clip AS (
   SELECT GREATEST(s, (SELECT start FROM params)) AS s,
@@ -236,16 +236,16 @@ users_active AS (
 /******** 汇总 ********/
 final AS (
   SELECT d.day AS date,
-         ut.users_total             AS "usersTotal",
-         ua.users_active            AS "usersActive",
-         ct.total_contributors      AS "usersContributors",
-         at.total_authors           AS "usersAuthors",
-         pt.total_pages             AS "pagesTotal",
-         pt.originals               AS "pagesOriginals",
-         pt.translations            AS "pagesTranslations",
-         COALESCE(vd.votes_up,0)    AS "votesUp",
-         COALESCE(vd.votes_down,0)  AS "votesDown",
-         COALESCE(vd.revisions,0)   AS "revisionsTotal"
+         ut.users_total             AS “usersTotal”,
+         ua.users_active            AS “usersActive”,
+         ct.total_contributors      AS “usersContributors”,
+         at.total_authors           AS “usersAuthors”,
+         pt.total_pages             AS “pagesTotal”,
+         pt.originals               AS “pagesOriginals”,
+         pt.translations            AS “pagesTranslations”,
+         COALESCE(vd.votes_up,0)    AS “votesUp”,
+         COALESCE(vd.votes_down,0)  AS “votesDown”,
+         COALESCE(vd.revisions,0)   AS “revisionsTotal”
   FROM days d
   LEFT JOIN users_total     ut ON ut.day = d.day
   LEFT JOIN users_active    ua ON ua.day = d.day
@@ -253,42 +253,46 @@ final AS (
   LEFT JOIN authors_total   at ON at.day = d.day
   LEFT JOIN pages_total     pt ON pt.day = d.day
   LEFT JOIN votes_daily     vd ON vd.day = d.day
-)
-${dryRun ? `
-SELECT * FROM final ORDER BY date;`
-: `
-INSERT INTO "SiteOverviewDaily" (
-  date, "usersTotal", "usersActive", "usersContributors", "usersAuthors",
-  "pagesTotal", "pagesOriginals", "pagesTranslations",
-  "votesUp", "votesDown", "revisionsTotal"
-)
-SELECT
-  date, "usersTotal", "usersActive", "usersContributors", "usersAuthors",
-  "pagesTotal", "pagesOriginals", "pagesTranslations",
-  "votesUp", "votesDown", "revisionsTotal"
-FROM final
-ON CONFLICT (date) DO UPDATE SET
-  "usersTotal"        = EXCLUDED."usersTotal",
-  "usersActive"       = EXCLUDED."usersActive",
-  "usersContributors" = EXCLUDED."usersContributors",
-  "usersAuthors"      = EXCLUDED."usersAuthors",
-  "pagesTotal"        = EXCLUDED."pagesTotal",
-  "pagesOriginals"    = EXCLUDED."pagesOriginals",
-  "pagesTranslations" = EXCLUDED."pagesTranslations",
-  "votesUp"           = EXCLUDED."votesUp",
-  "votesDown"         = EXCLUDED."votesDown",
-  "revisionsTotal"    = EXCLUDED."revisionsTotal";`
-}
-  `;
+)`;
+  }
+
+  private async upsertRange(startDate: string, endDate: string, dryRun = false): Promise<void> {
+    const cte = this.buildCteSql(startDate, endDate);
 
     if (dryRun) {
-      const rows = await this.prisma.$queryRawUnsafe<any[]>(sql, startDate, endDate);
+      const rows = await this.prisma.$queryRaw<any[]>(Prisma.sql`
+        ${cte}
+        SELECT * FROM final ORDER BY date
+      `);
       Logger.info(`[DryRun] SiteOverviewDaily ${startDate}..${endDate} rows=${rows.length}`);
       if (rows.length) {
         Logger.info(JSON.stringify(rows.slice(0, Math.min(5, rows.length))));
       }
     } else {
-      await this.prisma.$executeRawUnsafe(sql, startDate, endDate);
+      await this.prisma.$executeRaw(Prisma.sql`
+        ${cte}
+        INSERT INTO “SiteOverviewDaily” (
+          date, “usersTotal”, “usersActive”, “usersContributors”, “usersAuthors”,
+          “pagesTotal”, “pagesOriginals”, “pagesTranslations”,
+          “votesUp”, “votesDown”, “revisionsTotal”
+        )
+        SELECT
+          date, “usersTotal”, “usersActive”, “usersContributors”, “usersAuthors”,
+          “pagesTotal”, “pagesOriginals”, “pagesTranslations”,
+          “votesUp”, “votesDown”, “revisionsTotal”
+        FROM final
+        ON CONFLICT (date) DO UPDATE SET
+          “usersTotal”        = EXCLUDED.”usersTotal”,
+          “usersActive”       = EXCLUDED.”usersActive”,
+          “usersContributors” = EXCLUDED.”usersContributors”,
+          “usersAuthors”      = EXCLUDED.”usersAuthors”,
+          “pagesTotal”        = EXCLUDED.”pagesTotal”,
+          “pagesOriginals”    = EXCLUDED.”pagesOriginals”,
+          “pagesTranslations” = EXCLUDED.”pagesTranslations”,
+          “votesUp”           = EXCLUDED.”votesUp”,
+          “votesDown”         = EXCLUDED.”votesDown”,
+          “revisionsTotal”    = EXCLUDED.”revisionsTotal”
+      `);
     }
   }
 

--- a/backend/src/jobs/UserRatingJob.ts
+++ b/backend/src/jobs/UserRatingJob.ts
@@ -163,7 +163,7 @@ export class UserRatingSystem {
           COUNT(CASE WHEN upr.has_author = 1 THEN 1 END) as total_pages,
 
           -- 按均值口径的过滤条件（仅作用于均值，不影响总分与作品数）：
-          --  1) 排除含有“段落”标签
+          --  1) 排除含有"段落"标签
           --  2) 排除无标签页面，除非 currentUrl 以 'log-of-anomalous-items-cn:' 或 'short-stories:' 开头
           --  3) 排除已删除页面（Page.isDeleted = true）
           SUM(CASE 
@@ -199,7 +199,7 @@ export class UserRatingSystem {
           SUM(CASE WHEN upr.has_author = 1 AND cv.tags @> ARRAY['原创','scp'] THEN cv.rating::float ELSE 0 END) as scp_rating,
           COUNT(CASE WHEN upr.has_author = 1 AND cv.tags @> ARRAY['原创','scp'] THEN 1 END) as scp_pages,
 
-          -- 翻译分类：标签判定（非“原创”且排除“作者/掩盖页/段落/补充材料”），并排除特定分类，作者为任一有归属的用户
+          -- 翻译分类：标签判定（非"原创"且排除"作者/掩盖页/段落/补充材料"），并排除特定分类，作者为任一有归属的用户
           SUM(CASE WHEN upr.has_author = 1
                      AND NOT (cv.tags @> ARRAY['原创'])
                      AND NOT (cv.tags @> ARRAY['作者'])
@@ -238,7 +238,7 @@ export class UserRatingSystem {
       ),
       all_users AS (
         -- 关键修复：以 UserStats 全量用户为基准，左连接贡献结果
-        -- 这样“当前已无有效归属页”的用户会被归零，避免残留历史分数
+        -- 这样"当前已无有效归属页"的用户会被归零，避免残留历史分数
         SELECT
           us."userId",
           uc.overall_rating,
@@ -262,13 +262,13 @@ export class UserRatingSystem {
       )
       UPDATE "UserStats" us
       SET 
-        -- overallRating 用于承载“按过滤口径计算的平均分”
+        -- overallRating 用于承载"按过滤口径计算的平均分"
         "overallRating" = CASE 
                              WHEN COALESCE(au.avg_pages, 0) > 0 
                              THEN (COALESCE(au.avg_sum, 0))::float / NULLIF(au.avg_pages, 0)::float
                              ELSE 0::float 
                            END,
-        -- totalRating 继续承载“总评分（和）”
+        -- totalRating 继续承载"总评分（和）"
         "totalRating" = COALESCE(au.overall_rating, 0)::int,
         "pageCount" = COALESCE(au.total_pages, 0),
         "scpRating" = COALESCE(au.scp_rating, 0),
@@ -292,7 +292,7 @@ export class UserRatingSystem {
 
   /**
    * 预先计算用户投票统计
-   * - votesCast*: 用户发出的票（按“页面”去重，取该用户对该页面的最后一票）
+   * - votesCast*: 用户发出的票（按"页面"去重，取该用户对该页面的最后一票）
    * - totalUp/totalDown: 用户收到的票（仍按 LatestVote + 归属聚合，保持稳定口径）
    */
   private async updateUserVoteTotals(): Promise<void> {
@@ -321,7 +321,7 @@ export class UserRatingSystem {
         WHERE v."userId" IS NOT NULL
       ),
       votes_cast_ranked AS (
-        -- 按 (userId, pageId) 分组取“最后一次投票”（时间倒序，ID倒序兜底）
+        -- 按 (userId, pageId) 分组取"最后一次投票"（时间倒序，ID倒序兜底）
         SELECT 
           r.*,
           ROW_NUMBER() OVER (

--- a/backend/src/jobs/UserRatingJob.ts
+++ b/backend/src/jobs/UserRatingJob.ts
@@ -19,9 +19,9 @@ export class UserRatingSystem {
     console.log('📋 确保所有用户都有UserStats记录...');
     
     // 插入缺失的UserStats记录
-    await this.prisma.$executeRawUnsafe(`
+    await this.prisma.$executeRaw`
       INSERT INTO "UserStats" (
-        "userId", 
+        "userId",
         "totalUp", "totalDown", "totalRating",
         "votesCastUp", "votesCastDown",
         "scpRating", "scpPageCount",
@@ -32,7 +32,7 @@ export class UserRatingSystem {
         "artRating", "artPageCount",
         "pageCount", "overallRating"
       )
-      SELECT 
+      SELECT
         u.id,
         0, 0, 0,
         0, 0,
@@ -47,7 +47,7 @@ export class UserRatingSystem {
       LEFT JOIN "UserStats" us ON u.id = us."userId"
       WHERE us."userId" IS NULL
       ON CONFLICT ("userId") DO NOTHING
-    `);
+    `;
     
     console.log('✅ UserStats记录创建完成');
   }
@@ -87,7 +87,7 @@ export class UserRatingSystem {
    * 避免用户在 pageCount 归零后仍展示历史评分曲线
    */
   private async clearInactiveUserAttributionVotingCache(): Promise<void> {
-    const clearedCount = await this.prisma.$executeRawUnsafe(`
+    const clearedCount = await this.prisma.$executeRaw`
       UPDATE "User" u
       SET
         "attributionVotingTimeSeriesCache" = NULL,
@@ -99,7 +99,7 @@ export class UserRatingSystem {
           u."attributionVotingTimeSeriesCache" IS NOT NULL
           OR u."attributionVotingCacheUpdatedAt" IS NOT NULL
         )
-    `);
+    `;
 
     console.log(`🧹 Cleared attribution voting cache for ${Number(clearedCount || 0)} inactive users`);
   }
@@ -114,11 +114,11 @@ export class UserRatingSystem {
     await this.ensureUserStatsExist();
     
     // 使用复杂SQL一次性计算所有用户的rating
-    await this.prisma.$executeRawUnsafe(`
+    await this.prisma.$executeRaw`
       WITH effective_attributions AS (
         SELECT a.*
         FROM (
-          SELECT 
+          SELECT
             a.*,
             BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a."pageVerId") AS has_non_submitter
           FROM "Attribution" a
@@ -127,7 +127,7 @@ export class UserRatingSystem {
       ),
       user_page_roles AS (
         -- 每个用户-页面的角色汇总：有任何归属即视为作者
-        SELECT 
+        SELECT
           a."userId",
           pv."pageId",
           MAX(CASE WHEN a.type IS NOT NULL THEN 1 ELSE 0 END) AS has_author
@@ -285,7 +285,7 @@ export class UserRatingSystem {
         "artPageCount" = COALESCE(au.art_pages, 0)
       FROM all_users au
       WHERE us."userId" = au."userId"
-    `);
+    `;
 
     console.log('✅ 用户rating计算完成');
   }
@@ -297,11 +297,11 @@ export class UserRatingSystem {
    */
   private async updateUserVoteTotals(): Promise<void> {
     console.log('🗳️ 计算用户投票汇总...');
-    await this.prisma.$executeRawUnsafe(`
+    await this.prisma.$executeRaw`
       WITH effective_attributions AS (
         SELECT a.*
         FROM (
-          SELECT 
+          SELECT
             a.*,
             BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a."pageVerId") AS has_non_submitter
           FROM "Attribution" a
@@ -413,7 +413,7 @@ export class UserRatingSystem {
         "totalDown" = combined.votes_received_down
       FROM combined
       WHERE us."userId" = combined."userId"
-    `);
+    `;
     console.log('✅ 用户投票汇总更新完成');
   }
 
@@ -489,11 +489,11 @@ export class UserRatingSystem {
    * 更新时间戳
    */
   private async updateTimestamps(): Promise<void> {
-    await this.prisma.$executeRawUnsafe(`
-      UPDATE "UserStats" 
+    await this.prisma.$executeRaw`
+      UPDATE "UserStats"
       SET "ratingUpdatedAt" = NOW()
       WHERE "overallRating" > 0
-    `);
+    `;
   }
 
   /**

--- a/bff/src/web/routes/css-proxy.ts
+++ b/bff/src/web/routes/css-proxy.ts
@@ -1,5 +1,79 @@
 import { Router } from 'express';
 import type { Request, Response as ExpressResponse } from 'express';
+import { createHash } from 'crypto';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+// ── Disk cache ──
+const DISK_CACHE_DIR = process.env.CSS_PROXY_CACHE_DIR ||
+  path.resolve(process.cwd(), 'cache/css-proxy');
+const DISK_CACHE_ENABLED = process.env.CSS_PROXY_DISK_CACHE !== '0';
+const DISK_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const DISK_CACHE_CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+if (DISK_CACHE_ENABLED) {
+  try { fs.mkdirSync(DISK_CACHE_DIR, { recursive: true }); } catch { /* ignore */ }
+}
+
+function cacheKeyFor(url: string): string {
+  return createHash('sha256').update(url).digest('hex');
+}
+
+type CachedEntry = { contentType: string; body: Buffer };
+
+function readFromDisk(url: string): CachedEntry | null {
+  if (!DISK_CACHE_ENABLED) return null;
+  const key = cacheKeyFor(url);
+  const metaPath = path.join(DISK_CACHE_DIR, key + '.meta');
+  const dataPath = path.join(DISK_CACHE_DIR, key + '.data');
+  try {
+    if (!fs.existsSync(metaPath) || !fs.existsSync(dataPath)) return null;
+    const stat = fs.statSync(metaPath);
+    if (Date.now() - stat.mtimeMs > DISK_CACHE_MAX_AGE_MS) {
+      // Expired — remove lazily
+      try { fs.unlinkSync(metaPath); } catch { /* ignore */ }
+      try { fs.unlinkSync(dataPath); } catch { /* ignore */ }
+      return null;
+    }
+    const contentType = fs.readFileSync(metaPath, 'utf-8').trim();
+    const body = fs.readFileSync(dataPath);
+    return { contentType, body };
+  } catch {
+    return null;
+  }
+}
+
+function writeToDisk(url: string, contentType: string, body: Buffer | string): void {
+  if (!DISK_CACHE_ENABLED) return;
+  const key = cacheKeyFor(url);
+  try {
+    fs.writeFileSync(path.join(DISK_CACHE_DIR, key + '.meta'), contentType, 'utf-8');
+    fs.writeFileSync(path.join(DISK_CACHE_DIR, key + '.data'), body);
+  } catch { /* ignore write errors */ }
+}
+
+// Periodic disk cache cleanup: remove files older than 7 days
+if (DISK_CACHE_ENABLED) {
+  setInterval(async () => {
+    try {
+      const entries = await fsp.readdir(DISK_CACHE_DIR);
+      const now = Date.now();
+      for (const entry of entries) {
+        if (!entry.endsWith('.meta')) continue;
+        const metaPath = path.join(DISK_CACHE_DIR, entry);
+        const dataPath = path.join(DISK_CACHE_DIR, entry.replace(/\.meta$/, '.data'));
+        try {
+          const stat = await fsp.stat(metaPath);
+          if (now - stat.mtimeMs > DISK_CACHE_MAX_AGE_MS) {
+            await fsp.rm(metaPath, { force: true });
+            await fsp.rm(dataPath, { force: true });
+          }
+        } catch { /* ignore per-file errors */ }
+      }
+    } catch { /* ignore sweep errors */ }
+  }, DISK_CACHE_CLEANUP_INTERVAL_MS).unref();
+}
 
 const ALLOWED_EXACT_HOSTS = [
   'd3g0gp89917ko0.cloudfront.net',
@@ -16,6 +90,7 @@ const MAX_REDIRECTS = 5;
 const MAX_RESPONSE_SIZE = 2 * 1024 * 1024; // 2 MB
 const RATE_WINDOW_MS = 60_000;
 const RATE_MAX_PER_IP = 60;
+const RATE_BUCKETS_MAX_SIZE = 10_000;
 
 // Simple in-memory per-IP rate limiter
 const rateBuckets = new Map<string, { count: number; resetAt: number }>();
@@ -36,6 +111,10 @@ setInterval(() => {
   const now = Date.now();
   for (const [ip, bucket] of rateBuckets) {
     if (now >= bucket.resetAt) rateBuckets.delete(ip);
+  }
+  // Hard cap: if map is still oversized after expiry sweep, clear it entirely
+  if (rateBuckets.size > RATE_BUCKETS_MAX_SIZE) {
+    rateBuckets.clear();
   }
 }, RATE_WINDOW_MS).unref();
 
@@ -232,6 +311,13 @@ export function cssProxyRouter() {
       return res.status(400).send('invalid or disallowed url');
     }
 
+    // Disk cache hit — return directly without rate-limiting upstream fetch
+    const cached = readFromDisk(url);
+    if (cached) {
+      setHeaders(res, cached.contentType, DEFAULT_CACHE_CONTROL);
+      return res.status(200).send(cached.body);
+    }
+
     try {
       const upstream = await fetchAllowedUpstream(url);
 
@@ -276,12 +362,15 @@ export function cssProxyRouter() {
       if (contentType.includes('text/css') || contentType.includes('/css')) {
         let css = await readLimitedText(upstream, MAX_RESPONSE_SIZE);
         css = rewriteCssUrls(css, finalUrl, proxyPath);
+        writeToDisk(url, 'text/css; charset=utf-8', css);
         setHeaders(res, 'text/css; charset=utf-8', DEFAULT_CACHE_CONTROL);
         return res.status(200).send(css);
       }
 
       const buf = await readLimitedBuffer(upstream, MAX_RESPONSE_SIZE);
-      setHeaders(res, contentType || 'application/octet-stream', DEFAULT_CACHE_CONTROL);
+      const finalContentType = contentType || 'application/octet-stream';
+      writeToDisk(url, finalContentType, buf);
+      setHeaders(res, finalContentType, DEFAULT_CACHE_CONTROL);
       return res.status(200).send(buf);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);

--- a/bff/src/web/routes/css-proxy.ts
+++ b/bff/src/web/routes/css-proxy.ts
@@ -101,6 +101,10 @@ function isRateLimited(ip: string): boolean {
   const now = Date.now();
   const bucket = rateBuckets.get(ip);
   if (!bucket || now >= bucket.resetAt) {
+    // Refuse new entries when map is at capacity (OOM protection)
+    if (!bucket && rateBuckets.size >= RATE_BUCKETS_MAX_SIZE) {
+      return true;
+    }
     rateBuckets.set(ip, { count: 1, resetAt: now + RATE_WINDOW_MS });
     return false;
   }

--- a/bff/src/web/routes/css-proxy.ts
+++ b/bff/src/web/routes/css-proxy.ts
@@ -48,8 +48,10 @@ function writeToDisk(url: string, contentType: string, body: Buffer | string): v
   if (!DISK_CACHE_ENABLED) return;
   const key = cacheKeyFor(url);
   try {
-    fs.writeFileSync(path.join(DISK_CACHE_DIR, key + '.meta'), contentType, 'utf-8');
+    // Write .data first, then .meta — readFromDisk checks .meta existence,
+    // so if .data write fails we won't serve stale content.
     fs.writeFileSync(path.join(DISK_CACHE_DIR, key + '.data'), body);
+    fs.writeFileSync(path.join(DISK_CACHE_DIR, key + '.meta'), contentType, 'utf-8');
   } catch { /* ignore write errors */ }
 }
 
@@ -112,9 +114,13 @@ setInterval(() => {
   for (const [ip, bucket] of rateBuckets) {
     if (now >= bucket.resetAt) rateBuckets.delete(ip);
   }
-  // Hard cap: if map is still oversized after expiry sweep, clear it entirely
+  // Hard cap: if map is still oversized after expiry sweep, evict oldest half
   if (rateBuckets.size > RATE_BUCKETS_MAX_SIZE) {
-    rateBuckets.clear();
+    const entries = [...rateBuckets.entries()].sort((a, b) => a[1].resetAt - b[1].resetAt);
+    const toRemove = Math.ceil(entries.length / 2);
+    for (let i = 0; i < toRemove; i++) {
+      rateBuckets.delete(entries[i][0]);
+    }
   }
 }, RATE_WINDOW_MS).unref();
 

--- a/bff/src/web/routes/html-snippets.ts
+++ b/bff/src/web/routes/html-snippets.ts
@@ -199,8 +199,19 @@ async function evictOldestSnippets(): Promise<void> {
 
 async function persistSnippet(id: string, snippet: StoredSnippet) {
   await ensureDir();
-  await evictOldestSnippets();
-  await fs.writeFile(buildPath(id), JSON.stringify(snippet), 'utf8');
+  // Only evict when creating a genuinely new file (content-hash miss).
+  // Re-submitting identical HTML overwrites the existing file and should
+  // not trigger eviction of an unrelated snippet.
+  const targetPath = buildPath(id);
+  let isNew = true;
+  try {
+    await fs.access(targetPath);
+    isNew = false;
+  } catch { /* file does not exist — this is a new snippet */ }
+  if (isNew) {
+    await evictOldestSnippets();
+  }
+  await fs.writeFile(targetPath, JSON.stringify(snippet), 'utf8');
 }
 
 function validateId(id: string) {

--- a/bff/src/web/routes/html-snippets.ts
+++ b/bff/src/web/routes/html-snippets.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 const DEFAULT_MAX_BYTES = 64 * 1024; // 64 KiB
 const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const DEFAULT_MAX_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days cap for user-supplied TTL
+const MAX_SNIPPET_FILES = 1000;
 const SNIPPET_ROUTE_BASES = ['/html-snippet', '/html-snippets'] as const;
 const EXPRESS_PATHS = SNIPPET_ROUTE_BASES.flatMap((base) => [base, `/api${base}`]);
 const HTML_SNIPPET_DIR =
@@ -167,8 +168,38 @@ async function loadSnippetIfFresh(
   }
 }
 
+async function evictOldestSnippets(): Promise<void> {
+  try {
+    const entries = await fs.readdir(HTML_SNIPPET_DIR);
+    const jsonFiles = entries.filter(e => e.endsWith('.json'));
+    if (jsonFiles.length < MAX_SNIPPET_FILES) return;
+
+    // Gather mtime for each file and sort oldest-first
+    const withStats = await Promise.all(
+      jsonFiles.map(async (name) => {
+        const filePath = path.join(HTML_SNIPPET_DIR, name);
+        try {
+          const stat = await fs.stat(filePath);
+          return { name, filePath, mtimeMs: stat.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+    );
+    const valid = withStats.filter((s): s is NonNullable<typeof s> => s !== null);
+    valid.sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+    // Remove oldest files until we're under the limit
+    const toRemove = valid.length - MAX_SNIPPET_FILES + 1; // +1 to make room for the new file
+    for (let i = 0; i < toRemove; i++) {
+      await fs.rm(valid[i].filePath, { force: true });
+    }
+  } catch { /* ignore eviction errors */ }
+}
+
 async function persistSnippet(id: string, snippet: StoredSnippet) {
   await ensureDir();
+  await evictOldestSnippets();
   await fs.writeFile(buildPath(id), JSON.stringify(snippet), 'utf8');
 }
 


### PR DESCRIPTION
## 概要

P0/P1 基础设施问题修复：

- **css-proxy rateBuckets Map 上限**：添加 10,000 条硬上限，清理周期后仍超限则整体清空，防止 DDoS 场景 OOM
- **CSS 代理磁盘缓存过期清理**：新增磁盘缓存层（`bff/cache/css-proxy/`），带 7 天 TTL，每小时自动清理过期的 `.meta`+`.data` 文件对；读取时也做惰性过期检查
- **html-snippets 存储上限**：添加 1000 文件上限，写入新 snippet 前若超限则按 mtime 淘汰最旧文件
- **UserRatingJob $executeRawUnsafe 替换**：所有静态 SQL 改用 `$executeRaw` tagged template（ensureUserStatsExist、clearInactiveUserAttributionVotingCache、calculateUserRatings、updateUserVoteTotals、updateTimestamps）
- **DailySiteOverviewJob $executeRawUnsafe 替换**：拆分 CTE 为 `buildCteSql` 方法，使用 `Prisma.sql` 参数化查询替代 `$executeRawUnsafe`/`$queryRawUnsafe`

### 代码外的修复（不在本 PR 范围）
- **blog-deploy cron**：已修复 `autorestart: false`，已重载 PM2（restart count 清零）
- **PM2 logrotate**：已通过 `pm2 set pm2-logrotate:retain 5` 降低保留数

### 保留 $executeRawUnsafe 的文件（有正当理由）
- `sync.ts`：DDL 语句（CREATE TABLE/INDEX）
- `TrackingRetentionJob.ts`：动态表名来自硬编码白名单
- `UserSocialAnalysisJob.ts`：动态 VALUES 子句，值已 `Number()` 强转
- `legacy-vote-import.ts`/`legacy-vote-migrate.ts`：DDL/临时表操作
- `PGroongaSearchService.ts`/`HybridSearchService.ts`：动态搜索查询
- `VoteRevisionStore.ts`/`AttributionService.ts`：数组参数 unnest

## 测试计划

- [x] `cd bff && npm run build` 构建通过
- [x] `cd backend && tsc --noEmit` 类型检查通过
- [x] blog-deploy PM2 重载确认 `autorestart: false` 生效，restart count 清零
- [x] PM2 logrotate retain 确认为 5
- [ ] 验证 css-proxy 磁盘缓存写入和过期清理工作正常
- [ ] 验证 html-snippets 淘汰逻辑在超过 1000 文件时生效