### PR TITLE
fix: 修复 sync-hourly 和 user-backend 内存泄漏根因

### DIFF
--- a/backend/src/cli/sync.ts
+++ b/backend/src/cli/sync.ts
@@ -188,25 +188,33 @@ export async function sync({
       phase = phase || 'all';
       console.log('\n=== Test Mode: Phase A with first batch only ===');
       const phaseAProcessor = new PhaseAProcessor();
-      const phaseAResTest = await phaseAProcessor.runTestBatch();
-      results.phaseA = phaseAResTest;
-      console.log(`✅ Phase A (test batch) completed: ${phaseAResTest.totalScanned} pages scanned`);
-      console.log(`📊 Dirty Queue: ${phaseAResTest.queueStats.total} pages need processing`);
-      console.log(`   - Phase B: ${phaseAResTest.queueStats.phaseB} pages`);
-      console.log(`   - Phase C: ${phaseAResTest.queueStats.phaseC} pages`);
-      console.log(`   - Deleted: ${phaseAResTest.queueStats.deleted} pages`);
+      try {
+        const phaseAResTest = await phaseAProcessor.runTestBatch();
+        results.phaseA = phaseAResTest;
+        console.log(`✅ Phase A (test batch) completed: ${phaseAResTest.totalScanned} pages scanned`);
+        console.log(`📊 Dirty Queue: ${phaseAResTest.queueStats.total} pages need processing`);
+        console.log(`   - Phase B: ${phaseAResTest.queueStats.phaseB} pages`);
+        console.log(`   - Phase C: ${phaseAResTest.queueStats.phaseC} pages`);
+        console.log(`   - Deleted: ${phaseAResTest.queueStats.deleted} pages`);
+      } finally {
+        phaseAProcessor.destroy();
+      }
     } else if (phase === 'all' || phase === 'a') {
       // Avoid spinner to keep progress bar clean
       console.log('Phase A: Scanning pages...');
       const phaseAProcessor = new PhaseAProcessor();
-      const phaseARes = await phaseAProcessor.runComplete(onProgress);
-      results.phaseA = phaseARes;
-      console.log(`Phase A: ${phaseARes.totalScanned} pages scanned in ${phaseARes.elapsedTime.toFixed(1)}s`);
-      console.log(`📊 Dirty Queue: ${phaseARes.queueStats.total} pages need processing`);
-      console.log(`   - Phase B: ${phaseARes.queueStats.phaseB} pages`);
-      console.log(`   - Phase C: ${phaseARes.queueStats.phaseC} pages`);
-      console.log(`   - Deleted: ${phaseARes.queueStats.deleted} pages`);
-      onProgress?.();
+      try {
+        const phaseARes = await phaseAProcessor.runComplete(onProgress);
+        results.phaseA = phaseARes;
+        console.log(`Phase A: ${phaseARes.totalScanned} pages scanned in ${phaseARes.elapsedTime.toFixed(1)}s`);
+        console.log(`📊 Dirty Queue: ${phaseARes.queueStats.total} pages need processing`);
+        console.log(`   - Phase B: ${phaseARes.queueStats.phaseB} pages`);
+        console.log(`   - Phase C: ${phaseARes.queueStats.phaseC} pages`);
+        console.log(`   - Deleted: ${phaseARes.queueStats.deleted} pages`);
+        onProgress?.();
+      } finally {
+        phaseAProcessor.destroy();
+      }
 
       // Reconcile unseen and URL-reused pages and mark deletions now
       const db = new DatabaseStore();
@@ -218,17 +226,25 @@ export async function sync({
     if ((testMode && phase === 'all') || (!testMode && (phase === 'all' || phase === 'b'))) {
       console.log(testMode ? 'Phase B (test): Collecting content...' : 'Phase B: Collecting content...');
       const phaseBProcessor = new PhaseBProcessor();
-      await phaseBProcessor.run(full, testMode, onProgress);
-      console.log('Phase B completed');
-      onProgress?.();
+      try {
+        await phaseBProcessor.run(full, testMode, onProgress);
+        console.log('Phase B completed');
+        onProgress?.();
+      } finally {
+        phaseBProcessor.destroy();
+      }
     }
 
     if ((testMode && phase === 'all') || (!testMode && (phase === 'all' || phase === 'c'))) {
       console.log(testMode ? 'Phase C (test): Deep processing...' : 'Phase C: Deep processing...');
       const phaseCProcessor = new PhaseCProcessor({ concurrency: parseInt(concurrency || '4') });
-      await phaseCProcessor.run(testMode, onProgress);
-      console.log('Phase C completed');
-      onProgress?.();
+      try {
+        await phaseCProcessor.run(testMode, onProgress);
+        console.log('Phase C completed');
+        onProgress?.();
+      } finally {
+        phaseCProcessor.destroy();
+      }
     }
 
     // 只有在运行所有阶段或者明确指定 analyze 时才运行分析

--- a/backend/src/core/client/GraphQLClient.js
+++ b/backend/src/core/client/GraphQLClient.js
@@ -113,7 +113,9 @@ export class GraphQLClient {
   }
 
   /**
-   * 释放底层 HTTP 连接资源，防止 keep-alive 连接池泄漏。
+   * 释放引用以允许 GC 回收底层资源（包括 undici 连接池）。
+   * graphql-request 6.x 使用全局 fetch，没有暴露 per-instance HTTP agent，
+   * 因此无法显式关闭连接。通过断开引用链让 GC 回收是唯一可行的方式。
    * 调用后此实例不应再发起请求。
    */
   destroy() {

--- a/backend/src/core/client/GraphQLClient.js
+++ b/backend/src/core/client/GraphQLClient.js
@@ -1,12 +1,17 @@
 // src/core/client/GraphQLClient.js
 import { GraphQLClient as GQLClient } from 'graphql-request';
+import https from 'node:https';
 import { MAX_RETRY_ATTEMPTS } from '../../config/RateLimitConfig.js';
 import { BackoffManager } from '../scheduler/BackoffManager.js';
 import { Logger } from '../../utils/Logger.js';
 
 export class GraphQLClient {
   constructor(endpoint = 'https://apiv2.crom.avn.sh/graphql', options = {}) {
-    this.client = new GQLClient(endpoint);
+    // Per-instance HTTPS agent so we can destroy() its keep-alive sockets explicitly.
+    // graphql-request spreads extra requestConfig options into the fetch init,
+    // and node-fetch 3.x (via cross-fetch) reads `agent` from init.
+    this._agent = new https.Agent({ keepAlive: true, maxSockets: 4 });
+    this.client = new GQLClient(endpoint, { agent: this._agent });
     this.backoff = new BackoffManager();
     const timeoutFromEnv = Number.parseInt(process.env.SCPPER_GRAPHQL_TIMEOUT_MS || '', 10);
     const timeoutFromOptions = Number(options.requestTimeoutMs);
@@ -45,10 +50,10 @@ export class GraphQLClient {
           Logger.error('GraphQL request error:', err);
         }
         if (attempt === MAX_RETRY_ATTEMPTS) throw err;
-        
+
         Logger.warn(`Network error, retry #${attempt}`);
         await this.backoff.sleep(1000 * attempt);
-        
+
       } finally {
         clear();
       }
@@ -113,12 +118,14 @@ export class GraphQLClient {
   }
 
   /**
-   * 释放引用以允许 GC 回收底层资源（包括 undici 连接池）。
-   * graphql-request 6.x 使用全局 fetch，没有暴露 per-instance HTTP agent，
-   * 因此无法显式关闭连接。通过断开引用链让 GC 回收是唯一可行的方式。
+   * 显式销毁 per-instance HTTPS agent，关闭所有 keep-alive 连接。
    * 调用后此实例不应再发起请求。
    */
   destroy() {
+    if (this._agent) {
+      this._agent.destroy();
+      this._agent = null;
+    }
     this.client = null;
     this.backoff = null;
   }

--- a/backend/src/core/client/GraphQLClient.js
+++ b/backend/src/core/client/GraphQLClient.js
@@ -112,10 +112,19 @@ export class GraphQLClient {
            (h && (h['retry-after'] || (typeof h.get === 'function' && h.get('retry-after'))));
   }
 
+  /**
+   * 释放底层 HTTP 连接资源，防止 keep-alive 连接池泄漏。
+   * 调用后此实例不应再发起请求。
+   */
+  destroy() {
+    this.client = null;
+    this.backoff = null;
+  }
+
   _getRetryAfter(err) {
     const h = err?.response?.headers;
     if (!h) return 60;
-    
+
     // Handle different header object types
     if (typeof h.get === 'function') {
       return Number(h.get('retry-after') ?? 60);
@@ -123,7 +132,7 @@ export class GraphQLClient {
     if (typeof h['retry-after'] !== 'undefined') {
       return Number(h['retry-after']);
     }
-    
+
     return 60;
   }
 }

--- a/backend/src/core/processors/PhaseAProcessor.ts
+++ b/backend/src/core/processors/PhaseAProcessor.ts
@@ -193,6 +193,11 @@ export class PhaseAProcessor {
     this.attrService = new AttributionService(this.store.prisma);
   }
 
+  /** 释放 GraphQL 连接等资源，防止 keep-alive 泄漏 */
+  destroy(): void {
+    (this.client as any).destroy?.();
+  }
+
   async runComplete(onProgress?: () => void): Promise<PhaseAResult> {
     Logger.info('=== Phase A: Complete Page Scanning (New Architecture) ===');
 

--- a/backend/src/core/processors/PhaseBProcessor.ts
+++ b/backend/src/core/processors/PhaseBProcessor.ts
@@ -33,6 +33,11 @@ export class PhaseBProcessor {
     this.store = new DatabaseStore();
   }
 
+  /** 释放 GraphQL 连接等资源，防止 keep-alive 泄漏 */
+  destroy(): void {
+    (this.client as any).destroy?.();
+  }
+
   async run(fullSync = false, testMode = false, onProgress?: () => void): Promise<void> {
     Logger.info('=== Phase B: Targeted Page Content Collection ===');
     

--- a/backend/src/core/processors/PhaseCProcessor.ts
+++ b/backend/src/core/processors/PhaseCProcessor.ts
@@ -32,6 +32,11 @@ export class PhaseCProcessor {
     this.queue = new TaskQueue(concurrency);
   }
 
+  /** 释放 GraphQL 连接等资源，防止 keep-alive 泄漏 */
+  destroy(): void {
+    (this.client as any).destroy?.();
+  }
+
   async run(testMode = false, onProgress?: () => void): Promise<void> {
     Logger.info('=== Phase C: Targeted Complex Page Processing ===');
     

--- a/backend/src/core/store/DatabaseStore.ts
+++ b/backend/src/core/store/DatabaseStore.ts
@@ -35,54 +35,6 @@ export class DatabaseStore {
   }
 
   /**
-   * 加载进度（用于恢复）
-   * @deprecated 已被 DirtyPage 队列替代，保留供回退使用。每批限制 1000 条防止 OOM。
-   */
-  async loadProgress(phase = 'phase1', cursor?: number) {
-    const BATCH_SIZE = 1000;
-    const cursorOpt = cursor ? { skip: 1, cursor: { id: cursor } } : {};
-    switch (phase) {
-      case 'phase1':
-        return await this.prisma.page.findMany({
-          ...cursorOpt,
-          take: BATCH_SIZE,
-          orderBy: { id: 'asc' },
-          include: {
-            versions: {
-              orderBy: { validFrom: 'desc' },
-              take: 1,
-            },
-          },
-        });
-      case 'phase2':
-        return await this.prisma.pageVersion.findMany({
-          ...cursorOpt,
-          take: BATCH_SIZE,
-          orderBy: { id: 'asc' },
-          where: {
-            validTo: null,
-            textContent: { not: null },
-          },
-        });
-      case 'phase3':
-        return await this.prisma.pageVersion.findMany({
-          ...cursorOpt,
-          take: BATCH_SIZE,
-          orderBy: { id: 'asc' },
-          where: {
-            validTo: null,
-          },
-          include: {
-            revisions: true,
-            votes: true,
-          },
-        });
-      default:
-        return [];
-    }
-  }
-
-  /**
    * 添加数据（根据阶段）
    */
   async append(phase: string, obj: any) {

--- a/backend/src/utils/db-connection.ts
+++ b/backend/src/utils/db-connection.ts
@@ -14,38 +14,42 @@ let prismaInstance: PrismaClient | null = null;
 let signalsBound = false;
 
 /**
+ * 在 DATABASE_URL 中追加连接池参数（如果缺失）。
+ * Prisma Query Engine 通过 URL 参数读取 connection_limit / pool_timeout。
+ */
+function ensureConnectionLimit(url: string, defaultLimit = 10, defaultPoolTimeout = 10): string {
+  const u = new URL(url);
+  if (!u.searchParams.has('connection_limit')) {
+    u.searchParams.set('connection_limit', String(defaultLimit));
+  }
+  if (!u.searchParams.has('pool_timeout')) {
+    u.searchParams.set('pool_timeout', String(defaultPoolTimeout));
+  }
+  return u.toString();
+}
+
+/**
  * 创建或获取PrismaClient实例
  * 使用单例模式避免创建多个连接
  */
 export function getPrismaClient(): PrismaClient {
   if (!prismaInstance) {
     const databaseUrl = process.env.DATABASE_URL;
-    
+
     if (!databaseUrl) {
       throw new Error('DATABASE_URL environment variable is not set. Please check your .env file.');
     }
-    
+
     prismaInstance = new PrismaClient({
       datasources: {
         db: {
-          url: databaseUrl
+          url: ensureConnectionLimit(databaseUrl)
         }
       },
-      log: process.env.NODE_ENV === 'development' 
-        ? ['query', 'error', 'warn'] 
+      log: process.env.NODE_ENV === 'development'
+        ? ['query', 'error', 'warn']
         : ['error'],
-      // Add connection pooling configuration
-      __internal: {
-        engine: {
-          // Configure connection pool
-          maxIdleConnections: 5,
-          maxConnections: 20,
-          connectionTimeout: 20000,
-          maxWriteConnections: 10,
-          maxReadConnections: 10,
-        }
-      }
-    } as any);
+    });
   }
   
   if (!signalsBound) {

--- a/backend/src/utils/db-connection.ts
+++ b/backend/src/utils/db-connection.ts
@@ -16,16 +16,24 @@ let signalsBound = false;
 /**
  * 在 DATABASE_URL 中追加连接池参数（如果缺失）。
  * Prisma Query Engine 通过 URL 参数读取 connection_limit / pool_timeout。
+ * 仅对 postgresql/postgres 协议生效；其他协议（如 file: SQLite）原样返回。
  */
 function ensureConnectionLimit(url: string, defaultLimit = 10, defaultPoolTimeout = 10): string {
-  const u = new URL(url);
-  if (!u.searchParams.has('connection_limit')) {
-    u.searchParams.set('connection_limit', String(defaultLimit));
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'postgresql:' && u.protocol !== 'postgres:') {
+      return url;
+    }
+    if (!u.searchParams.has('connection_limit')) {
+      u.searchParams.set('connection_limit', String(defaultLimit));
+    }
+    if (!u.searchParams.has('pool_timeout')) {
+      u.searchParams.set('pool_timeout', String(defaultPoolTimeout));
+    }
+    return u.toString();
+  } catch {
+    return url;
   }
-  if (!u.searchParams.has('pool_timeout')) {
-    u.searchParams.set('pool_timeout', String(defaultPoolTimeout));
-  }
-  return u.toString();
 }
 
 /**

--- a/user-backend/src/db.ts
+++ b/user-backend/src/db.ts
@@ -2,16 +2,24 @@ import { PrismaClient } from '@prisma/client';
 
 /**
  * 在 DATABASE_URL 中追加连接池参数（如果缺失）。
+ * 仅对 postgresql/postgres 协议生效；其他协议原样返回。
  */
 function ensureConnectionLimit(url: string, defaultLimit = 5, defaultPoolTimeout = 10): string {
-  const u = new URL(url);
-  if (!u.searchParams.has('connection_limit')) {
-    u.searchParams.set('connection_limit', String(defaultLimit));
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'postgresql:' && u.protocol !== 'postgres:') {
+      return url;
+    }
+    if (!u.searchParams.has('connection_limit')) {
+      u.searchParams.set('connection_limit', String(defaultLimit));
+    }
+    if (!u.searchParams.has('pool_timeout')) {
+      u.searchParams.set('pool_timeout', String(defaultPoolTimeout));
+    }
+    return u.toString();
+  } catch {
+    return url;
   }
-  if (!u.searchParams.has('pool_timeout')) {
-    u.searchParams.set('pool_timeout', String(defaultPoolTimeout));
-  }
-  return u.toString();
 }
 
 const databaseUrl = process.env.USER_DATABASE_URL || process.env.DATABASE_URL;

--- a/user-backend/src/db.ts
+++ b/user-backend/src/db.ts
@@ -22,7 +22,7 @@ function ensureConnectionLimit(url: string, defaultLimit = 5, defaultPoolTimeout
   }
 }
 
-const databaseUrl = process.env.USER_DATABASE_URL || process.env.DATABASE_URL;
+const databaseUrl = process.env.USER_DATABASE_URL;
 
 export const prisma = new PrismaClient({
   datasources: databaseUrl ? {

--- a/user-backend/src/db.ts
+++ b/user-backend/src/db.ts
@@ -1,5 +1,24 @@
 import { PrismaClient } from '@prisma/client';
 
+/**
+ * 在 DATABASE_URL 中追加连接池参数（如果缺失）。
+ */
+function ensureConnectionLimit(url: string, defaultLimit = 5, defaultPoolTimeout = 10): string {
+  const u = new URL(url);
+  if (!u.searchParams.has('connection_limit')) {
+    u.searchParams.set('connection_limit', String(defaultLimit));
+  }
+  if (!u.searchParams.has('pool_timeout')) {
+    u.searchParams.set('pool_timeout', String(defaultPoolTimeout));
+  }
+  return u.toString();
+}
+
+const databaseUrl = process.env.USER_DATABASE_URL || process.env.DATABASE_URL;
+
 export const prisma = new PrismaClient({
+  datasources: databaseUrl ? {
+    db: { url: ensureConnectionLimit(databaseUrl) }
+  } : undefined,
   log: process.env.NODE_ENV === 'development' ? ['query', 'warn', 'error'] : ['warn', 'error'],
 });

--- a/user-backend/src/server.ts
+++ b/user-backend/src/server.ts
@@ -28,8 +28,17 @@ async function main() {
     // eslint-disable-next-line no-console
     console.log(`Received ${signal}, shutting down...`);
     clearInterval(sweepTimer);
+
+    const forceTimer = setTimeout(() => {
+      // eslint-disable-next-line no-console
+      console.error('Graceful shutdown timed out after 10s, forcing exit');
+      process.exit(1);
+    }, 10_000);
+    forceTimer.unref();
+
     server.close(async () => {
       await prisma.$disconnect();
+      clearTimeout(forceTimer);
       process.exit(0);
     });
   };

--- a/user-backend/src/server.ts
+++ b/user-backend/src/server.ts
@@ -24,7 +24,7 @@ async function main() {
     triggerMarketSettleSweep();
   }, EXPIRY_SWEEP_INTERVAL_MS);
 
-  const shutdown = async (signal: string) => {
+  const shutdown = (signal: string) => {
     // eslint-disable-next-line no-console
     console.log(`Received ${signal}, shutting down...`);
     clearInterval(sweepTimer);
@@ -36,10 +36,20 @@ async function main() {
     }, 10_000);
     forceTimer.unref();
 
-    server.close(async () => {
-      await prisma.$disconnect();
-      clearTimeout(forceTimer);
-      process.exit(0);
+    server.close((err) => {
+      if (err) {
+        // eslint-disable-next-line no-console
+        console.error('server.close error:', err);
+      }
+      prisma.$disconnect()
+        .catch((disconnectErr: unknown) => {
+          // eslint-disable-next-line no-console
+          console.error('prisma.$disconnect error:', disconnectErr);
+        })
+        .finally(() => {
+          clearTimeout(forceTimer);
+          process.exit(err ? 1 : 0);
+        });
     });
   };
 


### PR DESCRIPTION
## Summary

修复 sync-hourly (3.4GB) 和 user-backend (1GB RSS) 的内存泄漏根因，PR #31 添加的 `max_memory_restart` 是安全网，本 PR 解决底层问题。

### P0: GraphQLClient 连接池泄漏
- 每轮 sync 创建 3-4 个 Processor，每个含独立 `GraphQLClient` → undici HTTP 连接池
- 函数返回后 keep-alive 连接阻止 GC，72h ≈ 216 个未释放连接池
- **修复**: 添加 `GraphQLClient.destroy()` + Processor `destroy()`，sync.ts 中 try/finally 显式销毁

### P1: Prisma 连接池限制
- backend `db-connection.ts`: 移除无效的 `__internal` hack（Prisma 5+ 已忽略），改为通过 URL 参数 `connection_limit=10`
- user-backend `db.ts`: 添加 `connection_limit=5`

### P1: user-backend shutdown timeout
- 添加 10s 强制退出 timeout，防止 `server.close` 挂起导致 PM2 SIGKILL → 内存碎片

### P2: 清理死代码
- 删除 `DatabaseStore.loadProgress`（无调用方，已被 DirtyPage 队列替代）

## 受影响服务
- `sync-hourly` — GraphQLClient 泄漏修复 + Prisma 连接池限制
- `user-backend` — Prisma 连接池限制 + shutdown timeout

## Test plan
- [ ] `backend` TypeScript 编译通过（无新增错误）
- [ ] `user-backend` TypeScript 编译通过（无新增错误）
- [ ] 部署后观察 sync-hourly 内存趋势（预期每轮后不再增长）
- [ ] 部署后观察 user-backend RSS（预期稳定在 ~200MB 以下）
- [ ] 验证 user-backend SIGTERM 后 10s 内正常退出