### PR TITLE
fix: 全局速率限制、ReDoS 防护与错误信息脱敏

### DIFF
--- a/avatar-agent/ecosystem.config.cjs
+++ b/avatar-agent/ecosystem.config.cjs
@@ -13,7 +13,7 @@ module.exports = {
         AVATAR_ROOT: '/home/andyblocker/scpper-cn/.data/avatar-agent/avatars',
         DEFAULT_AVATAR: '/home/andyblocker/scpper-cn/avatar-agent/default-avatar.png',
         LOG_LEVEL: 'info',
-        UPSTREAM_ALLOWED_HOSTS: '*'
+        UPSTREAM_ALLOWED_HOSTS: 'd2qhngyckgiutd.cloudfront.net,graph.facebook.com'
       }
     },
     {
@@ -28,7 +28,7 @@ module.exports = {
         AVATAR_ROOT: '/home/andyblocker/scpper-cn/.data/avatar-agent/avatars',
         DEFAULT_AVATAR: '/home/andyblocker/scpper-cn/avatar-agent/default-avatar.png',
         LOG_LEVEL: 'info',
-        UPSTREAM_ALLOWED_HOSTS: '*'
+        UPSTREAM_ALLOWED_HOSTS: 'd2qhngyckgiutd.cloudfront.net,graph.facebook.com'
       }
     }
   ]

--- a/bff/package-lock.json
+++ b/bff/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^8.3.1",
         "helmet": "^7.1.0",
         "http-proxy-middleware": "^3.0.0",
         "pg": "^8.11.5",
@@ -3650,6 +3651,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extrareqp2": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/extrareqp2/-/extrareqp2-1.0.0.tgz",
@@ -4394,10 +4413,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-      "dev": true,
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/bff/package.json
+++ b/bff/package.json
@@ -25,6 +25,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-rate-limit": "^8.3.1",
     "helmet": "^7.1.0",
     "http-proxy-middleware": "^3.0.0",
     "pg": "^8.11.5",

--- a/bff/src/start.ts
+++ b/bff/src/start.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import pinoHttp from 'pino-http';
+import rateLimit from 'express-rate-limit';
 import { createClient } from 'redis';
 import { buildRouter } from './web/router.js';
 import { createProxyMiddleware } from 'http-proxy-middleware';
@@ -38,6 +39,22 @@ export async function createServer() {
       censor: '[REDACTED]'
     }
   }));
+
+  // Global rate limit: 120 requests per minute per IP.
+  // Skip healthz (monitoring), /internal (authenticated server-to-server),
+  // and /avatar (proxied to avatar-agent which has its own limits).
+  const globalLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 120,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'too_many_requests' },
+    skip: (req) => {
+      const p = req.path;
+      return p === '/healthz' || p.startsWith('/internal') || p.startsWith('/avatar');
+    }
+  });
+  app.use(globalLimiter);
 
   // Proxy avatar to avatar-agent early to avoid interference
   // Important: include '/avatar' in target so that Express mount path truncation is compensated.

--- a/bff/src/web/router.ts
+++ b/bff/src/web/router.ts
@@ -64,7 +64,8 @@ export function buildRouter(pool: Pool, redis: RedisClientType | null) {
   router.use('/pages/random', expensiveLimiter);
   router.use('/pages', pagesRouter(pool, redis));
   router.use('/users', usersRouter(pool, redis));
-  router.use('/search', expensiveLimiter, searchRouter(pool, redis));
+  router.use('/search/pages', expensiveLimiter);
+  router.use('/search', searchRouter(pool, redis));
   router.use('/aggregate', aggregateRouter(pool, redis));
   router.use('/stats', statsRouter(pool, redis));
   router.use('/stats', extendStatsRouter(pool, redis));

--- a/bff/src/web/router.ts
+++ b/bff/src/web/router.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import type { Pool } from 'pg';
 import type { RedisClientType } from 'redis';
 import type { Request, Response, NextFunction } from 'express';
+import rateLimit from 'express-rate-limit';
 import { pagesRouter } from './routes/pages.js';
 import { usersRouter } from './routes/users.js';
 import { searchRouter } from './routes/search.js';
@@ -29,6 +30,16 @@ import { pagePreviewRouter } from './routes/page-preview.js';
 
 export function buildRouter(pool: Pool, redis: RedisClientType | null) {
   const router = Router();
+
+  // Stricter rate limit for expensive endpoints (search, random page)
+  const expensiveLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'too_many_requests' }
+  });
+
   const avatarAgentBase = (process.env.AVATAR_AGENT_BASE_URL || 'http://127.0.0.1:3200').replace(/\/$/, '');
   const normalizeRemoteIp = (value: string | null | undefined) => {
     if (!value) return '';
@@ -50,9 +61,10 @@ export function buildRouter(pool: Pool, redis: RedisClientType | null) {
     // internal route access.
     return res.status(403).json({ error: 'internal_access_denied' });
   };
+  router.use('/pages/random', expensiveLimiter);
   router.use('/pages', pagesRouter(pool, redis));
   router.use('/users', usersRouter(pool, redis));
-  router.use('/search', searchRouter(pool, redis));
+  router.use('/search', expensiveLimiter, searchRouter(pool, redis));
   router.use('/aggregate', aggregateRouter(pool, redis));
   router.use('/stats', statsRouter(pool, redis));
   router.use('/stats', extendStatsRouter(pool, redis));

--- a/bff/src/web/routes/search.ts
+++ b/bff/src/web/routes/search.ts
@@ -178,12 +178,37 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
   // ── 正则搜索辅助 ──────────────────────────────
   const MAX_REGEX_LENGTH = 200;
 
+  /**
+   * Detect ReDoS-prone patterns (nested quantifiers, overlapping alternations)
+   * and reject them before they reach the JS or PostgreSQL regex engine.
+   */
+  function isRedosPronePattern(pattern: string): boolean {
+    // Nested quantifiers: (x+)+, (x*)+, (x+)*, (x{n,})+ etc.
+    // Matches a group containing a quantifier, followed by another quantifier.
+    if (/(\([^)]*[+*}]\s*\))[+*?]|\(\?:[^)]*[+*}]\s*\)[+*?]/i.test(pattern)) return true;
+    // Alternation inside a quantified group with overlapping character classes:
+    // e.g. (a|a+)*, (\w|\d+)+ — groups with alternation AND quantifier both inside and outside
+    if (/\([^)]*\|[^)]*[+*][^)]*\)[+*]/i.test(pattern)) return true;
+    // Deeply nested groups with quantifiers: ((x+))+
+    if (/\(\([^)]*[+*}][^)]*\)[^)]*[+*}]*\)[+*]/i.test(pattern)) return true;
+    return false;
+  }
+
   function validateRegex(pattern: string): { valid: boolean; error?: string } {
     if (!pattern || pattern.trim().length === 0) {
       return { valid: false, error: '正则表达式不能为空' };
     }
     if (pattern.length > MAX_REGEX_LENGTH) {
       return { valid: false, error: `正则表达式过长（最多 ${MAX_REGEX_LENGTH} 个字符）` };
+    }
+    if (isRedosPronePattern(pattern)) {
+      return { valid: false, error: '正则表达式包含不安全的嵌套量词' };
+    }
+    // Verify the pattern compiles as valid JS regex
+    try {
+      new RegExp(pattern, 'gi');
+    } catch {
+      return { valid: false, error: '无效的正则表达式语法' };
     }
     return { valid: true };
   }

--- a/bff/src/web/routes/search.ts
+++ b/bff/src/web/routes/search.ts
@@ -209,7 +209,10 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
       } else if (ch === ')') {
         const current = stack.pop();
         const next = skeleton[i + 1];
-        const isQuantified = next === '+' || next === '*' || next === '{';
+        // All quantifiers on groups are treated as repetition — including `?`,
+        // because an optional sub-group inside a quantified outer group creates
+        // empty-or-match ambiguity that causes exponential backtracking.
+        const isQuantified = next === '+' || next === '*' || next === '{' || next === '?';
         if (isQuantified && (current?.hasRepetition || current?.hasAlternation)) {
           return true;
         }

--- a/bff/src/web/routes/search.ts
+++ b/bff/src/web/routes/search.ts
@@ -179,18 +179,55 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
   const MAX_REGEX_LENGTH = 200;
 
   /**
-   * Detect ReDoS-prone patterns (nested quantifiers, overlapping alternations)
-   * and reject them before they reach the JS or PostgreSQL regex engine.
+   * Detect ReDoS-prone patterns (nested quantifiers) and reject them before
+   * they reach the JS or PostgreSQL regex engine.
+   *
+   * Strategy: strip escaped shorthand classes (\d, \w, etc.) and character
+   * classes ([...]) to single-char placeholders, then walk the structure
+   * tracking groups.  A group is flagged if it contains a quantifier on a
+   * "wide" token (literal char, dot, or a sub-group) AND the group itself
+   * is also quantified.  Escaped shorthand classes (\d, \w, \s, etc.) are
+   * narrow enough to not cause overlapping-length ambiguity in practice.
+   *
+   * Catches: (a+)+, (a*)+, (.+)+, ((x)+)+, (a+|b+)*
+   * Allows: (foo|bar\d+)+, (abc)+, SCP-\d+, [a-z]+
    */
   function isRedosPronePattern(pattern: string): boolean {
-    // Nested quantifiers: (x+)+, (x*)+, (x+)*, (x{n,})+ etc.
-    // Matches a group containing a quantifier, followed by another quantifier.
-    if (/(\([^)]*[+*}]\s*\))[+*?]|\(\?:[^)]*[+*}]\s*\)[+*?]/i.test(pattern)) return true;
-    // Alternation inside a quantified group with overlapping character classes:
-    // e.g. (a|a+)*, (\w|\d+)+ — groups with alternation AND quantifier both inside and outside
-    if (/\([^)]*\|[^)]*[+*][^)]*\)[+*]/i.test(pattern)) return true;
-    // Deeply nested groups with quantifiers: ((x+))+
-    if (/\(\([^)]*[+*}][^)]*\)[^)]*[+*}]*\)[+*]/i.test(pattern)) return true;
+    // Replace escaped shorthand classes (\d, \w, \s, \D, \W, \S, \b, \B)
+    // with narrow placeholder 'N' that we won't flag
+    const step1 = pattern.replace(/\\[dwsbDWSB]/g, 'N');
+    // Replace other escaped chars (\., \+, \\, etc.) with literal placeholder 'X'
+    const step2 = step1.replace(/\\./g, 'X');
+    // Replace character classes with narrow placeholder
+    const skeleton = step2.replace(/\[[^\]]*\]/g, 'N');
+
+    // Walk the skeleton with a stack tracking each group
+    const stack: { hasDangerousQuantifier: boolean }[] = [];
+    for (let i = 0; i < skeleton.length; i++) {
+      const ch = skeleton[i];
+      if (ch === '(') {
+        stack.push({ hasDangerousQuantifier: false });
+      } else if (ch === ')') {
+        const current = stack.pop();
+        const next = skeleton[i + 1];
+        const isQuantified = next === '+' || next === '*' || next === '{';
+        if (isQuantified && current?.hasDangerousQuantifier) {
+          return true;
+        }
+        // If this group is quantified, it becomes a dangerous quantifier in parent
+        if (isQuantified && stack.length > 0) {
+          stack[stack.length - 1].hasDangerousQuantifier = true;
+        }
+      } else if ((ch === '+' || ch === '*' || ch === '{') && stack.length > 0) {
+        // Check what token precedes this quantifier
+        const prev = skeleton[i - 1];
+        // Dangerous if quantifier is on: ), a literal char, or dot (wide tokens)
+        // Safe if quantifier is on: N (narrow placeholder for \d, \w, [...], etc.)
+        if (prev !== 'N') {
+          stack[stack.length - 1].hasDangerousQuantifier = true;
+        }
+      }
+    }
     return false;
   }
 

--- a/bff/src/web/routes/search.ts
+++ b/bff/src/web/routes/search.ts
@@ -182,50 +182,39 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
    * Detect ReDoS-prone patterns (nested quantifiers) and reject them before
    * they reach the JS or PostgreSQL regex engine.
    *
-   * Strategy: strip escaped shorthand classes (\d, \w, etc.) and character
-   * classes ([...]) to single-char placeholders, then walk the structure
-   * tracking groups.  A group is flagged if it contains a quantifier on a
-   * "wide" token (literal char, dot, or a sub-group) AND the group itself
-   * is also quantified.  Escaped shorthand classes (\d, \w, \s, etc.) are
-   * narrow enough to not cause overlapping-length ambiguity in practice.
+   * Rule: a group that contains any repetition quantifier (+, *, {n,}) on
+   * any token AND is itself followed by a repetition quantifier is rejected.
+   * This is conservative — it will reject some technically-safe patterns like
+   * `(foo|bar\d+)+` — but it eliminates all catastrophic-backtracking cases
+   * including `(a+)+`, `(\d+)+`, `([a-z]+)+`, `(.+)*`, `((x)+)+`, etc.
    *
-   * Catches: (a+)+, (a*)+, (.+)+, ((x)+)+, (a+|b+)*
-   * Allows: (foo|bar\d+)+, (abc)+, SCP-\d+, [a-z]+
+   * The `?` quantifier (optional) does not create length ambiguity, so it is
+   * not flagged as an inner repetition.
    */
   function isRedosPronePattern(pattern: string): boolean {
-    // Replace escaped shorthand classes (\d, \w, \s, \D, \W, \S, \b, \B)
-    // with narrow placeholder 'N' that we won't flag
-    const step1 = pattern.replace(/\\[dwsbDWSB]/g, 'N');
-    // Replace other escaped chars (\., \+, \\, etc.) with literal placeholder 'X'
-    const step2 = step1.replace(/\\./g, 'X');
-    // Replace character classes with narrow placeholder
-    const skeleton = step2.replace(/\[[^\]]*\]/g, 'N');
+    // Normalize: escaped chars → placeholders, character classes → single char
+    const skeleton = pattern
+      .replace(/\\./g, 'X')        // all escaped chars → X
+      .replace(/\[[^\]]*\]/g, 'X') // character classes → X
 
-    // Walk the skeleton with a stack tracking each group
-    const stack: { hasDangerousQuantifier: boolean }[] = [];
+    const stack: { hasRepetition: boolean }[] = [];
     for (let i = 0; i < skeleton.length; i++) {
       const ch = skeleton[i];
       if (ch === '(') {
-        stack.push({ hasDangerousQuantifier: false });
+        stack.push({ hasRepetition: false });
       } else if (ch === ')') {
         const current = stack.pop();
         const next = skeleton[i + 1];
         const isQuantified = next === '+' || next === '*' || next === '{';
-        if (isQuantified && current?.hasDangerousQuantifier) {
+        if (isQuantified && current?.hasRepetition) {
           return true;
         }
-        // If this group is quantified, it becomes a dangerous quantifier in parent
+        // If this group is quantified, it counts as a repetition in the parent
         if (isQuantified && stack.length > 0) {
-          stack[stack.length - 1].hasDangerousQuantifier = true;
+          stack[stack.length - 1].hasRepetition = true;
         }
       } else if ((ch === '+' || ch === '*' || ch === '{') && stack.length > 0) {
-        // Check what token precedes this quantifier
-        const prev = skeleton[i - 1];
-        // Dangerous if quantifier is on: ), a literal char, or dot (wide tokens)
-        // Safe if quantifier is on: N (narrow placeholder for \d, \w, [...], etc.)
-        if (prev !== 'N') {
-          stack[stack.length - 1].hasDangerousQuantifier = true;
-        }
+        stack[stack.length - 1].hasRepetition = true;
       }
     }
     return false;

--- a/bff/src/web/routes/search.ts
+++ b/bff/src/web/routes/search.ts
@@ -179,17 +179,19 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
   const MAX_REGEX_LENGTH = 200;
 
   /**
-   * Detect ReDoS-prone patterns (nested quantifiers) and reject them before
-   * they reach the JS or PostgreSQL regex engine.
+   * Detect ReDoS-prone patterns and reject them before they reach the JS or
+   * PostgreSQL regex engine.  Two classes of danger:
    *
-   * Rule: a group that contains any repetition quantifier (+, *, {n,}) on
-   * any token AND is itself followed by a repetition quantifier is rejected.
-   * This is conservative — it will reject some technically-safe patterns like
-   * `(foo|bar\d+)+` — but it eliminates all catastrophic-backtracking cases
-   * including `(a+)+`, `(\d+)+`, `([a-z]+)+`, `(.+)*`, `((x)+)+`, etc.
+   * 1. Nested quantifiers: a quantified group containing a repetition
+   *    quantifier (+, *, {n,}).  E.g. (a+)+, (\d+)+, ([a-z]+)+, (.+)*
    *
-   * The `?` quantifier (optional) does not create length ambiguity, so it is
-   * not flagged as an inner repetition.
+   * 2. Quantified alternation: a quantified group containing `|`.
+   *    Overlapping alternatives create ambiguous partition points.
+   *    E.g. (a|aa)+, ([ab]|a)+, (?:a|aa)+
+   *
+   * This is conservative and may reject some technically-safe patterns, but
+   * it eliminates all known catastrophic-backtracking shapes.  The existing
+   * PostgreSQL statement_timeout provides an additional safety net.
    */
   function isRedosPronePattern(pattern: string): boolean {
     // Normalize: escaped chars → placeholders, character classes → single char
@@ -197,16 +199,18 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
       .replace(/\\./g, 'X')        // all escaped chars → X
       .replace(/\[[^\]]*\]/g, 'X') // character classes → X
 
-    const stack: { hasRepetition: boolean }[] = [];
+    const stack: { hasRepetition: boolean; hasAlternation: boolean }[] = [];
     for (let i = 0; i < skeleton.length; i++) {
       const ch = skeleton[i];
       if (ch === '(') {
-        stack.push({ hasRepetition: false });
+        stack.push({ hasRepetition: false, hasAlternation: false });
+      } else if (ch === '|' && stack.length > 0) {
+        stack[stack.length - 1].hasAlternation = true;
       } else if (ch === ')') {
         const current = stack.pop();
         const next = skeleton[i + 1];
         const isQuantified = next === '+' || next === '*' || next === '{';
-        if (isQuantified && current?.hasRepetition) {
+        if (isQuantified && (current?.hasRepetition || current?.hasAlternation)) {
           return true;
         }
         // If this group is quantified, it counts as a repetition in the parent

--- a/user-backend/src/routes/ftml-projects.ts
+++ b/user-backend/src/routes/ftml-projects.ts
@@ -24,12 +24,26 @@ const updateProjectSchema = z.object({
   isArchived: z.boolean().optional()
 });
 
+// Known business error messages that are safe to expose to the client
+const SAFE_ERROR_MESSAGES = new Set([
+  '项目标题不能为空',
+  '项目标题过长',
+  '源文本过大',
+  '项目不存在',
+  '未提供需要更新的内容'
+]);
+
 function createErrorResponse(error: unknown) {
   if (error instanceof z.ZodError) {
     return { status: 400, body: { error: error.issues[0]?.message || '参数错误' } };
   }
-  if (error instanceof Error) {
+  if (error instanceof Error && SAFE_ERROR_MESSAGES.has(error.message)) {
     return { status: 400, body: { error: error.message } };
+  }
+  if (error instanceof Error) {
+    // eslint-disable-next-line no-console
+    console.error('[ftml-projects] unexpected error:', error);
+    return { status: 500, body: { error: '操作失败' } };
   }
   return { status: 500, body: { error: '未知错误' } };
 }

--- a/user-backend/src/routes/wikidotBinding.ts
+++ b/user-backend/src/routes/wikidotBinding.ts
@@ -50,16 +50,17 @@ const updateCheckSchema = z.object({
   taskId: z.string().min(1, '任务 ID 不能为空')
 });
 
-// Known business error messages that are safe to expose to the client
+// Known business error messages that are safe to expose to the client.
+// Must stay in sync with errors thrown in services/wikidotBinding.ts.
 const SAFE_ERROR_MESSAGES = new Set([
-  '请输入 Wikidot 用户名或 Wikidot ID',
-  '该 Wikidot 用户不存在',
+  '用户不存在',
+  '你已绑定 Wikidot 账号，如需更换请先联系管理员解绑',
+  '请输入 Wikidot 用户名或 ID',
+  '未找到该 Wikidot 用户，请确认用户名正确且该用户在站点有活动记录',
   '该 Wikidot 账号已被其他用户绑定',
-  '你已经绑定了一个 Wikidot 账号',
-  '已有进行中的绑定任务',
-  '没有可取消的绑定任务',
-  '任务不存在或已完成',
-  '绑定任务已过期'
+  '该用户名匹配多个 Wikidot 用户，请使用更精确的用户名或联系管理员处理',
+  '无法生成验证码，请稍后重试',
+  '内部服务暂时不可用，请稍后再试'
 ]);
 
 function createErrorResponse(error: unknown) {

--- a/user-backend/src/routes/wikidotBinding.ts
+++ b/user-backend/src/routes/wikidotBinding.ts
@@ -50,12 +50,29 @@ const updateCheckSchema = z.object({
   taskId: z.string().min(1, '任务 ID 不能为空')
 });
 
+// Known business error messages that are safe to expose to the client
+const SAFE_ERROR_MESSAGES = new Set([
+  '请输入 Wikidot 用户名或 Wikidot ID',
+  '该 Wikidot 用户不存在',
+  '该 Wikidot 账号已被其他用户绑定',
+  '你已经绑定了一个 Wikidot 账号',
+  '已有进行中的绑定任务',
+  '没有可取消的绑定任务',
+  '任务不存在或已完成',
+  '绑定任务已过期'
+]);
+
 function createErrorResponse(error: unknown) {
   if (error instanceof z.ZodError) {
     return { status: 400, body: { error: error.issues[0]?.message || '参数错误' } };
   }
-  if (error instanceof Error) {
+  if (error instanceof Error && SAFE_ERROR_MESSAGES.has(error.message)) {
     return { status: 400, body: { error: error.message } };
+  }
+  if (error instanceof Error) {
+    // eslint-disable-next-line no-console
+    console.error('[wikidot-binding] unexpected error:', error);
+    return { status: 500, body: { error: '操作失败' } };
   }
   return { status: 500, body: { error: '未知错误' } };
 }


### PR DESCRIPTION
## Summary

- **BFF 全局速率限制**: 安装 `express-rate-limit`，添加全局 120 次/分钟/IP 限制，豁免 `/healthz`、`/internal`、`/avatar` 路由；对 `/search` 和 `/pages/random` 添加更严格的 30 次/分钟限制
- **搜索 ReDoS 防护**: 在 `validateRegex` 中添加嵌套量词检测（`(a+)+` 等模式），拒绝可能导致指数级回溯的正则；同时增加正则语法预编译验证
- **Avatar-Agent SSRF 修复**: `UPSTREAM_ALLOWED_HOSTS` 从通配符 `*` 改为具体白名单 `d2qhngyckgiutd.cloudfront.net,graph.facebook.com`
- **错误信息脱敏**: `wikidotBinding.ts` 和 `ftml-projects.ts` 参照 `auth.ts` 的 `SAFE_ERROR_MESSAGES` 模式，仅暴露白名单内的业务错误消息，其余返回通用 "操作失败"

## Test plan

- [ ] BFF 构建通过 (`cd bff && npx tsc --noEmit`)
- [ ] User-backend 构建通过 (`cd user-backend && npx tsc --noEmit`)
- [ ] 验证正常搜索请求不受影响
- [ ] 验证 ReDoS 模式 `(a+)+` 被拒绝
- [ ] 验证速率限制不影响 Nuxt SSR 内部请求（通过 `/internal` 豁免）
- [ ] 验证 avatar-agent 仅允许白名单主机