### PR TITLE
fix: 清理冗余索引、添加缺失外键、修复事务问题

### DIFF
--- a/backend/prisma/migrations/20260324000000_cleanup_schema/migration.sql
+++ b/backend/prisma/migrations/20260324000000_cleanup_schema/migration.sql
@@ -2,7 +2,7 @@
 
 -- 1. Remove redundant indexes (unique constraints already create indexes)
 DROP INDEX IF EXISTS "SiteStats_date_idx";
-DROP INDEX IF EXISTS "SiteOverviewDaily_date_idx";
+DROP INDEX IF EXISTS "idx_siteoverviewdaily_date";
 DROP INDEX IF EXISTS "idx_category_index_tick_category_as_of_ts";
 DROP INDEX IF EXISTS "LeaderboardCache_key_period_idx";
 DROP INDEX IF EXISTS "SeriesStats_seriesNumber_idx";

--- a/backend/prisma/migrations/20260324000000_cleanup_schema/migration.sql
+++ b/backend/prisma/migrations/20260324000000_cleanup_schema/migration.sql
@@ -1,0 +1,38 @@
+-- cleanup_schema: remove redundant indexes, drop DirtyPageBackup, add missing foreign keys
+
+-- 1. Remove redundant indexes (unique constraints already create indexes)
+DROP INDEX IF EXISTS "SiteStats_date_idx";
+DROP INDEX IF EXISTS "SiteOverviewDaily_date_idx";
+DROP INDEX IF EXISTS "idx_category_index_tick_category_as_of_ts";
+DROP INDEX IF EXISTS "LeaderboardCache_key_period_idx";
+DROP INDEX IF EXISTS "SeriesStats_seriesNumber_idx";
+
+-- 2. Drop deprecated DirtyPageBackup table
+DROP TABLE IF EXISTS "DirtyPageBackup";
+
+-- 3. Add foreign keys for UserTagPreference and UserVoteInteraction
+-- Clean up orphan records first (userId not in User table)
+DELETE FROM "UserTagPreference"
+WHERE "userId" NOT IN (SELECT id FROM "User");
+
+DELETE FROM "UserVoteInteraction"
+WHERE "fromUserId" NOT IN (SELECT id FROM "User")
+   OR "toUserId" NOT IN (SELECT id FROM "User");
+
+-- Add foreign key: UserTagPreference.userId -> User.id
+ALTER TABLE "UserTagPreference"
+  ADD CONSTRAINT "UserTagPreference_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Add foreign key: UserVoteInteraction.fromUserId -> User.id
+ALTER TABLE "UserVoteInteraction"
+  ADD CONSTRAINT "UserVoteInteraction_fromUserId_fkey"
+  FOREIGN KEY ("fromUserId") REFERENCES "User"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Add foreign key: UserVoteInteraction.toUserId -> User.id
+ALTER TABLE "UserVoteInteraction"
+  ADD CONSTRAINT "UserVoteInteraction_toUserId_fkey"
+  FOREIGN KEY ("toUserId") REFERENCES "User"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -105,20 +105,6 @@ model SyncExecutionLock {
   @@index([expiresAt])
 }
 
-model DirtyPageBackup {
-  pageId      Int?
-  needPhaseB  Boolean?
-  needPhaseC  Boolean?
-  reasons     String[]
-  donePhaseB  Boolean?
-  donePhaseC  Boolean?
-  createdAt   DateTime?
-  updatedAt   DateTime?
-  url         String?
-  backup_time DateTime?
-  id          Int       @id @default(autoincrement())
-}
-
 model Page {
   id                    Int                @id @default(autoincrement())
   wikidotId             Int                @unique
@@ -387,7 +373,6 @@ model SeriesStats {
   createdAt       DateTime @default(now())
 
   @@index([isOpen])
-  @@index([seriesNumber])
   @@index([usagePercentage])
 }
 
@@ -404,7 +389,6 @@ model SiteStats {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
-  @@index([date])
 }
 
 model SourceVersion {
@@ -453,6 +437,9 @@ model User {
   metricPreferences                UserMetricPreference[]
   collections                      UserCollection[]
   collectionAccountOwner           CollectionAccountOwner?
+  tagPreferences                   UserTagPreference[]
+  voteInteractionsFrom             UserVoteInteraction[]   @relation("UserVoteInteractionFrom")
+  voteInteractionsTo               UserVoteInteraction[]   @relation("UserVoteInteractionTo")
   forumAlertsReceived              ForumInteractionAlert[] @relation("ForumInteractionAlertRecipient")
   forumAlertsTriggered             ForumInteractionAlert[] @relation("ForumInteractionAlertActor")
 
@@ -581,6 +568,7 @@ model UserTagPreference {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
   id            Int       @id @default(autoincrement())
+  user          User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, tag])
 }
@@ -595,6 +583,8 @@ model UserVoteInteraction {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
   id            Int       @id @default(autoincrement())
+  fromUser      User      @relation("UserVoteInteractionFrom", fields: [fromUserId], references: [id], onDelete: Cascade)
+  toUser        User      @relation("UserVoteInteractionTo", fields: [toUserId], references: [id], onDelete: Cascade)
 
   @@unique([fromUserId, toUserId])
 }
@@ -766,7 +756,6 @@ model CategoryIndexTick {
   createdAt        DateTime @default(now()) @map("created_at")
 
   @@unique([category, asOfTs], map: "uniq_category_index_tick_category_as_of_ts")
-  @@index([category, asOfTs], map: "idx_category_index_tick_category_as_of_ts")
   @@index([watermarkTs], map: "idx_category_index_tick_watermark_ts")
 }
 
@@ -869,7 +858,6 @@ model LeaderboardCache {
   expiresAt DateTime?
 
   @@unique([key, period])
-  @@index([key, period])
   @@index([expiresAt])
 }
 
@@ -894,7 +882,6 @@ model SiteOverviewDaily {
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
-  @@index([date])
 }
 
 /// 标签定义表 - 存储官方标签的中英文对照

--- a/backend/scripts/clear-data.ts
+++ b/backend/scripts/clear-data.ts
@@ -229,7 +229,6 @@ async function clearAllData(prisma: PrismaClient): Promise<void> {
     { name: 'User', op: () => prisma.user.deleteMany() },
     { name: 'PageMetaStaging', op: () => prisma.pageMetaStaging.deleteMany() },
     { name: 'DirtyPage', op: () => prisma.dirtyPage.deleteMany() },
-    { name: 'DirtyPageBackup', op: () => prisma.dirtyPageBackup.deleteMany() },
   ];
   for (const { name, op } of operations) {
     console.log(`  清空 ${name}...`);

--- a/bff/src/web/routes/collections.ts
+++ b/bff/src/web/routes/collections.ts
@@ -516,6 +516,14 @@ export function collectionsRouter(pool: Pool, _redis: RedisClientType | null) {
       try {
         await client.query('BEGIN');
 
+        // Lock owner's collections to serialize concurrent isDefault changes
+        if (isDefault) {
+          await client.query(
+            'SELECT id FROM "UserCollection" WHERE "ownerId" = $1 FOR UPDATE',
+            [ownerId]
+          );
+        }
+
         const result = await client.query<any>(
           supportsTransforms
             ? `
@@ -624,6 +632,14 @@ export function collectionsRouter(pool: Pool, _redis: RedisClientType | null) {
       const client = await pool.connect();
       try {
         await client.query('BEGIN');
+
+        // Lock owner's collections to serialize concurrent isDefault changes
+        if (isDefault) {
+          await client.query(
+            'SELECT id FROM "UserCollection" WHERE "ownerId" = $1 FOR UPDATE',
+            [ownerId]
+          );
+        }
 
         const updated = await client.query<any>(
           supportsTransforms

--- a/bff/src/web/routes/collections.ts
+++ b/bff/src/web/routes/collections.ts
@@ -516,12 +516,9 @@ export function collectionsRouter(pool: Pool, _redis: RedisClientType | null) {
       try {
         await client.query('BEGIN');
 
-        // Lock owner's collections to serialize concurrent isDefault changes
+        // Advisory lock on ownerId to serialize concurrent isDefault changes
         if (isDefault) {
-          await client.query(
-            'SELECT id FROM "UserCollection" WHERE "ownerId" = $1 FOR UPDATE',
-            [ownerId]
-          );
+          await client.query('SELECT pg_advisory_xact_lock($1)', [ownerId]);
         }
 
         const result = await client.query<any>(
@@ -633,12 +630,9 @@ export function collectionsRouter(pool: Pool, _redis: RedisClientType | null) {
       try {
         await client.query('BEGIN');
 
-        // Lock owner's collections to serialize concurrent isDefault changes
+        // Advisory lock on ownerId to serialize concurrent isDefault changes
         if (isDefault) {
-          await client.query(
-            'SELECT id FROM "UserCollection" WHERE "ownerId" = $1 FOR UPDATE',
-            [ownerId]
-          );
+          await client.query('SELECT pg_advisory_xact_lock($1)', [ownerId]);
         }
 
         const updated = await client.query<any>(

--- a/bff/src/web/routes/collections.ts
+++ b/bff/src/web/routes/collections.ts
@@ -99,6 +99,7 @@ const slugify = (input: string): string => input
   .replace(/^-|-$/g, '');
 
 async function ensureUniqueSlug(pool: Pool, ownerId: number, baseSlug: string, excludeId?: number | null): Promise<string> {
+  const MAX_SLUG_ATTEMPTS = 100;
   let attempt = 0;
   let candidate = baseSlug || `collection-${Date.now().toString(36)}`;
   while (true) {
@@ -114,6 +115,9 @@ async function ensureUniqueSlug(pool: Pool, ownerId: number, baseSlug: string, e
     );
     if (rows.length === 0) return candidate;
     attempt += 1;
+    if (attempt >= MAX_SLUG_ATTEMPTS) {
+      throw new Error(`Failed to generate unique slug after ${MAX_SLUG_ATTEMPTS} attempts`);
+    }
     candidate = `${baseSlug}-${attempt}`;
   }
 }
@@ -617,91 +621,102 @@ export function collectionsRouter(pool: Pool, _redis: RedisClientType | null) {
 
       const supportsTransforms = await ensureCoverTransformColumns(pool);
 
-      const updated = await pool.query<any>(
-        supportsTransforms
-          ? `
-            UPDATE "UserCollection"
-            SET
-              title = $1,
-              slug = $2,
-              visibility = $3,
-              description = $4,
-              notes = $5,
-              "coverImageUrl" = $6,
-              "coverImageOffsetX" = $7,
-              "coverImageOffsetY" = $8,
-              "coverImageScale" = $9,
-              "isDefault" = $10,
-              "publishedAt" = CASE
-                WHEN $11::timestamptz IS NOT NULL THEN $11
-                WHEN $12::boolean IS TRUE THEN NULL
-                ELSE "publishedAt"
-              END,
-              "updatedAt" = NOW()
-            WHERE id = $13
-            RETURNING *
-          `
-          : `
-            UPDATE "UserCollection"
-            SET
-              title = $1,
-              slug = $2,
-              visibility = $3,
-              description = $4,
-              notes = $5,
-              "coverImageUrl" = $6,
-              "isDefault" = $7,
-              "publishedAt" = CASE
-                WHEN $8::timestamptz IS NOT NULL THEN $8
-                WHEN $9::boolean IS TRUE THEN NULL
-                ELSE "publishedAt"
-              END,
-              "updatedAt" = NOW()
-            WHERE id = $10
-            RETURNING *
-          `,
-        supportsTransforms
-          ? [
-              title,
-              slug,
-              visibility,
-              description,
-              notes,
-              coverImageUrl,
-              coverImageOffsetX,
-              coverImageOffsetY,
-              coverImageScale,
-              isDefault,
-              publishMoment,
-              unpublish,
-              id
-            ]
-          : [
-              title,
-              slug,
-              visibility,
-              description,
-              notes,
-              coverImageUrl,
-              isDefault,
-              publishMoment,
-              unpublish,
-              id
-            ]
-      );
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
 
-      if (isDefault) {
-        await pool.query(
-          `
-            UPDATE "UserCollection"
-            SET "isDefault" = FALSE
-            WHERE "ownerId" = $1 AND id <> $2 AND "isDefault" = TRUE
-          `,
-          [ownerId, id]
+        const updated = await client.query<any>(
+          supportsTransforms
+            ? `
+              UPDATE "UserCollection"
+              SET
+                title = $1,
+                slug = $2,
+                visibility = $3,
+                description = $4,
+                notes = $5,
+                "coverImageUrl" = $6,
+                "coverImageOffsetX" = $7,
+                "coverImageOffsetY" = $8,
+                "coverImageScale" = $9,
+                "isDefault" = $10,
+                "publishedAt" = CASE
+                  WHEN $11::timestamptz IS NOT NULL THEN $11
+                  WHEN $12::boolean IS TRUE THEN NULL
+                  ELSE "publishedAt"
+                END,
+                "updatedAt" = NOW()
+              WHERE id = $13
+              RETURNING *
+            `
+            : `
+              UPDATE "UserCollection"
+              SET
+                title = $1,
+                slug = $2,
+                visibility = $3,
+                description = $4,
+                notes = $5,
+                "coverImageUrl" = $6,
+                "isDefault" = $7,
+                "publishedAt" = CASE
+                  WHEN $8::timestamptz IS NOT NULL THEN $8
+                  WHEN $9::boolean IS TRUE THEN NULL
+                  ELSE "publishedAt"
+                END,
+                "updatedAt" = NOW()
+              WHERE id = $10
+              RETURNING *
+            `,
+          supportsTransforms
+            ? [
+                title,
+                slug,
+                visibility,
+                description,
+                notes,
+                coverImageUrl,
+                coverImageOffsetX,
+                coverImageOffsetY,
+                coverImageScale,
+                isDefault,
+                publishMoment,
+                unpublish,
+                id
+              ]
+            : [
+                title,
+                slug,
+                visibility,
+                description,
+                notes,
+                coverImageUrl,
+                isDefault,
+                publishMoment,
+                unpublish,
+                id
+              ]
         );
-      }
 
-      res.json({ ok: true, collection: mapCollectionRow(updated.rows[0]) });
+        if (isDefault) {
+          await client.query(
+            `
+              UPDATE "UserCollection"
+              SET "isDefault" = FALSE
+              WHERE "ownerId" = $1 AND id <> $2 AND "isDefault" = TRUE
+            `,
+            [ownerId, id]
+          );
+        }
+
+        await client.query('COMMIT');
+        res.json({ ok: true, collection: mapCollectionRow(updated.rows[0]) });
+      } catch (txErr) {
+        await client.query('ROLLBACK').catch(() => {});
+        throw txErr;
+      } finally {
+        client.release();
+      }
     } catch (error) {
       next(error);
     }

--- a/bff/tests/collections.test.ts
+++ b/bff/tests/collections.test.ts
@@ -96,6 +96,7 @@ describe('Collections routes', () => {
           { column_name: 'coverImageScale' }
         ]
       })
+      .mockResolvedValueOnce({}) // BEGIN
       .mockResolvedValueOnce({
         rows: [{
           id: 2,
@@ -115,7 +116,8 @@ describe('Collections routes', () => {
           updatedAt: '2024-01-01T00:00:00.000Z',
           itemCount: 0
         }]
-      });
+      })
+      .mockResolvedValueOnce({}); // COMMIT
 
     const app = await createServer();
     const res = await request(app)
@@ -125,7 +127,7 @@ describe('Collections routes', () => {
 
     expect(res.body.ok).toBe(true);
     expect(res.body.collection.slug).toBe('xin-shoucangjia');
-    expect(queryMock).toHaveBeenCalledTimes(5);
+    expect(queryMock).toHaveBeenCalledTimes(7);
   });
 
   test('GET /collections/:id returns detail with items', async () => {

--- a/user-backend/prisma/migrations/20260324000000_remove_gacha_wallet_redundant_idx/migration.sql
+++ b/user-backend/prisma/migrations/20260324000000_remove_gacha_wallet_redundant_idx/migration.sql
@@ -1,0 +1,2 @@
+-- Remove redundant index on GachaWallet.userId (userId already has @unique constraint)
+DROP INDEX IF EXISTS "GachaWallet_userId_idx";

--- a/user-backend/prisma/schema.prisma
+++ b/user-backend/prisma/schema.prisma
@@ -140,8 +140,6 @@ model GachaWallet {
   updatedAt        DateTime     @updatedAt
   user             UserAccount  @relation(fields: [userId], references: [id], onDelete: Cascade)
   ledgerEntries    GachaLedgerEntry[]
-
-  @@index([userId])
 }
 
 model GachaPool {


### PR DESCRIPTION
## Summary

- 移除 6 个冗余 `@@index`（与已有 `@unique` / `@@unique` 重复）：
  - backend: `SiteStats(date)`, `SiteOverviewDaily(date)`, `LeaderboardCache(key,period)`, `SeriesStats(seriesNumber)`, `CategoryIndexTick(category,asOfTs)`
  - user-backend: `GachaWallet(userId)`
- 为 `UserTagPreference.userId`、`UserVoteInteraction.fromUserId/toUserId` 添加到 `User` 表的外键关联（含孤儿数据清理）
- 删除废弃的 `DirtyPageBackup` 模型及 `clear-data.ts` 中的引用
- `collections` PATCH 路由的 UPDATE + isDefault 清除操作包裹在数据库事务中
- `ensureUniqueSlug` 添加 100 次最大重试限制，防止无限循环

## 迁移说明

- **backend**: `20260324000000_cleanup_schema` — DROP 冗余索引、DROP DirtyPageBackup 表、清理孤儿数据后 ADD FOREIGN KEY
- **user-backend**: `20260324000000_remove_gacha_wallet_redundant_idx` — DROP 冗余索引
- 迁移已创建但未在生产环境执行，需手动 `prisma migrate deploy`

## 验证

- [x] `npx prisma validate` 通过 (backend + user-backend)
- [x] `npx prisma generate` 通过 (backend)
- [x] `npx tsc --noEmit` 无新增错误 (backend src/)
- [x] `npm run build` + `npx tsc --noEmit` 通过 (bff)

## Test plan

- [ ] 在 staging 环境执行 `prisma migrate deploy` 验证迁移成功
- [ ] 确认外键约束生效：尝试插入不存在 userId 的 UserTagPreference 记录应失败
- [ ] 测试 collections PATCH 接口的 isDefault 切换是否原子性
- [ ] 测试 ensureUniqueSlug 在大量重复时是否正确抛出错误