### PR TITLE
refactor: 提取重复代码、统一缓存、修复同步 I/O

### DIFF
--- a/bff/src/web/routes/internal.ts
+++ b/bff/src/web/routes/internal.ts
@@ -5,7 +5,7 @@ import { createCache } from '../utils/cache.js';
 export function internalRouter() {
   const router = Router();
   const readPool = getReadPoolSync();
-  const cache = createCache(null, 'internal:');
+  const cache = createCache(null, 'internal:', { isolatedMemory: true, maxMemorySize: 400 });
   const MARKET_CATEGORIES = ['OVERALL', 'TRANSLATION', 'SCP', 'TALE', 'GOI', 'WANDERERS'] as const;
   type MarketCategory = typeof MARKET_CATEGORIES[number];
   type MarketTickRow = {

--- a/bff/src/web/routes/internal.ts
+++ b/bff/src/web/routes/internal.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import { getReadPoolSync } from '../utils/dbPool.js';
+import { createCache } from '../utils/cache.js';
 
 export function internalRouter() {
   const router = Router();
   const readPool = getReadPoolSync();
+  const cache = createCache(null, 'internal:');
   const MARKET_CATEGORIES = ['OVERALL', 'TRANSLATION', 'SCP', 'TALE', 'GOI', 'WANDERERS'] as const;
   type MarketCategory = typeof MARKET_CATEGORIES[number];
   type MarketTickRow = {
@@ -16,10 +18,7 @@ export function internalRouter() {
     crowdDrag: string | null;
     createdAt: Date;
   };
-  const MARKET_TICK_CACHE_TTL_MS = 8_000;
-  const SHORT_CACHE_MAX_ENTRIES = 400;
-  const marketTicksCache = new Map<string, { expiresAt: number; payload: any }>();
-  const marketPriceAtCache = new Map<string, { expiresAt: number; payload: any }>();
+  const MARKET_TICK_CACHE_TTL_S = 8;
 
   type WikidotUserRow = {
     wikidotId: number | null;
@@ -60,42 +59,6 @@ export function internalRouter() {
     const date = new Date(input);
     date.setUTCMinutes(0, 0, 0);
     return date.toISOString();
-  };
-
-  const pruneShortCache = <T,>(cache: Map<string, { expiresAt: number; payload: T }>) => {
-    const nowMs = Date.now();
-    for (const [key, entry] of cache.entries()) {
-      if (entry.expiresAt <= nowMs) {
-        cache.delete(key);
-      }
-    }
-    while (cache.size >= SHORT_CACHE_MAX_ENTRIES) {
-      const oldestKey = cache.keys().next().value;
-      if (!oldestKey) break;
-      cache.delete(oldestKey);
-    }
-  };
-
-  const readShortCache = <T,>(cache: Map<string, { expiresAt: number; payload: T }>, key: string): T | null => {
-    const nowMs = Date.now();
-    if (cache.size > SHORT_CACHE_MAX_ENTRIES) {
-      pruneShortCache(cache);
-    }
-    const hit = cache.get(key);
-    if (!hit) return null;
-    if (hit.expiresAt <= nowMs) {
-      cache.delete(key);
-      return null;
-    }
-    return hit.payload;
-  };
-
-  const writeShortCache = <T,>(cache: Map<string, { expiresAt: number; payload: T }>, key: string, payload: T) => {
-    pruneShortCache(cache);
-    cache.set(key, {
-      expiresAt: Date.now() + MARKET_TICK_CACHE_TTL_MS,
-      payload
-    });
   };
 
   async function findUserByWikidotId(wikidotId: number): Promise<WikidotUserRow | null> {
@@ -337,8 +300,8 @@ export function internalRouter() {
       const asOfDate = asOfRaw ? new Date(asOfRaw) : null;
       const asOfTs = asOfDate && !Number.isNaN(asOfDate.getTime()) ? asOfDate : new Date();
 
-      const cacheKey = `${category}:${limit}:${floorHourIso(asOfTs)}`;
-      const cached = readShortCache(marketTicksCache, cacheKey);
+      const cacheKey = `ticks:${category}:${limit}:${floorHourIso(asOfTs)}`;
+      const cached = await cache.getJSON(cacheKey);
       if (cached) {
         return res.json(cached);
       }
@@ -376,7 +339,7 @@ export function internalRouter() {
           createdAt: row.createdAt.toISOString()
         }))
       };
-      writeShortCache(marketTicksCache, cacheKey, payload);
+      await cache.setJSON(cacheKey, payload, MARKET_TICK_CACHE_TTL_S);
       return res.json(payload);
     } catch (err) {
       next(err);
@@ -399,8 +362,8 @@ export function internalRouter() {
         return res.status(400).json({ error: 'ts_invalid' });
       }
 
-      const cacheKey = `${category}:${floorHourIso(ts)}`;
-      const cached = readShortCache(marketPriceAtCache, cacheKey);
+      const cacheKey = `price:${category}:${floorHourIso(ts)}`;
+      const cached = await cache.getJSON(cacheKey);
       if (cached) {
         return res.json(cached);
       }
@@ -439,7 +402,7 @@ export function internalRouter() {
           createdAt: row.createdAt.toISOString()
         }
       };
-      writeShortCache(marketPriceAtCache, cacheKey, payload);
+      await cache.setJSON(cacheKey, payload, MARKET_TICK_CACHE_TTL_S);
       return res.json(payload);
     } catch (err) {
       next(err);

--- a/bff/src/web/routes/pages.ts
+++ b/bff/src/web/routes/pages.ts
@@ -5,6 +5,7 @@ import { extractPreviewCandidates, pickPreview, toPreviewPick, extractExcerptFal
 import { buildPageImagePath } from '../pageImagesConfig.js';
 import { createCache } from '../utils/cache.js';
 import { getReadPoolSync } from '../utils/dbPool.js';
+import { parsePositiveInt } from '../utils/helpers.js';
 
 export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
   const router = Router();
@@ -12,13 +13,6 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
 
   // 读写分离：pages 全部是读操作，使用从库
   const readPool = getReadPoolSync(pool);
-  const parsePositiveInt = (value: unknown): number | null => {
-    const parsed = Number(value);
-    if (!Number.isInteger(parsed) || parsed <= 0) {
-      return null;
-    }
-    return parsed;
-  };
 
   router.param('wikidotId', (req, res, next, value) => {
     if (parsePositiveInt(value) === null) {

--- a/bff/src/web/routes/search.ts
+++ b/bff/src/web/routes/search.ts
@@ -2,6 +2,8 @@ import { Router } from 'express';
 import type { Pool } from 'pg';
 import type { RedisClientType } from 'redis';
 import { getReadPoolSync } from '../utils/dbPool.js';
+import { createCache } from '../utils/cache.js';
+import { extractExcerpt, escapeHtml } from '../utils/helpers.js';
 
 const CACHE_VERSION = 'v4';
 
@@ -46,6 +48,7 @@ type PageSearchResult = {
 
 export function searchRouter(pool: Pool, redis: RedisClientType | null) {
   const router = Router();
+  const cache = createCache(redis, 'scpcn:search:');
 
   // 读写分离：search 全部是读操作，使用从库
   const readPool = getReadPoolSync(pool);
@@ -82,27 +85,6 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
       .sort()
       .join('&');
     return `${prefix}:${CACHE_VERSION}:${normalized}`;
-  }
-
-  async function readCache<T>(key: string | null): Promise<T | null> {
-    if (!redis || !key) return null;
-    try {
-      const cached = await redis.get(key);
-      if (!cached) return null;
-      return JSON.parse(cached) as T;
-    } catch (err) {
-      console.warn('[search-cache] Failed to read cache:', err);
-      return null;
-    }
-  }
-
-  async function writeCache<T>(key: string | null, payload: T, ttlSeconds: number): Promise<void> {
-    if (!redis || !key || ttlSeconds <= 0) return;
-    try {
-      await redis.set(key, JSON.stringify(payload), { EX: ttlSeconds });
-    } catch (err) {
-      console.warn('[search-cache] Failed to write cache:', err);
-    }
   }
 
   const parseNullableInt = (value: unknown): number | null => {
@@ -202,36 +184,6 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
     } finally {
       client.release();
     }
-  }
-
-  function extractExcerpt(textContent: string | null, maxLength = 160): string | null {
-    if (!textContent) return null;
-    const cleanText = textContent
-      .replace(/\[\[[^\]]*\]\]/g, '')
-      .replace(/\{\{[^}]*\}\}/g, '')
-      .replace(/<[^>]+>/g, '')
-      .replace(/^[#*\-+>|\s]+/gm, '')
-      .replace(/\n+/g, ' ')
-      .replace(/\s{2,}/g, ' ')
-      .trim();
-
-    if (!cleanText) return null;
-
-    const sentences = (cleanText.match(/[^。！？.!?]+[。！？.!?]+/g) || [])
-      .map((s) => s.trim())
-      .filter((s) => s.length > 12);
-    const chosen = sentences.length > 0 ? sentences[Math.floor(Math.random() * sentences.length)] : cleanText;
-    const normalized = chosen.trim();
-    if (!normalized) return null;
-
-    if (normalized.length <= maxLength) {
-      return normalized;
-    }
-    return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
-  }
-
-  function escapeHtml(str: string): string {
-    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   }
 
   /**
@@ -1426,7 +1378,7 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
         hasQuery ? 'search:pages:query' : 'search:pages:filters',
         cacheParamsBase
       );
-      const cached = await readCache<{ results: any[]; total?: number }>(cacheKey);
+      const cached = cacheKey ? await cache.getJSON<{ results: any[]; total?: number }>(cacheKey) : null;
       if (cached) {
         return res.json(cached);
       }
@@ -1470,7 +1422,7 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
         ? { results: pageData.results, total: pageData.total }
         : { results: pageData.results };
 
-      await writeCache(cacheKey, payload, defaultCacheTtl);
+      if (cacheKey && defaultCacheTtl > 0) await cache.setJSON(cacheKey, payload, defaultCacheTtl);
       return res.json(payload);
     } catch (err: any) {
       if (regexMode && err?.code === '2201B') {
@@ -1661,10 +1613,10 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
         includeDate: wantDate,
         exactTags: enforceExactTags
       });
-      const cached = await readCache<{
+      const cached = cacheKey ? await cache.getJSON<{
         results: any[];
         meta: { counts: { pages: number; users: number }; usedCaps: { pageLimit: number; userLimit: number }; orderBy: string };
-      }>(cacheKey);
+      }>(cacheKey) : null;
       if (cached) {
         return res.json(cached);
       }
@@ -1834,7 +1786,7 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
         }
       };
 
-      await writeCache(cacheKey, payload, defaultCacheTtl);
+      if (cacheKey && defaultCacheTtl > 0) await cache.setJSON(cacheKey, payload, defaultCacheTtl);
       res.json(payload);
     } catch (err) {
       next(err);

--- a/bff/src/web/routes/stats.ts
+++ b/bff/src/web/routes/stats.ts
@@ -4,14 +4,7 @@ import type { RedisClientType } from 'redis';
 import { consola } from 'consola';
 import { createCache } from '../utils/cache.js';
 import { getReadPoolSync } from '../utils/dbPool.js';
-
-function parsePositiveInt(value: unknown): number | null {
-	const parsed = Number(value);
-	if (!Number.isInteger(parsed) || parsed <= 0) {
-		return null;
-	}
-	return parsed;
-}
+import { parsePositiveInt } from '../utils/helpers.js';
 
 export function statsRouter(pool: Pool, redis: RedisClientType | null) {
 	const router = Router();

--- a/bff/src/web/routes/text-analysis.ts
+++ b/bff/src/web/routes/text-analysis.ts
@@ -21,6 +21,7 @@ const DATA_DIR = (() => {
 
 // In-memory cache: { data, loadedAt }
 const cache = new Map<string, { data: any; loadedAt: number }>();
+const inflight = new Map<string, Promise<any>>();
 const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
 async function loadJSON(filename: string): Promise<any> {
@@ -31,16 +32,26 @@ async function loadJSON(filename: string): Promise<any> {
     return cached.data;
   }
 
-  const filePath = path.join(DATA_DIR, filename);
-  try {
-    const raw = await fs.readFile(filePath, 'utf8');
-    const data = JSON.parse(raw);
-    cache.set(key, { data, loadedAt: now });
-    return data;
-  } catch (err: any) {
-    if (err?.code === 'ENOENT') return null;
-    throw err;
-  }
+  // Deduplicate concurrent loads for the same file
+  const pending = inflight.get(key);
+  if (pending) return pending;
+
+  const promise = (async () => {
+    try {
+      const filePath = path.join(DATA_DIR, filename);
+      const raw = await fs.readFile(filePath, 'utf8');
+      const data = JSON.parse(raw);
+      cache.set(key, { data, loadedAt: Date.now() });
+      return data;
+    } catch (err: any) {
+      if (err?.code === 'ENOENT') return null;
+      throw err;
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+  inflight.set(key, promise);
+  return promise;
 }
 
 function jsonEndpoint(filename: string) {

--- a/bff/src/web/routes/text-analysis.ts
+++ b/bff/src/web/routes/text-analysis.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
+import fsSyncForInit from 'node:fs';
 import path from 'node:path';
 
 const DATA_DIR = (() => {
@@ -10,7 +11,7 @@ const DATA_DIR = (() => {
   ].filter((value): value is string => Boolean(value));
 
   for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) {
+    if (fsSyncForInit.existsSync(candidate)) {
       return candidate;
     }
   }
@@ -22,7 +23,7 @@ const DATA_DIR = (() => {
 const cache = new Map<string, { data: any; loadedAt: number }>();
 const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
-function loadJSON(filename: string): any {
+async function loadJSON(filename: string): Promise<any> {
   const key = filename;
   const now = Date.now();
   const cached = cache.get(key);
@@ -31,20 +32,21 @@ function loadJSON(filename: string): any {
   }
 
   const filePath = path.join(DATA_DIR, filename);
-  if (!fs.existsSync(filePath)) {
-    return null;
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const data = JSON.parse(raw);
+    cache.set(key, { data, loadedAt: now });
+    return data;
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return null;
+    throw err;
   }
-
-  const raw = fs.readFileSync(filePath, 'utf8');
-  const data = JSON.parse(raw);
-  cache.set(key, { data, loadedAt: now });
-  return data;
 }
 
 function jsonEndpoint(filename: string) {
-  return (_req: any, res: any, next: any) => {
+  return async (_req: any, res: any, next: any) => {
     try {
-      const data = loadJSON(filename);
+      const data = await loadJSON(filename);
       if (data === null) {
         return res.status(404).json({ error: 'data_not_generated', message: `${filename} not found. Run the text-analysis pipeline first.` });
       }
@@ -56,9 +58,9 @@ function jsonEndpoint(filename: string) {
 }
 
 function paginatedEndpoint(filename: string, defaultLimit = 100) {
-  return (req: any, res: any, next: any) => {
+  return async (req: any, res: any, next: any) => {
     try {
-      const data = loadJSON(filename);
+      const data = await loadJSON(filename);
       if (data === null) {
         return res.status(404).json({ error: 'data_not_generated' });
       }

--- a/bff/src/web/utils/cache.ts
+++ b/bff/src/web/utils/cache.ts
@@ -20,43 +20,56 @@ const DEFAULT_PREFIX = 'scpcn:bff:';
 const memoryCache = new Map<string, { value: unknown; expiresAt: number }>();
 const MAX_MEMORY_CACHE_SIZE = 1000;
 
-function memoryGet<T>(key: string): T | null {
-  const entry = memoryCache.get(key);
+type MemoryStore = Map<string, { value: unknown; expiresAt: number }>;
+
+function memoryGet<T>(store: MemoryStore, key: string): T | null {
+  const entry = store.get(key);
   if (!entry) return null;
   if (Date.now() > entry.expiresAt) {
-    memoryCache.delete(key);
+    store.delete(key);
     return null;
   }
   return entry.value as T;
 }
 
-function memorySet(key: string, value: unknown, ttlSeconds: number): void {
+function memorySet(store: MemoryStore, maxSize: number, key: string, value: unknown, ttlSeconds: number): void {
   // Evict old entries if cache is too large
-  if (memoryCache.size >= MAX_MEMORY_CACHE_SIZE) {
+  if (store.size >= maxSize) {
     const now = Date.now();
-    for (const [k, v] of memoryCache) {
-      if (v.expiresAt < now) memoryCache.delete(k);
+    for (const [k, v] of store) {
+      if (v.expiresAt < now) store.delete(k);
     }
     // If still too large, delete oldest entries
-    if (memoryCache.size >= MAX_MEMORY_CACHE_SIZE) {
-      const keysToDelete = Array.from(memoryCache.keys()).slice(0, 100);
-      keysToDelete.forEach(k => memoryCache.delete(k));
+    if (store.size >= maxSize) {
+      const keysToDelete = Array.from(store.keys()).slice(0, 100);
+      keysToDelete.forEach(k => store.delete(k));
     }
   }
-  memoryCache.set(key, { value, expiresAt: Date.now() + ttlSeconds * 1000 });
+  store.set(key, { value, expiresAt: Date.now() + ttlSeconds * 1000 });
 }
 
-export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREFIX): CacheHandle {
+type CreateCacheOptions = {
+  /** Use an isolated in-memory store instead of the shared global one */
+  isolatedMemory?: boolean;
+  /** Max entries for isolated memory store (default: MAX_MEMORY_CACHE_SIZE) */
+  maxMemorySize?: number;
+};
+
+export function createCache(redis: RedisClientType | null, prefix?: string, options?: CreateCacheOptions): CacheHandle;
+export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREFIX, options: CreateCacheOptions = {}): CacheHandle {
   // In-flight loader deduplication (singleflight) to prevent thundering herd
   const inflight = new Map<string, Promise<unknown>>();
 
+  const maxSize = options.maxMemorySize ?? MAX_MEMORY_CACHE_SIZE;
+
   if (!redis) {
+    const store: MemoryStore = options.isolatedMemory ? new Map() : memoryCache;
     // Use in-memory cache as fallback when Redis is unavailable
     return {
       enabled: true, // Memory cache is still caching
-      async remember<T>(key: string, ttl: number, loader: Loader<T>, options?: RememberOptions): Promise<T> {
+      async remember<T>(key: string, ttl: number, loader: Loader<T>, opts?: RememberOptions): Promise<T> {
         const fullKey = `${prefix}${key}`;
-        const cached = memoryGet<T>(fullKey);
+        const cached = memoryGet<T>(store, fullKey);
         if (cached !== null) return cached;
 
         // Deduplicate concurrent loads for the same key
@@ -67,8 +80,8 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
           try {
             const result = await loader();
             if (result === undefined) return result;
-            if (result === null && options?.cacheNull !== true) return result;
-            memorySet(fullKey, result, ttl);
+            if (result === null && opts?.cacheNull !== true) return result;
+            memorySet(store, maxSize, fullKey, result, ttl);
             return result;
           } finally {
             inflight.delete(fullKey);
@@ -78,11 +91,11 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
         return promise as Promise<T>;
       },
       async getJSON<T>(key: string): Promise<T | null> {
-        return memoryGet<T>(`${prefix}${key}`);
+        return memoryGet<T>(store, `${prefix}${key}`);
       },
       async setJSON(key: string, value: unknown, ttlSeconds: number): Promise<void> {
         if (value !== undefined) {
-          memorySet(`${prefix}${key}`, value, ttlSeconds);
+          memorySet(store, maxSize, `${prefix}${key}`, value, ttlSeconds);
         }
       }
     };

--- a/bff/src/web/utils/helpers.ts
+++ b/bff/src/web/utils/helpers.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared helper functions used across multiple BFF route modules.
+ */
+
+/**
+ * Parse a value as a positive integer (> 0). Returns null if invalid.
+ */
+export function parsePositiveInt(value: unknown): number | null {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * Extract a plain-text excerpt from wiki/HTML content.
+ * Strips markup, picks a random sentence, and truncates to maxLength.
+ */
+export function extractExcerpt(textContent: string | null | undefined, maxLength = 160): string | null {
+  if (!textContent) return null;
+  const cleanText = String(textContent)
+    .replace(/\[\[[^\]]*\]\]/g, '')
+    .replace(/\{\{[^}]*\}\}/g, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/^[#*\-+>|\s]+/gm, '')
+    .replace(/\n+/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+
+  if (!cleanText) return null;
+
+  const sentences = (cleanText.match(/[^。！？.!?]+[。！？.!?]+/g) || [])
+    .map((s) => s.trim())
+    .filter((s) => s.length > 12);
+  const chosen = sentences.length > 0 ? sentences[Math.floor(Math.random() * sentences.length)] : cleanText;
+  const normalized = chosen.trim();
+  if (!normalized) return null;
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+/**
+ * Escape HTML special characters to prevent XSS.
+ */
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/bff/src/web/utils/preview.ts
+++ b/bff/src/web/utils/preview.ts
@@ -4,6 +4,8 @@
 //   SCPPER_CN_PREVIEW_BEGIN(meta: ... ) ... SCPPER_CN_PREVIEW_END
 //   Content may be wrapped by /* ... */ or { ... } and will be unwrapped.
 
+import { escapeHtml as _escapeHtml } from './helpers.js';
+
 export type PreviewPick = {
   text: string;
   html: string;
@@ -113,18 +115,11 @@ export function pickPreview(items: string[], seed?: string | number): string | n
   return items[idx] || null;
 }
 
-export function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
+export { escapeHtml } from './helpers.js';
 
 export function toPreviewPick(text: string): PreviewPick {
   const trimmed = text.trim();
-  const html = escapeHtml(trimmed).replace(/\n/g, '<br>');
+  const html = _escapeHtml(trimmed).replace(/\n/g, '<br>');
   return { text: trimmed, html };
 }
 

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -182,56 +182,6 @@ onBeforeUnmount(() => {
   relativeTimer = null
 })
 
-function parseDateInput(input?: string | Date | null): Date | null {
-  if (!input) return null
-  const d = new Date(input as any)
-  if (isNaN(d.getTime())) return null
-  return d
-}
-
-function formatToGmt8Full(input?: string | Date | null): string {
-  const d = parseDateInput(input)
-  if (!d) return '—'
-  const parts = new Intl.DateTimeFormat('zh-CN', {
-    timeZone: 'Asia/Shanghai',
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
-  }).formatToParts(d)
-  const get = (type: string) => parts.find(p => p.type === type)?.value || ''
-  const y = get('year')
-  const M = get('month')
-  const D = get('day')
-  const h = get('hour')
-  const m = get('minute')
-  const s = get('second')
-  return `${y}-${M}-${D} ${h}:${m}:${s} GMT+8`
-}
-
-function chineseNum(n: number, unit: string): string {
-  if (n === 1) return `一${unit}前`
-  if (n === 2) return `两${unit}前`
-  return `${n}${unit}前`
-}
-
-function formatRelativeZh(input?: string | Date | null, nowMs = Date.now()): string {
-  const d = parseDateInput(input)
-  if (!d) return '—'
-  const diffMs = nowMs - d.getTime()
-  if (diffMs < -60_000) return formatToGmt8Full(d)
-  const diffSec = Math.max(0, Math.floor(diffMs / 1000))
-  if (diffSec < 60) return '刚刚'
-  const mins = Math.floor(diffSec / 60)
-  if (mins < 60) return chineseNum(mins, '分钟')
-  const hours = Math.floor(mins / 60)
-  if (hours < 24) return chineseNum(hours, '小时')
-  const days = Math.floor(hours / 24)
-  if (days < 30) return chineseNum(days, '天')
-  const months = Math.floor(days / 30)
-  if (months < 12) return chineseNum(months, '个月')
-  const years = Math.floor(days / 365)
-  return chineseNum(years, '年')
-}
-
 const overviewUpdatedAtRaw = computed(() => (overview.value as any)?.updatedAt || (overview.value as any)?.date || null)
 const overviewUpdatedAtFull = computed(() => formatToGmt8Full(overviewUpdatedAtRaw.value))
 const overviewUpdatedAtRelative = computed(() => mounted.value

--- a/frontend/pages/page/[wikidotId]/index.vue
+++ b/frontend/pages/page/[wikidotId]/index.vue
@@ -1921,16 +1921,6 @@ function formatDateCompact(dateStr: string) {
   if (!dateStr) return ''
   return formatDateIsoUtc8(dateStr)
 }
-function formatRelativeTime(dateStr: string) {
-  if (!dateStr) return ''
-  const diffDays = diffUtc8CalendarDays(new Date(), dateStr)
-  if (diffDays == null) return ''
-  if (diffDays === 0) return '今天'
-  if (diffDays === 1) return '昨天'
-  if (diffDays < 30) return `${diffDays} 天前`
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)} 个月前`
-  return `${Math.floor(diffDays / 365)} 年前`
-}
 
 function formatRevisionType(type: string) {
   const map:Record<string,string> = {

--- a/frontend/pages/sample/index.vue
+++ b/frontend/pages/sample/index.vue
@@ -476,9 +476,14 @@ const mounted = ref(false)
 onMounted(() => { mounted.value = true })
 
 function formatRelativeZhShort(input?: string | Date | null): string {
-  const result = formatRelativeZh(input)
-  if (result.includes('个月') || result.includes('年')) return '很久以前'
-  return result
+  if (!input) return '—'
+  const d = new Date(input as any)
+  if (isNaN(d.getTime())) return '—'
+  const diffMs = Date.now() - d.getTime()
+  // Original behavior: future timestamps clamped to "刚刚", >=30 days to "很久以前"
+  if (diffMs < 0) return '刚刚'
+  if (diffMs >= 30 * 86400_000) return '很久以前'
+  return formatRelativeZh(input)
 }
 
 const overviewUpdatedAtRelative = computed(() => mounted.value ? formatRelativeZhShort(overview.value.updatedAt) : '...')

--- a/frontend/pages/sample/index.vue
+++ b/frontend/pages/sample/index.vue
@@ -475,34 +475,6 @@ function formatNumber(num: number): string {
 const mounted = ref(false)
 onMounted(() => { mounted.value = true })
 
-function parseDateInput(input?: string | Date | null): Date | null {
-  if (!input) return null
-  const d = new Date(input as any)
-  if (isNaN(d.getTime())) return null
-  return d
-}
-
-function chineseNum(n: number, unit: string): string {
-  if (n === 1) return `一${unit}前`
-  if (n === 2) return `两${unit}前`
-  return `${n}${unit}前`
-}
-
-function formatRelativeZh(input?: string | Date | null): string {
-  const d = parseDateInput(input)
-  if (!d) return '—'
-  const now = Date.now()
-  const diffSec = Math.max(0, Math.floor((now - d.getTime()) / 1000))
-  if (diffSec < 60) return '刚刚'
-  const mins = Math.floor(diffSec / 60)
-  if (mins < 60) return chineseNum(mins, '分钟')
-  const hours = Math.floor(mins / 60)
-  if (hours < 24) return chineseNum(hours, '小时')
-  const days = Math.floor(hours / 24)
-  if (days < 30) return chineseNum(days, '天')
-  return '很久以前'
-}
-
 const overviewUpdatedAtRelative = computed(() => mounted.value ? formatRelativeZh(overview.value.updatedAt) : '...')
 
 const onHeroSearch = () => {

--- a/frontend/pages/sample/index.vue
+++ b/frontend/pages/sample/index.vue
@@ -475,7 +475,13 @@ function formatNumber(num: number): string {
 const mounted = ref(false)
 onMounted(() => { mounted.value = true })
 
-const overviewUpdatedAtRelative = computed(() => mounted.value ? formatRelativeZh(overview.value.updatedAt) : '...')
+function formatRelativeZhShort(input?: string | Date | null): string {
+  const result = formatRelativeZh(input)
+  if (result.includes('个月') || result.includes('年')) return '很久以前'
+  return result
+}
+
+const overviewUpdatedAtRelative = computed(() => mounted.value ? formatRelativeZhShort(overview.value.updatedAt) : '...')
 
 const onHeroSearch = () => {
   const q = heroQuery.value.trim()

--- a/frontend/pages/user/[wikidotId].vue
+++ b/frontend/pages/user/[wikidotId].vue
@@ -1364,16 +1364,6 @@ function formatDate(dateStr: string) {
   }) || 'N/A';
 }
 
-function formatRelativeTime(dateStr: string) {
-  if (!dateStr) return '';
-  const diffDays = diffUtc8CalendarDays(nowUtc8(), dateStr);
-  if (diffDays == null) return '';
-  if (diffDays === 0) return '今天';
-  if (diffDays === 1) return '昨天';
-  if (diffDays < 30) return `${diffDays} 天前`;
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)} 个月前`;
-  return `${Math.floor(diffDays / 365)} 年前`;
-}
 
 function formatActivityType(type: string) {
   const typeMap: Record<string, string> = {

--- a/frontend/utils/dateFormat.ts
+++ b/frontend/utils/dateFormat.ts
@@ -1,0 +1,75 @@
+import { diffUtc8CalendarDays, nowUtc8 } from './timezone';
+
+type DateLike = string | Date | null | undefined;
+
+function parseDateInput(input?: DateLike): Date | null {
+  if (!input) return null;
+  const d = new Date(input as any);
+  if (isNaN(d.getTime())) return null;
+  return d;
+}
+
+function chineseNum(n: number, unit: string): string {
+  if (n === 1) return `一${unit}前`;
+  if (n === 2) return `两${unit}前`;
+  return `${n}${unit}前`;
+}
+
+/**
+ * Format a date to full GMT+8 datetime string: "2025-01-15 14:30:00 GMT+8"
+ */
+export function formatToGmt8Full(input?: DateLike): string {
+  const d = parseDateInput(input);
+  if (!d) return '—';
+  const parts = new Intl.DateTimeFormat('zh-CN', {
+    timeZone: 'Asia/Shanghai',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
+  }).formatToParts(d);
+  const get = (type: string) => parts.find(p => p.type === type)?.value || '';
+  const y = get('year');
+  const M = get('month');
+  const D = get('day');
+  const h = get('hour');
+  const m = get('minute');
+  const s = get('second');
+  return `${y}-${M}-${D} ${h}:${m}:${s} GMT+8`;
+}
+
+/**
+ * Format a date as Chinese relative time: "刚刚", "一分钟前", "3小时前", etc.
+ * Falls back to full GMT+8 format for future dates.
+ */
+export function formatRelativeZh(input?: DateLike, nowMs = Date.now()): string {
+  const d = parseDateInput(input);
+  if (!d) return '—';
+  const diffMs = nowMs - d.getTime();
+  if (diffMs < -60_000) return formatToGmt8Full(d);
+  const diffSec = Math.max(0, Math.floor(diffMs / 1000));
+  if (diffSec < 60) return '刚刚';
+  const mins = Math.floor(diffSec / 60);
+  if (mins < 60) return chineseNum(mins, '分钟');
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return chineseNum(hours, '小时');
+  const days = Math.floor(hours / 24);
+  if (days < 30) return chineseNum(days, '天');
+  const months = Math.floor(days / 30);
+  if (months < 12) return chineseNum(months, '个月');
+  const years = Math.floor(days / 365);
+  return chineseNum(years, '年');
+}
+
+/**
+ * Format a date as relative day-level time: "今天", "昨天", "5 天前", "2 个月前", etc.
+ * Uses UTC+8 calendar day boundaries for diffing.
+ */
+export function formatRelativeTime(dateStr: string): string {
+  if (!dateStr) return '';
+  const diffDays = diffUtc8CalendarDays(nowUtc8(), dateStr);
+  if (diffDays == null) return '';
+  if (diffDays === 0) return '今天';
+  if (diffDays === 1) return '昨天';
+  if (diffDays < 30) return `${diffDays} 天前`;
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} 个月前`;
+  return `${Math.floor(diffDays / 365)} 年前`;
+}


### PR DESCRIPTION
## 概要

- **提取共享辅助函数**：将 `parsePositiveInt`、`extractExcerpt`、`escapeHtml` 提取到 `bff/src/web/utils/helpers.ts`，消除 `pages.ts`、`stats.ts`、`search.ts`、`preview.ts` 中的重复定义
- **统一缓存实现**：将 `search.ts` 和 `internal.ts` 的内联缓存替换为 `cache.ts` 提供的 `createCache()` 统一抽象
- **修复同步文件 I/O**：将 `text-analysis.ts` 中的 `fs.readFileSync` 改为 `fs.promises.readFile`，避免缓存未命中时阻塞事件循环
- **提取前端日期格式化**：将 `formatToGmt8Full`、`formatRelativeZh`、`formatRelativeTime` 提取到 `frontend/utils/dateFormat.ts`，消除 4 个页面文件中的重复实现

## 影响范围

- BFF：`pages.ts`、`stats.ts`、`search.ts`、`internal.ts`、`text-analysis.ts`、`preview.ts`
- Frontend：`index.vue`、`page/[wikidotId]/index.vue`、`sample/index.vue`、`user/[wikidotId].vue`

## 验证

- [x] `npm run build`（BFF）通过
- [x] `npm run build`（Frontend）通过
- [ ] 线上验证搜索、页面详情、用户页、首页功能正常