### PR TITLE
fix: 迁移 annual-summary 静态资源至 BFF 路由

### DIFF
--- a/backend/scripts/export-annual-summary.ts
+++ b/backend/scripts/export-annual-summary.ts
@@ -6,7 +6,7 @@
  * - users/index.json: user index
  * - users/{id}.json: individual user data
  *
- * Run: npx tsx scripts/export-annual-summary.ts [--year 2025] [--output ../frontend/public/annual-summary]
+ * Run: npx tsx scripts/export-annual-summary.ts [--year 2025] [--output ../bff/data/annual-summary]
  */
 
 import { prisma, disconnectPrisma } from '../src/utils/db-connection.ts';
@@ -978,7 +978,7 @@ async function loadOrGenerateUserFirsts(year: number, forceGenerate: boolean, re
   }
 }
 
-const DEFAULT_OUTPUT = path.join(process.cwd(), '..', 'frontend', 'public', 'annual-summary');
+const DEFAULT_OUTPUT = path.join(process.cwd(), '..', 'bff', 'data', 'annual-summary');
 
 interface CommandArgs {
   year: number;

--- a/bff/src/web/router.ts
+++ b/bff/src/web/router.ts
@@ -27,6 +27,7 @@ import { textAnalysisRouter } from './routes/text-analysis.js';
 import { forumsRouter } from './routes/forums.js';
 import { cssProxyRouter } from './routes/css-proxy.js';
 import { pagePreviewRouter } from './routes/page-preview.js';
+import { annualSummaryRouter } from './routes/annual-summary.js';
 
 export function buildRouter(pool: Pool, redis: RedisClientType | null) {
   const router = Router();
@@ -83,6 +84,7 @@ export function buildRouter(pool: Pool, redis: RedisClientType | null) {
   router.use('/forums', forumsRouter(pool, redis));
   router.use('/pages', pagePreviewRouter(pool));
   router.use(cssProxyRouter());
+  router.use('/annual-summary', annualSummaryRouter());
   router.use('/internal', guardInternalRoutes, internalRouter());
   router.use('/', htmlSnippetsRouter);
   router.use(PAGE_IMAGE_ROUTE_PREFIX, pageImagesRouter(pool));

--- a/bff/src/web/routes/annual-summary.ts
+++ b/bff/src/web/routes/annual-summary.ts
@@ -1,9 +1,22 @@
 import { Router } from 'express';
 import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 
-// annual-summary 数据根目录（BFF 进程 cwd 下的 data/annual-summary）
-const DATA_ROOT = path.resolve(process.cwd(), 'data', 'annual-summary');
+// annual-summary 数据根目录：兼容从 bff/ 或 repo root 启动
+const DATA_ROOT = (() => {
+  const candidates = [
+    process.env.ANNUAL_SUMMARY_DATA_DIR,
+    path.resolve(process.cwd(), 'data/annual-summary'),
+    path.resolve(process.cwd(), 'bff/data/annual-summary')
+  ].filter((v): v is string => Boolean(v));
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  return candidates[0] || path.resolve(process.cwd(), 'data/annual-summary');
+})();
 
 // 年份白名单：仅允许纯数字
 const YEAR_RE = /^\d{4}$/;

--- a/bff/src/web/routes/annual-summary.ts
+++ b/bff/src/web/routes/annual-summary.ts
@@ -1,0 +1,84 @@
+import { Router } from 'express';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+// annual-summary 数据根目录（BFF 进程 cwd 下的 data/annual-summary）
+const DATA_ROOT = path.resolve(process.cwd(), 'data', 'annual-summary');
+
+// 年份白名单：仅允许纯数字
+const YEAR_RE = /^\d{4}$/;
+// userId 白名单：仅允许纯数字（wikidot userId）
+const USER_ID_RE = /^\d+$/;
+
+const CACHE_HEADER = 'public, max-age=86400, stale-while-revalidate=604800';
+
+export function annualSummaryRouter() {
+  const router = Router();
+
+  // GET /:year/site.json
+  router.get('/:year/site.json', async (req, res) => {
+    const { year } = req.params;
+    if (!YEAR_RE.test(year)) return res.status(400).json({ error: 'invalid_year' });
+
+    const filePath = path.join(DATA_ROOT, year, 'site.json');
+    try {
+      const data = await readFile(filePath, 'utf-8');
+      res.set('Cache-Control', CACHE_HEADER);
+      res.set('Content-Type', 'application/json');
+      res.send(data);
+    } catch {
+      res.status(404).json({ error: 'not_found' });
+    }
+  });
+
+  // GET /:year/meta.json
+  router.get('/:year/meta.json', async (req, res) => {
+    const { year } = req.params;
+    if (!YEAR_RE.test(year)) return res.status(400).json({ error: 'invalid_year' });
+
+    const filePath = path.join(DATA_ROOT, year, 'meta.json');
+    try {
+      const data = await readFile(filePath, 'utf-8');
+      res.set('Cache-Control', CACHE_HEADER);
+      res.set('Content-Type', 'application/json');
+      res.send(data);
+    } catch {
+      res.status(404).json({ error: 'not_found' });
+    }
+  });
+
+  // GET /:year/users/index.json
+  router.get('/:year/users/index.json', async (req, res) => {
+    const { year } = req.params;
+    if (!YEAR_RE.test(year)) return res.status(400).json({ error: 'invalid_year' });
+
+    const filePath = path.join(DATA_ROOT, year, 'users', 'index.json');
+    try {
+      const data = await readFile(filePath, 'utf-8');
+      res.set('Cache-Control', CACHE_HEADER);
+      res.set('Content-Type', 'application/json');
+      res.send(data);
+    } catch {
+      res.status(404).json({ error: 'not_found' });
+    }
+  });
+
+  // GET /:year/users/:userId.json
+  router.get('/:year/users/:userId.json', async (req, res) => {
+    const { year, userId } = req.params;
+    if (!YEAR_RE.test(year)) return res.status(400).json({ error: 'invalid_year' });
+    if (!USER_ID_RE.test(userId)) return res.status(400).json({ error: 'invalid_user_id' });
+
+    const filePath = path.join(DATA_ROOT, year, 'users', `${userId}.json`);
+    try {
+      const data = await readFile(filePath, 'utf-8');
+      res.set('Cache-Control', CACHE_HEADER);
+      res.set('Content-Type', 'application/json');
+      res.send(data);
+    } catch {
+      res.status(404).json({ error: 'not_found' });
+    }
+  });
+
+  return router;
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -89,6 +89,7 @@ export default defineNuxtConfig({
     output: {
       dir: outputDir
     },
+    compressPublicAssets: { gzip: true, brotli: true },
     preset: 'node-server',
     // 在生产环境代理 /api 请求到 BFF 服务
     devProxy: {

--- a/frontend/pages/annual2025.vue
+++ b/frontend/pages/annual2025.vue
@@ -261,8 +261,8 @@ const progressPercent = computed(() => {
 onMounted(async () => {
   try {
     const [site, users] = await Promise.all([
-      $fetch('/annual-summary/2025/site.json'),
-      $fetch('/annual-summary/2025/users/index.json')
+      $fetch('/api/annual-summary/2025/site.json'),
+      $fetch('/api/annual-summary/2025/users/index.json')
     ])
     rawSiteData.value = site
     usersIndex.value = users
@@ -309,7 +309,7 @@ async function handleLogin() {
       return
     }
 
-    const userDataResponse = await $fetch(`/annual-summary/2025/users/${userId}.json`)
+    const userDataResponse = await $fetch(`/api/annual-summary/2025/users/${userId}.json`)
     rawUserData.value = userDataResponse
 
     isLoading.value = false


### PR DESCRIPTION
## 概要

- **annual-summary 948MB 静态数据迁移**：将 `frontend/public/annual-summary/` 下 12,876 个用户 JSON 文件改为通过 BFF API 路由提供，不再在构建时全量复制到 `.output/public`
- **启用 Nitro 公共资产预压缩**：为 `ftml_bg.wasm`（24MB）等大文件生成 gzip/brotli 压缩变体

## 改动

1. **新增 `bff/src/web/routes/annual-summary.ts`**
   - `GET /annual-summary/:year/site.json` — 站点年度数据
   - `GET /annual-summary/:year/meta.json` — 元数据
   - `GET /annual-summary/:year/users/index.json` — 用户索引
   - `GET /annual-summary/:year/users/:userId.json` — 单用户数据
   - 参数白名单校验（年份 4 位数字、userId 纯数字）
   - 长期缓存头：`max-age=86400, stale-while-revalidate=604800`

2. **`bff/src/web/router.ts`** — 注册 `/annual-summary` 路由

3. **`frontend/pages/annual2025.vue`** — `$fetch` 路径从 `/annual-summary/...` 改为 `/api/annual-summary/...`

4. **`frontend/nuxt.config.ts`** — 添加 `compressPublicAssets: { gzip: true, brotli: true }`

## 部署步骤

合并后需在生产服务器执行：

```bash
# 1. 移动数据文件（一次性操作）
mv frontend/public/annual-summary bff/data/annual-summary

# 2. 重建并重启 BFF
cd bff && npm run build && pm2 restart scpper-bff

# 3. 重建并重启前端（此次构建将不再复制 948MB 数据）
cd frontend && npm run build && pm2 restart scpper-nuxt
```

## 测试计划

- [ ] BFF 构建通过（已验证）
- [ ] 前端构建通过（已验证）
- [ ] 部署后访问 `/annual2025` 页面，确认站点数据和用户数据正常加载
- [ ] 确认 `.output/public/` 中不再包含 `annual-summary/` 目录
- [ ] 确认 WASM 文件生成了 `.gz` 和 `.br` 压缩变体