### PR TITLE
refactor: 拆分巨型前端页面为子组件

### DIFF
--- a/frontend/components/page/PageImages.vue
+++ b/frontend/components/page/PageImages.vue
@@ -1,0 +1,322 @@
+<template>
+  <section
+    v-if="pending || hasImages || error"
+    id="page-images"
+    class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm"
+  >
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div class="space-y-1">
+        <div class="flex items-center gap-2">
+          <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-200">相关图片</h3>
+          <button
+            type="button"
+            class="inline-flex h-7 w-7 items-center justify-center rounded-full border border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:text-[var(--g-accent)] hover:border-[var(--g-accent-border)] dark:text-neutral-400 dark:hover:text-[var(--g-accent)]"
+            @click="$emit('copy-anchor', 'page-images')"
+            :title="copiedAnchorId === 'page-images' ? '已复制链接' : '复制该段落链接'"
+          >
+            <LucideIcon v-if="copiedAnchorId === 'page-images'" name="Check" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
+            <LucideIcon v-else name="Link" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
+          </button>
+        </div>
+        <p v-if="hasImages" class="text-xs text-neutral-500 dark:text-neutral-400">
+          第 {{ currentPage }} / {{ totalPages }} 页 · 展示 {{ rangeLabel }} · 共 {{ images.length }} 张
+        </p>
+        <p v-else class="text-xs text-neutral-500 dark:text-neutral-400">
+          暂无可用图片资源。
+        </p>
+      </div>
+      <div v-if="hasImages" class="flex flex-wrap items-center gap-3 text-xs text-neutral-500 dark:text-neutral-400">
+        <div class="inline-flex items-center gap-2">
+          <span class="hidden sm:inline">每行数量</span>
+          <div class="inline-flex overflow-hidden rounded-full border border-neutral-200 dark:border-neutral-700 bg-neutral-100/60 dark:bg-neutral-800/60">
+            <button
+              v-for="option in sizeOptions"
+              :key="option.value"
+              type="button"
+              @click="localColumns = option.value"
+              :class="[
+                'px-3 py-1 font-medium transition-colors',
+                localColumns === option.value
+                  ? 'bg-white dark:bg-neutral-700 text-[var(--g-accent)] shadow'
+                  : 'text-neutral-600 dark:text-neutral-300 hover:text-[var(--g-accent)]'
+              ]"
+            >
+              {{ option.label }} ({{ option.value }})
+            </button>
+          </div>
+        </div>
+        <div class="inline-flex items-center gap-2">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 rounded-full border border-neutral-200 dark:border-neutral-700 px-3 py-1 text-neutral-600 dark:text-neutral-300 hover:border-[var(--g-accent)] hover:text-[var(--g-accent)] disabled:opacity-40"
+            @click="localPage = Math.max(1, localPage - 1)"
+            :disabled="localPage <= 1"
+          >上一页</button>
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 rounded-full border border-neutral-200 dark:border-neutral-700 px-3 py-1 text-neutral-600 dark:text-neutral-300 hover:border-[var(--g-accent)] hover:text-[var(--g-accent)] disabled:opacity-40"
+            @click="localPage = Math.min(totalPages, localPage + 1)"
+            :disabled="localPage >= totalPages"
+          >下一页</button>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="pending" class="mt-6 text-sm text-neutral-500 dark:text-neutral-400">正在加载图片…</div>
+    <div v-else-if="error" class="mt-6 rounded-lg border border-dashed border-neutral-300 dark:border-neutral-700 bg-neutral-50/80 dark:bg-neutral-900/60 p-6 text-sm text-neutral-600 dark:text-neutral-400">
+      加载图片失败。
+      <button type="button" class="ml-2 inline-flex items-center gap-1 text-[var(--g-accent)] hover:underline" @click="$emit('refresh')">重试</button>
+    </div>
+    <div v-else-if="hasImages" class="page-images-grid mt-4" :style="gridStyle">
+      <figure
+        v-for="img in paginatedImages"
+        :key="img.imageKey"
+        class="group space-y-2"
+      >
+        <button
+          type="button"
+          class="page-image-trigger relative w-full overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-900/40"
+          :style="img.aspectStyle"
+          :title="`放大查看：${img.label || pageDisplayTitle}`"
+          @click="openPreview(img)"
+        >
+          <img
+            :src="img.imageSrc"
+            :srcset="img.imageSrcFull && img.imageSrc ? `${img.imageSrc} 1x, ${img.imageSrcFull} 2x` : undefined"
+            :alt="img.label || pageDisplayTitle"
+            loading="lazy"
+            class="absolute inset-0 h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.03]"
+          >
+          <span class="page-image-zoom-chip">点击放大</span>
+        </button>
+        <figcaption class="flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400">
+          <span class="min-w-0 flex-1 truncate">
+            {{ img.label || '图片资源' }}
+          </span>
+          <button
+            type="button"
+            class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-neutral-200 text-neutral-500 transition hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
+            :title="copiedImageKey === img.imageKey ? '已复制图片 URL' : '复制图片 URL'"
+            @click="copyImageUrl(img)"
+          >
+            <LucideIcon
+              v-if="copiedImageKey === img.imageKey"
+              name="Check"
+              class="h-3.5 w-3.5"
+              stroke-width="2"
+              aria-hidden="true"
+            />
+            <LucideIcon
+              v-else
+              name="Copy"
+              class="h-3.5 w-3.5"
+              stroke-width="2"
+              aria-hidden="true"
+            />
+          </button>
+        </figcaption>
+      </figure>
+    </div>
+    <div v-else class="mt-6 text-sm text-neutral-500 dark:text-neutral-400">暂无图片。</div>
+    <ImagePreviewDialog
+      v-if="previewItem"
+      v-model:open="previewOpen"
+      :src="previewItem.imageSrcFull || previewItem.imageSrc"
+      :alt="previewItem.label || pageDisplayTitle"
+      :title="previewItem.label || pageDisplayTitle"
+      :copy-url="previewItem.copyUrl"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import ImagePreviewDialog from '~/components/media/ImagePreviewDialog.vue'
+import { copyTextWithFallback } from '~/utils/clipboard'
+
+type PageImageItem = {
+  imageKey: string
+  width: number
+  height: number
+  ratio: number | null
+  orientation: 'unknown' | 'wide' | 'tall' | 'normal'
+  aspectStyle: string
+  label: string
+  imageSrc: string
+  imageSrcFull: string
+  copyUrl: string
+  pageVersionImageId?: number
+  normalizedUrl?: string
+  originUrl?: string
+}
+
+const props = defineProps<{
+  images: PageImageItem[]
+  pending: boolean
+  error: any
+  pageDisplayTitle: string
+  copiedAnchorId: string | null
+}>()
+
+defineEmits<{
+  'copy-anchor': [sectionId: string]
+  'refresh': []
+}>()
+
+const sizeOptions = [
+  { label: '小', value: 9 },
+  { label: '中', value: 6 },
+  { label: '大', value: 3 }
+]
+
+const localColumns = ref<number>(6)
+const localPage = ref(1)
+
+const hasImages = computed(() => props.images.length > 0)
+
+const rows = computed(() => {
+  const cols = localColumns.value
+  if (cols >= 9) return 5
+  if (cols >= 6) return 4
+  return 3
+})
+const perPage = computed(() => Math.max(1, localColumns.value * rows.value))
+const totalPages = computed(() => {
+  if (!props.images.length) return 1
+  return Math.max(1, Math.ceil(props.images.length / perPage.value))
+})
+const currentPage = computed(() => Math.max(1, Math.min(localPage.value, totalPages.value)))
+
+const paginatedImages = computed(() => {
+  const pageIndex = currentPage.value - 1
+  const start = pageIndex * perPage.value
+  return props.images.slice(start, start + perPage.value)
+})
+
+const rangeLabel = computed(() => {
+  if (!props.images.length) return '0'
+  const start = (currentPage.value - 1) * perPage.value + 1
+  const end = Math.min(props.images.length, start + perPage.value - 1)
+  return `${start} - ${end}`
+})
+
+const gridStyle = computed(() => ({
+  '--columns': String(Math.max(1, Math.min(localColumns.value, 12)))
+}))
+
+type PreviewPayload = {
+  imageKey: string
+  label: string
+  imageSrc: string
+  imageSrcFull: string
+  copyUrl: string
+}
+const previewOpen = ref(false)
+const previewItem = ref<PreviewPayload | null>(null)
+const copiedImageKey = ref<string | null>(null)
+let copyTimer: ReturnType<typeof setTimeout> | null = null
+
+function openPreview(img: PageImageItem) {
+  previewItem.value = {
+    imageKey: img.imageKey,
+    label: img.label,
+    imageSrc: img.imageSrc,
+    imageSrcFull: img.imageSrcFull || img.imageSrc,
+    copyUrl: img.copyUrl || img.imageSrcFull || img.imageSrc
+  }
+  previewOpen.value = true
+}
+
+async function copyImageUrl(img: PageImageItem) {
+  const imageKey = img.imageKey
+  const target = (img.copyUrl || img.imageSrcFull || img.imageSrc || '').trim()
+  if (!imageKey || !target) return
+
+  const copied = await copyTextWithFallback(target, '请复制图片 URL')
+  if (!copied) return
+
+  copiedImageKey.value = imageKey
+  if (copyTimer) clearTimeout(copyTimer)
+  copyTimer = setTimeout(() => {
+    if (copiedImageKey.value === imageKey) copiedImageKey.value = null
+  }, 1800)
+}
+
+watch(() => props.images, () => {
+  if (localPage.value > totalPages.value) {
+    localPage.value = totalPages.value
+  }
+  if (previewItem.value) {
+    const exists = props.images.some((img) => img.imageKey === previewItem.value?.imageKey)
+    if (!exists) {
+      previewOpen.value = false
+      previewItem.value = null
+    }
+  }
+})
+
+watch(localColumns, () => {
+  localPage.value = 1
+})
+</script>
+
+<style scoped>
+.page-images-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(var(--columns, 6), minmax(0, 1fr));
+}
+
+.page-image-trigger {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border-width: 1px;
+  text-align: left;
+  cursor: zoom-in;
+}
+
+.page-image-trigger:focus-visible {
+  outline: 2px solid var(--g-accent-border);
+  outline-offset: 1px;
+}
+
+.page-image-zoom-chip {
+  pointer-events: none;
+  position: absolute;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: rgba(15, 23, 42, 0.48);
+  padding: 0.15rem 0.5rem;
+  font-size: 10px;
+  line-height: 1.2;
+  color: rgba(248, 250, 252, 0.95);
+  opacity: 0.86;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.group:hover .page-image-zoom-chip {
+  opacity: 1;
+  transform: translateY(-1px);
+}
+
+@media (max-width: 1024px) {
+  .page-images-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .page-images-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 420px) {
+  .page-images-grid {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+}
+</style>

--- a/frontend/components/page/PageImages.vue
+++ b/frontend/components/page/PageImages.vue
@@ -242,7 +242,14 @@ async function copyImageUrl(img: PageImageItem) {
   }, 1800)
 }
 
-watch(() => props.images, () => {
+watch(() => props.images, (newImages, oldImages) => {
+  // Full reset when images array changes identity (route navigation)
+  if (newImages !== oldImages) {
+    previewOpen.value = false
+    previewItem.value = null
+    copiedImageKey.value = null
+    localPage.value = 1
+  }
   if (localPage.value > totalPages.value) {
     localPage.value = totalPages.value
   }

--- a/frontend/components/page/PageMetrics.vue
+++ b/frontend/components/page/PageMetrics.vue
@@ -1,0 +1,110 @@
+<template>
+  <section id="metrics" class="space-y-3">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex items-center gap-2">
+        <h2 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">核心指标</h2>
+        <button
+          type="button"
+          class="inline-flex h-7 w-7 items-center justify-center rounded-full border border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:text-[var(--g-accent)] hover:border-[var(--g-accent-border)] dark:text-neutral-400 dark:hover:text-[var(--g-accent)]"
+          @click="$emit('copy-anchor', 'metrics')"
+          :title="copiedAnchorId === 'metrics' ? '已复制链接' : '复制该段落链接'"
+        >
+          <LucideIcon v-if="copiedAnchorId === 'metrics'" name="Check" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
+          <LucideIcon v-else name="Link" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
+        </button>
+      </div>
+      <span v-if="metricsUpdatedAt" class="text-xs text-neutral-500 dark:text-neutral-400">
+        更新于 {{ formatDate(metricsUpdatedAt) }}
+      </span>
+    </div>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <!-- 评分 -->
+      <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-3 bg-white dark:bg-neutral-900 shadow-sm">
+        <div class="flex items-start justify-between">
+          <div class="text-[12px] text-neutral-600 dark:text-neutral-400">评分</div>
+          <div class="text-lg font-bold text-neutral-900 dark:text-neutral-100" :title="ratingTooltip">
+            {{ totalScoreDisplay }}
+          </div>
+        </div>
+        <div class="mt-2 grid grid-cols-2 text-[11px]">
+          <div class="text-green-600 dark:text-green-400">↑ {{ upvotes }}</div>
+          <div class="text-red-600 dark:text-red-400 text-right">↓ {{ downvotes }}</div>
+        </div>
+        <div class="mt-2 h-1.5 w-full rounded bg-neutral-200 dark:bg-neutral-800 overflow-hidden flex">
+          <div class="h-full bg-[var(--g-accent)]" :style="{ width: upvotePct + '%' }" aria-hidden="true"></div>
+          <div class="h-full bg-red-500" :style="{ width: downvotePct + '%' }" aria-hidden="true"></div>
+        </div>
+      </div>
+
+      <!-- 支持率 -->
+      <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-3 bg-white dark:bg-neutral-900 shadow-sm">
+        <div class="flex items-start justify-between">
+          <div class="text-[12px] text-neutral-600 dark:text-neutral-400">支持率</div>
+          <div class="text-lg font-bold text-neutral-900 dark:text-neutral-100" :title="voteTooltip">
+            {{ likeRatioPct.toFixed(0) }}%
+          </div>
+        </div>
+        <div class="mt-2 text-[11px] text-neutral-500 dark:text-neutral-400">总票数 {{ totalVotes }}</div>
+        <div class="mt-2 h-1.5 w-full rounded bg-neutral-200 dark:bg-neutral-800 overflow-hidden">
+          <div class="h-full bg-[var(--g-accent)]" :style="{ width: likeRatioPct + '%' }" aria-hidden="true"></div>
+        </div>
+      </div>
+
+      <!-- Wilson95 下界 -->
+      <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-3 bg-white dark:bg-neutral-900 shadow-sm">
+        <div class="flex items-start justify-between">
+          <div class="text-[12px] text-neutral-600 dark:text-neutral-400">Wilson 95% 下界</div>
+          <div class="text-lg font-bold text-neutral-900 dark:text-neutral-100" :title="wilsonTooltip">
+            {{ (wilsonLB * 100).toFixed(1) }}%
+          </div>
+        </div>
+        <div class="mt-2 text-[11px] text-neutral-500 dark:text-neutral-400">
+          在相同票数下更稳健的支持率估计
+        </div>
+        <div class="mt-2 h-1.5 w-full rounded bg-neutral-200 dark:bg-neutral-800 overflow-hidden">
+          <div class="h-full bg-[var(--g-accent)]" :style="{ width: Math.max(0, Math.min(100, wilsonLB * 100)) + '%' }" aria-hidden="true"></div>
+        </div>
+      </div>
+
+      <!-- 争议指数 -->
+      <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-3 bg-white dark:bg-neutral-900 shadow-sm">
+        <div class="flex items-start justify-between">
+          <div class="text-[12px] text-neutral-600 dark:text-neutral-400">争议指数</div>
+          <div class="text-lg font-bold text-neutral-900 dark:text-neutral-100">
+            {{ controversyIdx.toFixed(3) }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { formatDateUtc8 } from '~/utils/timezone'
+
+defineProps<{
+  totalScoreDisplay: string
+  upvotes: number
+  downvotes: number
+  totalVotes: number
+  upvotePct: number
+  downvotePct: number
+  likeRatioPct: number
+  wilsonLB: number
+  controversyIdx: number
+  ratingTooltip: string
+  voteTooltip: string
+  wilsonTooltip: string
+  metricsUpdatedAt: string | null
+  copiedAnchorId: string | null
+}>()
+
+defineEmits<{
+  'copy-anchor': [sectionId: string]
+}>()
+
+function formatDate(dateStr: string) {
+  if (!dateStr) return 'N/A'
+  return formatDateUtc8(dateStr, { year: 'numeric', month: 'short', day: 'numeric' }) || 'N/A'
+}
+</script>

--- a/frontend/components/page/PageRevisions.vue
+++ b/frontend/components/page/PageRevisions.vue
@@ -1,0 +1,155 @@
+<template>
+  <section id="revisions" class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-4 bg-white dark:bg-neutral-900 shadow-sm min-h-[280px] flex flex-col">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-4">
+      <div class="flex items-center gap-2">
+        <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">最近修订</h3>
+        <button
+          type="button"
+          class="inline-flex h-7 w-7 items-center justify-center rounded-full border border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:text-[var(--g-accent)] hover:border-[var(--g-accent-border)] dark:text-neutral-400 dark:hover:text-[var(--g-accent)]"
+          @click="$emit('copy-anchor', 'revisions')"
+          :title="copiedAnchorId === 'revisions' ? '已复制链接' : '复制该段落链接'"
+        >
+          <LucideIcon v-if="copiedAnchorId === 'revisions'" name="Check" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
+          <LucideIcon v-else name="Link" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
+        </button>
+      </div>
+      <div class="text-xs text-neutral-500 dark:text-neutral-400">{{ (revPage + 1) }} / {{ revTotalPages }}</div>
+    </div>
+
+    <div v-if="pending" class="flex-1 flex items-center justify-center text-neutral-500 dark:text-neutral-400">
+      正在加载修订记录…
+    </div>
+
+    <div v-else-if="error" class="flex-1 flex flex-col items-center justify-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
+      加载修订记录失败。
+      <button type="button" class="inline-flex items-center gap-1 text-[var(--g-accent)] hover:underline" @click="$emit('refresh')">重试</button>
+    </div>
+
+    <div v-else-if="!revisions || revisions.length === 0" class="flex-1 flex items-center justify-center text-neutral-500 dark:text-neutral-400">
+      暂无修订记录
+    </div>
+
+    <div v-else class="flex-1">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+        <div
+          v-for="rev in revisions"
+          :key="rev.revisionId || rev.wikidotId"
+          class="p-2 rounded border border-neutral-200 dark:border-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-800"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <div class="flex items-center gap-2 min-w-0">
+              <span :class="['inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium shrink-0 w-[120px] justify-center', revisionTypeClass(rev.type)]">
+                {{ formatRevisionType(rev.type) }}
+              </span>
+              <div class="min-w-0">
+                <UserCard
+                  size="sm"
+                  :wikidot-id="rev.userWikidotId || null"
+                  :display-name="rev.userDisplayName || '(account deleted)'"
+                  :to="rev.userWikidotId ? `/user/${rev.userWikidotId}` : null"
+                  :avatar="true"
+                />
+              </div>
+            </div>
+            <div class="text-xs text-neutral-500 dark:text-neutral-400 whitespace-nowrap shrink-0">{{ formatRelativeTime(rev.timestamp) }}</div>
+          </div>
+          <div v-if="rev.comment" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;">{{ rev.comment }}</div>
+        </div>
+      </div>
+
+    </div>
+    <div v-if="revisions && revisions.length > 0" class="mt-3">
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <button @click="$emit('prev-page')" :disabled="revPage === 0"
+                class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
+        <div class="flex items-center gap-1">
+          <button
+            v-for="n in revPageNumbers"
+            :key="`rp-${n}`"
+            @click="$emit('go-page', n)"
+            :class="['text-xs px-2 py-1 rounded border', (revPage + 1 === n) ? 'bg-neutral-200 dark:bg-neutral-700 border-neutral-300 dark:border-neutral-700' : 'bg-neutral-100 dark:bg-neutral-800 border-neutral-200 dark:border-neutral-800']"
+          >{{ n }}</button>
+        </div>
+        <div class="hidden sm:flex items-center gap-1">
+          <input
+            :value="jumpPage"
+            @input="$emit('update:jump-page', Number(($event.target as HTMLInputElement).value))"
+            type="number"
+            :min="1"
+            :max="revTotalPages"
+            placeholder="页码"
+            @keyup.enter="$emit('jump')"
+            class="w-16 text-xs px-2 py-1 rounded border border-neutral-300 dark:border-neutral-700 bg-neutral-100 dark:bg-neutral-800"
+          />
+          <button @click="$emit('jump')" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">跳转</button>
+        </div>
+        <button @click="$emit('next-page')" :disabled="!hasMore"
+                class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { formatDateUtc8 } from '~/utils/timezone'
+
+defineProps<{
+  revisions: any[] | null
+  pending: boolean
+  error: any
+  revPage: number
+  revTotalPages: number
+  revPageNumbers: number[]
+  hasMore: boolean
+  jumpPage: number | null
+  copiedAnchorId: string | null
+}>()
+
+defineEmits<{
+  'copy-anchor': [sectionId: string]
+  'refresh': []
+  'prev-page': []
+  'next-page': []
+  'go-page': [n: number]
+  'jump': []
+  'update:jump-page': [value: number]
+}>()
+
+function formatRevisionType(type: string) {
+  const map: Record<string, string> = {
+    'PAGE_CREATED': '创建页面', 'PAGE_EDITED': '编辑内容', 'PAGE_RENAMED': '重命名', 'PAGE_DELETED': '删除', 'PAGE_RESTORED': '恢复', 'METADATA_CHANGED': '修改元数据', 'TAGS_CHANGED': '修改标签', 'SOURCE_CHANGED': '编辑内容'
+  }
+  return map[type] || type
+}
+
+function revisionTypeClass(type: string) {
+  const t = String(type || '')
+  if (t === 'PAGE_CREATED' || t === 'PAGE_RESTORED') {
+    return 'bg-[var(--g-accent-soft)] dark:bg-[var(--g-accent-strong)] text-[var(--g-accent)]'
+  }
+  if (t === 'PAGE_EDITED') {
+    return 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+  }
+  if (t === 'PAGE_RENAMED') {
+    return 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400'
+  }
+  if (t === 'PAGE_DELETED') {
+    return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400'
+  }
+  if (t === 'METADATA_CHANGED') {
+    return 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
+  }
+  if (t === 'TAGS_CHANGED') {
+    return 'bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400'
+  }
+  if (t === 'SOURCE_CHANGED') {
+    return 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400'
+  }
+  return 'bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300'
+}
+
+function formatRelativeTime(dateStr: string) {
+  if (!dateStr) return ''
+  return formatDateUtc8(dateStr, { year: 'numeric', month: 'short', day: 'numeric' }) || ''
+}
+</script>

--- a/frontend/components/page/PageRevisions.vue
+++ b/frontend/components/page/PageRevisions.vue
@@ -73,7 +73,7 @@
         <div class="hidden sm:flex items-center gap-1">
           <input
             :value="jumpPage"
-            @input="$emit('update:jump-page', Number(($event.target as HTMLInputElement).value))"
+            @input="emitJumpPage($event)"
             type="number"
             :min="1"
             :max="revTotalPages"
@@ -105,15 +105,25 @@ defineProps<{
   copiedAnchorId: string | null
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   'copy-anchor': [sectionId: string]
   'refresh': []
   'prev-page': []
   'next-page': []
   'go-page': [n: number]
   'jump': []
-  'update:jump-page': [value: number]
+  'update:jump-page': [value: number | null]
 }>()
+
+function emitJumpPage(event: Event) {
+  const raw = (event.target as HTMLInputElement).value
+  if (raw === '') {
+    emit('update:jump-page', null)
+  } else {
+    const num = Number(raw)
+    if (Number.isFinite(num)) emit('update:jump-page', num)
+  }
+}
 
 function formatRevisionType(type: string) {
   const map: Record<string, string> = {

--- a/frontend/components/page/PageSource.vue
+++ b/frontend/components/page/PageSource.vue
@@ -1,0 +1,827 @@
+<template>
+  <section id="page-source" class="border border-neutral-200 dark:border-neutral-800 rounded-lg bg-white dark:bg-neutral-900 shadow-sm">
+    <header class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between px-6 pt-6">
+      <div class="flex items-center gap-2">
+        <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">页面源码</h3>
+        <button
+          type="button"
+          class="inline-flex h-7 w-7 items-center justify-center rounded-full border border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:text-[var(--g-accent)] hover:border-[var(--g-accent-border)] dark:text-neutral-400 dark:hover:text-[var(--g-accent)]"
+          @click="$emit('copy-anchor', 'page-source')"
+          :title="copiedAnchorId === 'page-source' ? '已复制链接' : '复制该段落链接'"
+        >
+          <LucideIcon v-if="copiedAnchorId === 'page-source'" name="Check" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
+          <LucideIcon v-else name="Link" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
+        </button>
+      </div>
+      <div class="flex flex-wrap items-center gap-3">
+        <button @click="toggleDiffMode"
+                class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700">
+          {{ diffMode ? '退出对比' : '对比版本' }}
+        </button>
+
+        <div v-if="!diffMode" class="flex items-center gap-2">
+          <label class="text-xs text-neutral-500 dark:text-neutral-400">页面版本:</label>
+          <select v-model="localSelectedVersion" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">
+            <option v-for="v in pageVersions" :key="v.pageVersionId" :value="v.pageVersionId">
+              {{ v.validTo ? '历史' : '当前' }} · {{ formatDate(v.createdAt) }} · {{ v.title || '' }}
+            </option>
+          </select>
+        </div>
+
+        <div v-else class="diff-toolbar flex flex-col gap-2 text-xs text-neutral-600 dark:text-neutral-400 sm:flex-row sm:flex-wrap sm:items-stretch sm:gap-3">
+          <div class="diff-chip flex items-center gap-2 px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-100/70 dark:bg-neutral-800/60 shadow-sm sm:flex-[1_1_220px]">
+            <span class="diff-label text-neutral-500 dark:text-neutral-300">基准</span>
+            <select
+              v-model="baseVersionId"
+              class="diff-select flex-1 min-w-0 px-2 py-1 rounded border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-[var(--g-accent-border)]"
+            >
+              <option v-for="v in orderedVersions" :key="`b-${v.pageVersionId}`" :value="v.pageVersionId">
+                {{ v.validTo ? '历史' : '当前' }} · {{ formatDate(v.createdAt) }} · {{ v.title || '' }}
+              </option>
+            </select>
+          </div>
+          <div class="diff-chip flex items-center gap-2 px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-100/70 dark:bg-neutral-800/60 shadow-sm sm:flex-[1_1_220px]">
+            <span class="diff-label text-neutral-500 dark:text-neutral-300">对比</span>
+            <select
+              v-model="compareVersionId"
+              class="diff-select flex-1 min-w-0 px-2 py-1 rounded border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-[var(--g-accent-border)]"
+            >
+              <option v-for="v in orderedVersions" :key="`c-${v.pageVersionId}`" :value="v.pageVersionId">
+                {{ v.validTo ? '历史' : '当前' }} · {{ formatDate(v.createdAt) }} · {{ v.title || '' }}
+              </option>
+            </select>
+          </div>
+          <div class="diff-chip flex items-center gap-3 px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-100/70 dark:bg-neutral-800/60 shadow-sm sm:flex-[1_1_200px]">
+            <span class="diff-label text-neutral-500 dark:text-neutral-300">视图</span>
+            <div class="diff-view-toggle inline-flex items-center rounded-full bg-neutral-200/60 dark:bg-neutral-800/70 p-[3px]">
+              <button
+                type="button"
+                :class="[
+                  'diff-view-toggle__btn px-3 py-1 rounded-full text-[11px] font-medium transition-colors',
+                  diffViewMode === 'unified'
+                    ? 'bg-white text-[var(--g-accent)] shadow-sm dark:bg-neutral-700'
+                    : 'text-neutral-600 hover:text-neutral-800 dark:text-neutral-300 dark:hover:text-neutral-100'
+                ]"
+                @click="diffViewMode = 'unified'"
+              >
+                合并
+              </button>
+              <button
+                type="button"
+                :class="[
+                  'diff-view-toggle__btn px-3 py-1 rounded-full text-[11px] font-medium transition-colors',
+                  diffViewMode === 'split'
+                    ? 'bg-white text-[var(--g-accent)] shadow-sm dark:bg-neutral-700'
+                    : 'text-neutral-600 hover:text-neutral-800 dark:text-neutral-300 dark:hover:text-neutral-100'
+                ]"
+                @click="diffViewMode = 'split'"
+              >
+                并排
+              </button>
+            </div>
+          </div>
+          <div class="diff-chip diff-chip--context flex items-center gap-2 px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-100/70 dark:bg-neutral-800/60 shadow-sm sm:flex-[0_1_150px]">
+            <span class="diff-label text-neutral-500 dark:text-neutral-300">上下文</span>
+            <select
+              v-model.number="diffContextLines"
+              class="diff-select diff-select--narrow flex-none px-2 py-1 rounded border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-[var(--g-accent-border)]"
+            >
+              <option :value="1">1</option>
+              <option :value="2">2</option>
+              <option :value="3">3</option>
+              <option :value="5">5</option>
+            </select>
+          </div>
+          <div class="diff-chip diff-chip--toggles flex gap-2 px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-100/70 dark:bg-neutral-800/60 shadow-sm sm:flex-[1_1_220px]">
+            <span class="diff-label text-neutral-500 dark:text-neutral-300">显示</span>
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+              <label class="inline-flex items-center gap-2">
+                <input type="checkbox" v-model="ignoreWhitespace" class="rounded">
+                <span class="text-neutral-600 dark:text-neutral-300">忽略空白</span>
+              </label>
+              <label class="inline-flex items-center gap-2">
+                <input type="checkbox" v-model="diffCollapseUnchanged" class="rounded">
+                <span class="text-neutral-600 dark:text-neutral-300">折叠未变化</span>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <button @click="copySource" :disabled="diffMode" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 disabled:opacity-50">
+            复制源码
+          </button>
+          <button @click="downloadSource" :disabled="diffMode" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 disabled:opacity-50">
+            下载源码
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <div class="mt-4 border-t border-neutral-100 dark:border-neutral-800"></div>
+
+    <div v-if="!diffMode" class="px-6 pb-6">
+      <div class="mb-2 text-[11px] text-neutral-500 dark:text-neutral-400 flex flex-wrap items-center gap-x-2 gap-y-1">
+        <span>源码字符数 {{ sourceCharacterCount }}</span>
+        <span aria-hidden="true">·</span>
+        <span>文字字数 {{ textContentCharacterCount }}</span>
+      </div>
+      <pre class="source-code-block border border-neutral-200 dark:border-neutral-700 rounded bg-neutral-50 dark:bg-neutral-800 p-3 max-h-96 overflow-auto text-xs font-mono whitespace-pre-wrap select-text"
+           aria-label="页面源码内容">{{ displayedSource }}</pre>
+    </div>
+
+    <div v-else class="px-6 pb-6">
+      <div class="source-code-block border border-neutral-200 dark:border-neutral-700 rounded bg-neutral-50 dark:bg-neutral-800 overflow-hidden text-xs font-mono select-text">
+        <div v-if="diffLoading" class="px-3 py-4 text-neutral-500 dark:text-neutral-400">计算对比中…</div>
+        <div v-else-if="diffError" class="px-3 py-4 text-red-600 dark:text-red-400">{{ diffError }}</div>
+        <div v-else-if="!diffData" class="px-3 py-4 text-neutral-500 dark:text-neutral-400">尚未生成对比</div>
+        <template v-else>
+          <div class="flex flex-wrap items-center gap-3 px-3 py-2 text-[11px] text-neutral-600 dark:text-neutral-400 border-b border-neutral-200 dark:border-neutral-700 bg-white/60 dark:bg-neutral-900/40">
+            <span>变化 {{ diffSummary.blocks }} 处 · +{{ diffSummary.added }} / -{{ diffSummary.removed }}</span>
+            <span v-if="!diffHasChanges" class="text-neutral-500 dark:text-neutral-400">两个版本内容一致</span>
+          </div>
+          <div v-if="diffViewMode === 'unified'" class="diff-viewer-unified max-h-[28rem] overflow-auto">
+            <template v-for="row in diffUnifiedRows" :key="row.kind === 'fold' ? `fold-${row.id}` : row.key">
+              <div v-if="row.kind === 'fold'" class="border-b border-neutral-200 dark:border-neutral-700 bg-neutral-100/60 dark:bg-neutral-800/60 px-3 py-2">
+                <button type="button" @click="toggleDiffFold(row.id)"
+                        class="inline-flex items-center gap-1 text-[11px] text-neutral-600 dark:text-neutral-300">
+                  <span>{{ row.isExpanded ? '折叠' : '展开' }} {{ row.skipped }} 行未变化</span>
+                  <span v-if="row.oldRange || row.newRange" class="opacity-60">
+                    (旧 {{ formatRange(row.oldRange) }} / 新 {{ formatRange(row.newRange) }})
+                  </span>
+                </button>
+              </div>
+              <div v-else
+                   :class="['grid grid-cols-[56px_56px_1fr] gap-2 px-3 py-1 border-b border-neutral-200 dark:border-neutral-800 whitespace-pre-wrap',
+                     row.type === 'added' ? 'bg-[var(--g-accent-soft)] dark:bg-[var(--g-accent-strong)] text-[var(--g-accent)]' :
+                     row.type === 'removed' ? 'bg-red-100/60 dark:bg-red-900/30 text-red-700 dark:text-red-300' :
+                     'text-neutral-800 dark:text-neutral-200']">
+                <span class="text-right text-[10px] text-neutral-400">
+                  {{ row.oldLine ?? '' }}
+                </span>
+                <span class="text-right text-[10px] text-neutral-400">
+                  {{ row.newLine ?? '' }}
+                </span>
+                <span>{{ row.text || ' ' }}</span>
+              </div>
+            </template>
+          </div>
+          <div v-else class="diff-viewer-split max-h-[28rem] overflow-auto">
+            <template v-for="row in diffSplitRows" :key="row.kind === 'fold' ? `fold-${row.id}` : row.key">
+              <div v-if="row.kind === 'fold'" class="border-b border-neutral-200 dark:border-neutral-700 bg-neutral-100/60 dark:bg-neutral-800/60 px-3 py-2">
+                <button type="button" @click="toggleDiffFold(row.id)"
+                        class="inline-flex items-center gap-1 text-[11px] text-neutral-600 dark:text-neutral-300">
+                  <span>{{ row.isExpanded ? '折叠' : '展开' }} {{ row.skipped }} 行未变化</span>
+                  <span v-if="row.oldRange || row.newRange" class="opacity-60">
+                    (旧 {{ formatRange(row.oldRange) }} / 新 {{ formatRange(row.newRange) }})
+                  </span>
+                </button>
+              </div>
+              <div v-else class="grid gap-2 px-3 py-1 border-b border-neutral-200 dark:border-neutral-800 text-neutral-800 dark:text-neutral-200 sm:grid-cols-[56px_minmax(0,1fr)_56px_minmax(0,1fr)]">
+                <div class="flex items-baseline justify-between sm:block text-[10px] text-neutral-400">
+                  <span class="sm:hidden text-neutral-500 mr-2">基准</span>
+                  <span>{{ row.left.line ?? '' }}</span>
+                </div>
+                <span :class="[
+                    'block whitespace-pre-wrap',
+                    row.changeType === 'removed' || row.changeType === 'modified'
+                      ? 'bg-red-100/60 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded'
+                      : '']">
+                  {{ row.left.text || ' ' }}
+                </span>
+                <div class="flex items-baseline justify-between sm:block text-[10px] text-neutral-400">
+                  <span class="sm:hidden text-neutral-500 mr-2">对比</span>
+                  <span>{{ row.right.line ?? '' }}</span>
+                </div>
+                <span :class="[
+                    'block whitespace-pre-wrap',
+                    row.changeType === 'added' || row.changeType === 'modified'
+                      ? 'bg-[var(--g-accent-soft)] dark:bg-[var(--g-accent-strong)] text-[var(--g-accent)] rounded'
+                      : '']">
+                  {{ row.right.text || ' ' }}
+                </span>
+              </div>
+            </template>
+          </div>
+        </template>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch, onBeforeUnmount } from 'vue'
+import { useNuxtApp } from '#imports'
+import { formatDateUtc8 } from '~/utils/timezone'
+
+const props = defineProps<{
+  wikidotId: string
+  pageDisplayTitle: string
+  copiedAnchorId: string | null
+  pageVersions: any[] | null
+  displayedSource: string
+  sourceCharacterCount: number
+  textContentCharacterCount: number
+}>()
+
+const emit = defineEmits<{
+  'copy-anchor': [sectionId: string]
+  'version-change': [versionId: number | null]
+}>()
+
+const { $bff } = useNuxtApp()
+
+const localSelectedVersion = ref<number | null>(null)
+
+watch(() => props.pageVersions, (list) => {
+  if (Array.isArray(list) && list.length > 0) {
+    const current = list.find((v: any) => !v.validTo)
+    localSelectedVersion.value = (current || list[0]).pageVersionId
+  } else {
+    localSelectedVersion.value = null
+  }
+}, { immediate: true })
+
+watch(localSelectedVersion, (ver) => {
+  emit('version-change', ver)
+})
+
+function formatDate(dateStr: string) {
+  if (!dateStr) return 'N/A'
+  return formatDateUtc8(dateStr, { year: 'numeric', month: 'short', day: 'numeric' }) || 'N/A'
+}
+
+// ===== Diff mode state =====
+const diffMode = ref(false)
+const baseVersionId = ref<number | null>(null)
+const compareVersionId = ref<number | null>(null)
+const ignoreWhitespace = ref(true)
+const diffLoading = ref(false)
+const diffError = ref<string | null>(null)
+const diffViewMode = ref<'unified' | 'split'>('unified')
+const diffCollapseUnchanged = ref(true)
+const diffContextLines = ref(3)
+const diffExpandedFoldIds = ref<string[]>([])
+let diffJobSeq = 0
+let diffScheduleHandle: ReturnType<typeof setTimeout> | null = null
+
+type DiffLineType = 'context' | 'added' | 'removed'
+interface DiffLine {
+  kind: DiffLineType
+  text: string
+  oldLine: number | null
+  newLine: number | null
+}
+interface DiffContextSegment {
+  type: 'context'
+  index: number
+  lines: DiffLine[]
+}
+interface DiffChangeSegment {
+  type: 'change'
+  index: number
+  removed: DiffLine[]
+  added: DiffLine[]
+}
+type DiffSegment = DiffContextSegment | DiffChangeSegment
+
+interface DiffPrepared {
+  lines: DiffLine[]
+  segments: DiffSegment[]
+  stats: { added: number; removed: number; blocks: number }
+}
+
+interface DiffFoldRow {
+  kind: 'fold'
+  id: string
+  skipped: number
+  oldRange: [number, number] | null
+  newRange: [number, number] | null
+  isExpanded: boolean
+}
+interface DiffUnifiedLineRow {
+  kind: 'line'
+  key: string
+  type: DiffLineType
+  text: string
+  oldLine: number | null
+  newLine: number | null
+}
+type DiffUnifiedRow = DiffUnifiedLineRow | DiffFoldRow
+
+interface DiffSplitCell {
+  text: string
+  line: number | null
+}
+interface DiffSplitLineRow {
+  kind: 'line'
+  key: string
+  left: DiffSplitCell
+  right: DiffSplitCell
+  changeType: 'context' | 'added' | 'removed' | 'modified'
+}
+type DiffSplitRow = DiffSplitLineRow | DiffFoldRow
+
+const diffData = ref<DiffPrepared | null>(null)
+
+const diffSummary = computed(() => diffData.value?.stats ?? { added: 0, removed: 0, blocks: 0 })
+const diffHasChanges = computed(() => diffSummary.value.blocks > 0)
+
+watch(diffCollapseUnchanged, () => {
+  diffExpandedFoldIds.value = []
+})
+watch(diffContextLines, (value) => {
+  const numeric = Number(value)
+  const normalized = Number.isFinite(numeric) ? Math.max(0, Math.min(20, Math.round(numeric))) : 0
+  if (normalized !== diffContextLines.value) {
+    diffContextLines.value = normalized
+    return
+  }
+  diffExpandedFoldIds.value = []
+})
+
+const orderedVersions = computed<any[]>(() => {
+  const list = Array.isArray(props.pageVersions) ? [...(props.pageVersions as any[])] : []
+  return list.sort((a: any, b: any) => {
+    const ta = new Date(a?.createdAt || 0).getTime()
+    const tb = new Date(b?.createdAt || 0).getTime()
+    return ta - tb
+  })
+})
+
+interface BuildDiffViewOptions {
+  collapse: boolean
+  context: number
+  expanded: Set<string>
+  hasChanges: boolean
+}
+
+const diffUnifiedRows = computed<DiffUnifiedRow[]>(() => {
+  if (!diffData.value) return []
+  return buildUnifiedRows(diffData.value.segments, {
+    collapse: diffCollapseUnchanged.value,
+    context: Math.max(0, Math.min(20, Math.round(Number(diffContextLines.value) || 0))),
+    expanded: new Set(diffExpandedFoldIds.value),
+    hasChanges: diffHasChanges.value
+  })
+})
+
+const diffSplitRows = computed<DiffSplitRow[]>(() => {
+  if (!diffData.value) return []
+  return buildSplitRows(diffData.value.segments, {
+    collapse: diffCollapseUnchanged.value,
+    context: Math.max(0, Math.min(20, Math.round(Number(diffContextLines.value) || 0))),
+    expanded: new Set(diffExpandedFoldIds.value),
+    hasChanges: diffHasChanges.value
+  })
+})
+
+function resetDiffResults() {
+  diffError.value = null
+  diffData.value = null
+  diffExpandedFoldIds.value = []
+}
+
+function toggleDiffMode() {
+  diffMode.value = !diffMode.value
+  if (diffMode.value) {
+    const list = orderedVersions.value
+    if (list.length === 0) {
+      baseVersionId.value = null
+      compareVersionId.value = null
+    } else {
+      const currentId = localSelectedVersion.value
+      const idx = currentId != null ? list.findIndex((v: any) => v.pageVersionId === currentId) : list.length - 1
+      const prevIdx = Math.max(0, Math.min(list.length - 1, idx - 1))
+      const nextIdx = Math.max(0, Math.min(list.length - 1, idx))
+      baseVersionId.value = list[prevIdx]?.pageVersionId ?? null
+      compareVersionId.value = list[nextIdx]?.pageVersionId ?? null
+    }
+    resetDiffResults()
+    scheduleDiff()
+  } else {
+    if (diffScheduleHandle) {
+      clearTimeout(diffScheduleHandle)
+      diffScheduleHandle = null
+    }
+    diffLoading.value = false
+    resetDiffResults()
+  }
+}
+
+watch([baseVersionId, compareVersionId, () => ignoreWhitespace.value], () => {
+  if (!diffMode.value) return
+  scheduleDiff()
+})
+
+const versionSourceCache = new Map<number, string | null>()
+
+async function getSourceForVersion(verId: number): Promise<string> {
+  if (versionSourceCache.has(verId)) {
+    return String(versionSourceCache.get(verId) || '')
+  }
+  const resp = await $bff(`/pages/${props.wikidotId}/versions/${verId}/source`)
+  const text = (resp && typeof resp.source === 'string') ? resp.source : ''
+  versionSourceCache.set(verId, text)
+  return text
+}
+
+async function runDiff() {
+  if (!diffMode.value) return
+  if (baseVersionId.value == null || compareVersionId.value == null) {
+    diffLoading.value = false
+    diffError.value = null
+    diffData.value = null
+    diffExpandedFoldIds.value = []
+    return
+  }
+  const jobId = ++diffJobSeq
+  diffLoading.value = true
+  diffError.value = null
+  diffData.value = null
+  diffExpandedFoldIds.value = []
+  try {
+    const [baseText, compareText] = await Promise.all([
+      getSourceForVersion(Number(baseVersionId.value)),
+      getSourceForVersion(Number(compareVersionId.value))
+    ])
+    const diffLib: any = await import('diff')
+    const parts = (diffLib?.diffLines || diffLib?.default?.diffLines)?.call(diffLib, String(baseText), String(compareText), {
+      ignoreWhitespace: !!ignoreWhitespace.value
+    }) || []
+    if (jobId !== diffJobSeq) return
+    diffData.value = Array.isArray(parts) ? prepareDiffData(parts) : { lines: [], segments: [], stats: { added: 0, removed: 0, blocks: 0 } }
+  } catch {
+    if (jobId !== diffJobSeq) return
+    diffError.value = '对比失败'
+  } finally {
+    if (jobId === diffJobSeq) diffLoading.value = false
+  }
+}
+
+function scheduleDiff(immediate = false) {
+  if (!diffMode.value) return
+  if (diffScheduleHandle) {
+    clearTimeout(diffScheduleHandle)
+    diffScheduleHandle = null
+  }
+  if (immediate) {
+    runDiff()
+    return
+  }
+  diffScheduleHandle = setTimeout(() => {
+    diffScheduleHandle = null
+    runDiff()
+  }, 120)
+}
+
+function prepareDiffData(parts: Array<{ value: string; added?: boolean; removed?: boolean }>): DiffPrepared {
+  let oldLine = 1
+  let newLine = 1
+  let added = 0
+  let removed = 0
+  const lines: DiffLine[] = []
+
+  parts.forEach((part) => {
+    const chunkLines = extractDiffLines(part)
+    chunkLines.forEach((text) => {
+      if (part?.added) {
+        lines.push({ kind: 'added', text, oldLine: null, newLine })
+        newLine += 1
+        added += 1
+      } else if (part?.removed) {
+        lines.push({ kind: 'removed', text, oldLine, newLine: null })
+        oldLine += 1
+        removed += 1
+      } else {
+        lines.push({ kind: 'context', text, oldLine, newLine })
+        oldLine += 1
+        newLine += 1
+      }
+    })
+  })
+
+  const segments = buildSegments(lines)
+  return {
+    lines,
+    segments,
+    stats: {
+      added,
+      removed,
+      blocks: segments.filter((seg) => seg.type === 'change').length
+    }
+  }
+}
+
+function extractDiffLines(part: { value?: string; added?: boolean; removed?: boolean; count?: number }): string[] {
+  const raw = String(part?.value ?? '').replace(/\r/g, '')
+  if (!raw) {
+    return part?.added || part?.removed ? [''] : []
+  }
+  const lines = raw.split('\n')
+  if (raw.endsWith('\n')) {
+    lines.pop()
+  }
+  return lines.length ? lines : ['']
+}
+
+function buildSegments(lines: DiffLine[]): DiffSegment[] {
+  type PendingSegment = { type: 'context'; lines: DiffLine[] } | { type: 'change'; removed: DiffLine[]; added: DiffLine[] }
+  const segments: PendingSegment[] = []
+  let contextBuffer: DiffLine[] = []
+  let removedBuffer: DiffLine[] = []
+  let addedBuffer: DiffLine[] = []
+
+  const pushContext = () => {
+    if (contextBuffer.length) {
+      segments.push({ type: 'context', lines: contextBuffer })
+      contextBuffer = []
+    }
+  }
+  const pushChange = () => {
+    if (removedBuffer.length || addedBuffer.length) {
+      segments.push({ type: 'change', removed: removedBuffer, added: addedBuffer })
+      removedBuffer = []
+      addedBuffer = []
+    }
+  }
+
+  lines.forEach((line) => {
+    if (line.kind === 'context') {
+      pushChange()
+      contextBuffer.push(line)
+    } else if (line.kind === 'removed') {
+      pushContext()
+      removedBuffer.push(line)
+    } else if (line.kind === 'added') {
+      pushContext()
+      addedBuffer.push(line)
+    }
+  })
+
+  pushChange()
+  pushContext()
+
+  return segments.map((seg, idx) => seg.type === 'context'
+    ? { type: 'context', index: idx, lines: seg.lines }
+    : { type: 'change', index: idx, removed: seg.removed, added: seg.added })
+}
+
+function buildUnifiedRows(segments: DiffSegment[], options: BuildDiffViewOptions): DiffUnifiedRow[] {
+  const rows: DiffUnifiedRow[] = []
+  if (!segments.length) return rows
+
+  const { collapse, context, expanded, hasChanges } = options
+  const changeAfter: boolean[] = new Array(segments.length).fill(false)
+  let seenChangeAhead = false
+  for (let i = segments.length - 1; i >= 0; i -= 1) {
+    changeAfter[i] = seenChangeAhead
+    if (segments[i].type === 'change') {
+      seenChangeAhead = true
+    }
+  }
+
+  let seenChange = false
+  let keyCounter = 0
+  const pushLine = (line: DiffLine, override?: DiffLineType) => {
+    rows.push({
+      kind: 'line',
+      key: `u-${keyCounter++}`,
+      type: override ?? line.kind,
+      text: line.text,
+      oldLine: line.oldLine,
+      newLine: line.newLine
+    })
+  }
+
+  segments.forEach((segment) => {
+    if (segment.type === 'change') {
+      seenChange = true
+      segment.removed.forEach((line) => pushLine(line, 'removed'))
+      segment.added.forEach((line) => pushLine(line, 'added'))
+      return
+    }
+
+    const lines = segment.lines
+    if (!collapse || !hasChanges) {
+      lines.forEach((line) => pushLine(line, 'context'))
+      return
+    }
+
+    const keepBefore = seenChange ? context : 0
+    const keepAfter = changeAfter[segment.index] ? context : 0
+    if (keepBefore + keepAfter >= lines.length) {
+      lines.forEach((line) => pushLine(line, 'context'))
+      return
+    }
+
+    const head = keepBefore > 0 ? lines.slice(0, keepBefore) : []
+    const tail = keepAfter > 0 ? lines.slice(lines.length - keepAfter) : []
+    const hidden = lines.slice(keepBefore, lines.length - keepAfter)
+
+    head.forEach((line) => pushLine(line, 'context'))
+    if (hidden.length) {
+      const foldRow = createFoldRow(`context-${segment.index}`, hidden, expanded)
+      rows.push(foldRow)
+      if (foldRow.isExpanded) {
+        hidden.forEach((line) => pushLine(line, 'context'))
+      }
+    }
+    tail.forEach((line) => pushLine(line, 'context'))
+  })
+
+  return rows
+}
+
+function buildSplitRows(segments: DiffSegment[], options: BuildDiffViewOptions): DiffSplitRow[] {
+  const rows: DiffSplitRow[] = []
+  if (!segments.length) return rows
+
+  const { collapse, context, expanded, hasChanges } = options
+  const changeAfter: boolean[] = new Array(segments.length).fill(false)
+  let seenChangeAhead = false
+  for (let i = segments.length - 1; i >= 0; i -= 1) {
+    changeAfter[i] = seenChangeAhead
+    if (segments[i].type === 'change') {
+      seenChangeAhead = true
+    }
+  }
+
+  let seenChange = false
+  let keyCounter = 0
+  const pushContextRow = (line: DiffLine) => {
+    rows.push({
+      kind: 'line',
+      key: `s-${keyCounter++}`,
+      left: { text: line.text, line: line.oldLine },
+      right: { text: line.text, line: line.newLine },
+      changeType: 'context'
+    })
+  }
+
+  segments.forEach((segment) => {
+    if (segment.type === 'change') {
+      seenChange = true
+      const maxLen = Math.max(segment.removed.length, segment.added.length)
+      for (let idx = 0; idx < maxLen; idx += 1) {
+        const leftLine = segment.removed[idx]
+        const rightLine = segment.added[idx]
+        const changeType: 'added' | 'removed' | 'modified' = leftLine && rightLine
+          ? 'modified'
+          : leftLine
+            ? 'removed'
+            : 'added'
+        rows.push({
+          kind: 'line',
+          key: `s-${keyCounter++}`,
+          left: { text: leftLine ? leftLine.text : '', line: leftLine?.oldLine ?? null },
+          right: { text: rightLine ? rightLine.text : '', line: rightLine?.newLine ?? null },
+          changeType
+        })
+      }
+      return
+    }
+
+    const lines = segment.lines
+    if (!collapse || !hasChanges) {
+      lines.forEach((line) => pushContextRow(line))
+      return
+    }
+
+    const keepBefore = seenChange ? context : 0
+    const keepAfter = changeAfter[segment.index] ? context : 0
+    if (keepBefore + keepAfter >= lines.length) {
+      lines.forEach((line) => pushContextRow(line))
+      return
+    }
+
+    const head = keepBefore > 0 ? lines.slice(0, keepBefore) : []
+    const tail = keepAfter > 0 ? lines.slice(lines.length - keepAfter) : []
+    const hidden = lines.slice(keepBefore, lines.length - keepAfter)
+
+    head.forEach((line) => pushContextRow(line))
+    if (hidden.length) {
+      const foldRow = createFoldRow(`context-${segment.index}`, hidden, expanded)
+      rows.push(foldRow)
+      if (foldRow.isExpanded) {
+        hidden.forEach((line) => pushContextRow(line))
+      }
+    }
+    tail.forEach((line) => pushContextRow(line))
+  })
+
+  return rows
+}
+
+function createFoldRow(id: string, lines: DiffLine[], expanded: Set<string>): DiffFoldRow {
+  return {
+    kind: 'fold',
+    id,
+    skipped: lines.length,
+    oldRange: rangeFromLines(lines, 'oldLine'),
+    newRange: rangeFromLines(lines, 'newLine'),
+    isExpanded: expanded.has(id)
+  }
+}
+
+function rangeFromLines(lines: DiffLine[], key: 'oldLine' | 'newLine'): [number, number] | null {
+  const values = lines
+    .map((line) => line[key])
+    .filter((value): value is number => typeof value === 'number')
+  if (!values.length) return null
+  return [values[0], values[values.length - 1]]
+}
+
+function toggleDiffFold(id: string) {
+  if (!id) return
+  if (diffExpandedFoldIds.value.includes(id)) {
+    diffExpandedFoldIds.value = diffExpandedFoldIds.value.filter((item) => item !== id)
+  } else {
+    diffExpandedFoldIds.value = [...diffExpandedFoldIds.value, id]
+  }
+}
+
+function formatRange(range: [number, number] | null): string {
+  if (!range) return '--'
+  const [start, end] = range
+  if (start == null || end == null) return '--'
+  return start === end ? String(start) : `${start}-${end}`
+}
+
+function copySource() {
+  const text = props.displayedSource || ''
+  if (!text || text === '加载中...' || text === '暂无源码') return
+  navigator.clipboard?.writeText(text).catch(() => {})
+}
+
+function downloadSource() {
+  const text = props.displayedSource || ''
+  if (!text || text === '加载中...' || text === '暂无源码') return
+  try {
+    const blob = new Blob([text], { type: 'text/plain;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${props.pageDisplayTitle || 'source'}.txt`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  } catch {
+    // Blob downloads can fail in restricted environments.
+  }
+}
+
+onBeforeUnmount(() => {
+  if (diffScheduleHandle) {
+    clearTimeout(diffScheduleHandle)
+    diffScheduleHandle = null
+  }
+})
+</script>
+
+<style scoped>
+.source-code-block,
+.source-code-block * {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.diff-label {
+  white-space: nowrap;
+}
+
+.diff-chip {
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.diff-chip--toggles {
+  align-items: flex-start;
+}
+
+@media (min-width: 640px) {
+  .diff-chip--toggles {
+    align-items: center;
+  }
+}
+
+.diff-view-toggle__btn {
+  border: none;
+  cursor: pointer;
+}
+
+.diff-view-toggle__btn:focus-visible {
+  outline: 2px solid var(--g-accent-border);
+  outline-offset: 1px;
+}
+
+.diff-select--narrow {
+  max-width: 5.5rem;
+}
+
+@media (min-width: 640px) {
+  .diff-select--narrow {
+    max-width: 4.5rem;
+  }
+}
+</style>

--- a/frontend/components/page/PageVotes.vue
+++ b/frontend/components/page/PageVotes.vue
@@ -72,7 +72,7 @@
         <div class="hidden sm:flex items-center gap-1">
           <input
             :value="jumpPage"
-            @input="$emit('update:jump-page', Number(($event.target as HTMLInputElement).value))"
+            @input="emitJumpPage($event)"
             type="number"
             :min="1"
             :max="totalPages"
@@ -105,15 +105,25 @@ defineProps<{
   copiedAnchorId: string | null
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   'copy-anchor': [sectionId: string]
   'refresh': []
   'prev-page': []
   'next-page': []
   'go-page': [n: number]
   'jump': []
-  'update:jump-page': [value: number]
+  'update:jump-page': [value: number | null]
 }>()
+
+function emitJumpPage(event: Event) {
+  const raw = (event.target as HTMLInputElement).value
+  if (raw === '') {
+    emit('update:jump-page', null)
+  } else {
+    const num = Number(raw)
+    if (Number.isFinite(num)) emit('update:jump-page', num)
+  }
+}
 
 function formatDateCompact(dateStr: string) {
   if (!dateStr) return ''

--- a/frontend/components/page/PageVotes.vue
+++ b/frontend/components/page/PageVotes.vue
@@ -1,0 +1,122 @@
+<template>
+  <section id="votes" class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-4 bg-white dark:bg-neutral-900 shadow-sm min-h-[280px] flex flex-col">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-4">
+      <div class="flex items-center gap-2">
+        <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">最近投票</h3>
+        <button
+          type="button"
+          class="inline-flex h-7 w-7 items-center justify-center rounded-full border border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:text-[var(--g-accent)] hover:border-[var(--g-accent-border)] dark:text-neutral-400 dark:hover:text-[var(--g-accent)]"
+          @click="$emit('copy-anchor', 'votes')"
+          :title="copiedAnchorId === 'votes' ? '已复制链接' : '复制该段落链接'"
+        >
+          <LucideIcon v-if="copiedAnchorId === 'votes'" name="Check" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
+          <LucideIcon v-else name="Link" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
+        </button>
+      </div>
+      <div class="text-xs text-neutral-500 dark:text-neutral-400">{{ currentPage }} / {{ totalPages }}</div>
+    </div>
+
+    <div v-if="pending" class="flex-1 flex items-center justify-center text-neutral-500 dark:text-neutral-400">
+      正在加载投票记录…
+    </div>
+
+    <div v-else-if="error" class="flex-1 flex flex-col items-center justify-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
+      加载投票记录失败。
+      <button type="button" class="inline-flex items-center gap-1 text-[var(--g-accent)] hover:underline" @click="$emit('refresh')">重试</button>
+    </div>
+
+    <div v-else-if="!votes || votes.length === 0" class="flex-1 flex items-center justify-center text-neutral-500 dark:text-neutral-400">
+      暂无投票
+    </div>
+
+    <div v-else class="flex-1">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-2">
+        <div
+          v-for="v in votes"
+          :key="`${v.timestamp}-${v.userId || v.userWikidotId}`"
+          :class="[
+            'p-2 rounded',
+            v.direction > 0 ? 'bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800/40' :
+            v.direction < 0 ? 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/40' :
+            'bg-neutral-50 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-800'
+          ]"
+        >
+          <div class="flex items-center gap-2">
+            <div class="min-w-0 flex-1">
+              <UserCard
+                size="sm"
+                :wikidot-id="v.userWikidotId || null"
+                :display-name="v.userDisplayName || '(account deleted)'"
+                :to="v.userWikidotId ? `/user/${v.userWikidotId}` : null"
+                :avatar="true"
+                :viewer-vote="viewerLinkedId != null && Number(v.userWikidotId || 0) === viewerLinkedId ? Number(v.direction || 0) : null"
+              />
+            </div>
+            <div class="text-[11px] text-neutral-600 dark:text-neutral-400 whitespace-nowrap shrink-0 tabular-nums">{{ formatDateCompact(v.timestamp) }}</div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+    <div v-if="votes && votes.length > 0" class="mt-3">
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <button @click="$emit('prev-page')" :disabled="offset === 0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
+        <div class="flex items-center gap-1">
+          <button
+            v-for="n in pageNumbers"
+            :key="`vp-${n}`"
+            @click="$emit('go-page', n)"
+            :class="['text-xs px-2 py-1 rounded border', (currentPage === n) ? 'bg-neutral-200 dark:bg-neutral-700 border-neutral-300 dark:border-neutral-700' : 'bg-neutral-100 dark:bg-neutral-800 border-neutral-200 dark:border-neutral-800']"
+          >{{ n }}</button>
+        </div>
+        <div class="hidden sm:flex items-center gap-1">
+          <input
+            :value="jumpPage"
+            @input="$emit('update:jump-page', Number(($event.target as HTMLInputElement).value))"
+            type="number"
+            :min="1"
+            :max="totalPages"
+            placeholder="页码"
+            @keyup.enter="$emit('jump')"
+            class="w-16 text-xs px-2 py-1 rounded border border-neutral-300 dark:border-neutral-700 bg-neutral-100 dark:bg-neutral-800"
+          />
+          <button @click="$emit('jump')" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">跳转</button>
+        </div>
+        <button @click="$emit('next-page')" :disabled="!hasMore" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { formatDateIsoUtc8 } from '~/utils/timezone'
+
+defineProps<{
+  votes: any[] | null
+  pending: boolean
+  error: any
+  offset: number
+  currentPage: number
+  totalPages: number
+  pageNumbers: number[]
+  hasMore: boolean
+  jumpPage: number | null
+  viewerLinkedId: number | null
+  copiedAnchorId: string | null
+}>()
+
+defineEmits<{
+  'copy-anchor': [sectionId: string]
+  'refresh': []
+  'prev-page': []
+  'next-page': []
+  'go-page': [n: number]
+  'jump': []
+  'update:jump-page': [value: number]
+}>()
+
+function formatDateCompact(dateStr: string) {
+  if (!dateStr) return ''
+  return formatDateIsoUtc8(dateStr)
+}
+</script>

--- a/frontend/components/search/SearchResults.vue
+++ b/frontend/components/search/SearchResults.vue
@@ -1,0 +1,323 @@
+<template>
+  <div v-if="searchPerformed">
+    <div v-if="initialLoading" class="text-sm text-neutral-600 dark:text-neutral-400">搜索中…</div>
+    <div v-else-if="error" class="text-sm text-red-600 dark:text-red-400">搜索失败，请稍后重试</div>
+    <div v-else>
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <div v-if="scope === 'forums'" class="text-sm text-neutral-600 dark:text-neutral-400">
+          找到讨论区帖子 <span class="font-semibold text-[var(--g-accent)]">{{ totalForums }}</span>
+        </div>
+        <div v-else class="text-sm text-neutral-600 dark:text-neutral-400">
+          找到用户 <span class="font-semibold text-[var(--g-accent)]">{{ totalUsers }}</span>
+          ，页面 <span class="font-semibold text-[var(--g-accent)]">{{ totalPages }}</span>
+        </div>
+      </div>
+
+      <div class="space-y-8">
+        <!-- Users -->
+        <section v-if="(scope==='both' || scope==='users') && (totalUsers > 0 || usersLoading)" class="space-y-3">
+          <div class="flex items-center justify-between">
+            <div class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">用户</div>
+            <div class="text-[11px] text-neutral-400 dark:text-neutral-500">共 {{ totalUsers }}</div>
+          </div>
+          <div v-if="usersLoading && userResults.length === 0" class="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+            <div v-for="i in 6" :key="`user-skel-${i}`" class="h-24 rounded-lg border border-neutral-200 bg-neutral-100/70 animate-pulse dark:border-neutral-800 dark:bg-neutral-800/40"></div>
+          </div>
+          <div v-else-if="userResults.length === 0" class="rounded-lg border border-dashed border-neutral-300 bg-neutral-50/80 px-4 py-6 text-sm text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/70 dark:text-neutral-300">
+            暂无用户符合条件。
+          </div>
+          <div v-else class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <UserCard
+              v-for="u in userResults"
+              :key="u.wikidotId || u.id"
+              size="md"
+              :wikidot-id="u.wikidotId"
+              :display-name="u.displayName"
+              :rank="u.rank"
+              :totals="{ totalRating: u.totalRating, works: u.pageCount }"
+            />
+          </div>
+          <div v-if="userLoadingMore" class="flex items-center justify-center text-xs text-neutral-500 dark:text-neutral-400">
+            正在载入更多用户…
+          </div>
+          <div v-else-if="userHasMore" class="flex flex-col items-center gap-2">
+            <button
+              type="button"
+              class="rounded-full border border-neutral-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-neutral-600 hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:bg-neutral-900/70 dark:text-neutral-300"
+              @click="$emit('load-more-users')"
+            >加载更多用户</button>
+            <div ref="userSentinelRef" class="h-1 w-full"></div>
+          </div>
+        </section>
+
+        <!-- Pages -->
+        <section v-if="(scope==='both' || scope==='pages')" class="space-y-4">
+          <div class="flex items-center justify-between">
+            <div class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">页面</div>
+            <div class="text-[11px] text-neutral-400 dark:text-neutral-500">共 {{ totalPages }}</div>
+          </div>
+          <div v-if="pagesLoading && pageResults.length === 0" class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div v-for="i in 6" :key="`page-skel-${i}`" class="h-48 rounded-lg border border-neutral-200 bg-neutral-100/70 animate-pulse dark:border-neutral-800 dark:bg-neutral-800/40"></div>
+          </div>
+          <div v-else-if="pageResults.length === 0" class="rounded-lg border border-dashed border-neutral-300 bg-neutral-50/80 px-4 py-6 text-sm text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/70 dark:text-neutral-300">
+            暂无页面符合条件。
+          </div>
+          <div v-else>
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+              <PageCard size="md" v-for="p in pageResults" :key="p.wikidotId || p.id" :p="p" />
+            </div>
+          </div>
+          <div v-if="pageLoadingMore" class="flex items-center justify-center text-xs text-neutral-500 dark:text-neutral-400">
+            正在载入更多页面…
+          </div>
+          <div v-else-if="pageHasMore" class="flex flex-col items-center gap-2">
+            <button
+              type="button"
+              class="rounded-full border border-neutral-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-neutral-600 hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:bg-neutral-900/70 dark:text-neutral-300"
+              @click="$emit('load-more-pages')"
+            >加载更多页面</button>
+            <div ref="pageSentinelRef" class="h-1 w-full"></div>
+          </div>
+          <div v-else>
+            <div ref="pageSentinelRef" class="h-0 w-full"></div>
+          </div>
+        </section>
+
+        <!-- Forums -->
+        <section v-if="scope==='forums'" class="space-y-4">
+          <div class="flex items-center justify-between">
+            <div class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">讨论区</div>
+            <div class="text-[11px] text-neutral-400 dark:text-neutral-500">共 {{ totalForums }}</div>
+          </div>
+          <div v-if="forumsLoading && forumResults.length === 0" class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div v-for="i in 6" :key="`forum-skel-${i}`" class="h-36 rounded-lg border border-neutral-200 bg-neutral-100/70 animate-pulse dark:border-neutral-800 dark:bg-neutral-800/40"></div>
+          </div>
+          <div v-else-if="forumResults.length === 0" class="rounded-lg border border-dashed border-neutral-300 bg-neutral-50/80 px-4 py-6 text-sm text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/70 dark:text-neutral-300">
+            暂无讨论区帖子符合条件。
+          </div>
+          <div v-else class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <NuxtLink
+              v-for="post in forumResults"
+              :key="post.postId || `${post.threadId}-${post.createdAt}`"
+              :to="forumPostLink(post)"
+              class="block rounded-lg border border-neutral-200 bg-white p-4 shadow-sm transition hover:border-[var(--g-accent-border)] hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
+            >
+              <div class="flex items-start gap-3">
+                <UserAvatar
+                  v-if="post.createdByWikidotId"
+                  :wikidot-id="post.createdByWikidotId"
+                  :name="post.createdByName"
+                  :size="32"
+                  class="shrink-0 mt-0.5"
+                />
+                <div class="min-w-0 flex-1 space-y-1.5">
+                  <h3 class="text-sm font-semibold text-neutral-800 dark:text-neutral-100 line-clamp-1">
+                    {{ post.title || post.threadTitle || '(无标题)' }}
+                  </h3>
+                  <div v-if="post.categoryTitle || post.threadTitle" class="text-xs text-neutral-500 dark:text-neutral-400 line-clamp-1">
+                    <span v-if="post.categoryTitle">{{ post.categoryTitle }}</span>
+                    <span v-if="post.categoryTitle && post.threadTitle"> > </span>
+                    <span v-if="post.threadTitle">{{ post.threadTitle }}</span>
+                  </div>
+                  <p class="text-xs text-neutral-600 dark:text-neutral-300 line-clamp-2" v-html="highlightForumSnippet(post.textHtml, searchQuery)"></p>
+                  <div class="flex items-center gap-2 text-[11px] text-neutral-400 dark:text-neutral-500">
+                    <span v-if="post.createdByName" class="font-medium text-neutral-500 dark:text-neutral-400">{{ post.createdByName }}</span>
+                    <span v-if="post.createdAt">{{ formatForumDate(post.createdAt) }}</span>
+                  </div>
+                </div>
+              </div>
+            </NuxtLink>
+          </div>
+          <div v-if="forumLoadingMore" class="flex items-center justify-center text-xs text-neutral-500 dark:text-neutral-400">
+            正在载入更多帖子…
+          </div>
+          <div v-else-if="forumHasMore" class="flex flex-col items-center gap-2">
+            <button
+              type="button"
+              class="rounded-full border border-neutral-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-neutral-600 hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:bg-neutral-900/70 dark:text-neutral-300"
+              @click="$emit('load-more-forums')"
+            >加载更多帖子</button>
+            <div ref="forumSentinelRef" class="h-1 w-full"></div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
+import UserAvatar from '~/components/UserAvatar.vue'
+
+const props = defineProps<{
+  searchPerformed: boolean
+  initialLoading: boolean
+  error: boolean
+  scope: 'both' | 'users' | 'pages' | 'forums'
+  searchQuery: string
+  userResults: any[]
+  pageResults: any[]
+  forumResults: any[]
+  totalUsers: number
+  totalPages: number
+  totalForums: number
+  usersLoading: boolean
+  pagesLoading: boolean
+  forumsLoading: boolean
+  userLoadingMore: boolean
+  pageLoadingMore: boolean
+  forumLoadingMore: boolean
+  userHasMore: boolean
+  pageHasMore: boolean
+  forumHasMore: boolean
+}>()
+
+const emit = defineEmits<{
+  'load-more-users': []
+  'load-more-pages': []
+  'load-more-forums': []
+}>()
+
+const pageSentinelRef = ref<HTMLElement | null>(null)
+const userSentinelRef = ref<HTMLElement | null>(null)
+const forumSentinelRef = ref<HTMLElement | null>(null)
+
+let pageObserver: IntersectionObserver | null = null
+let userObserver: IntersectionObserver | null = null
+let forumObserver: IntersectionObserver | null = null
+const isClient = typeof window !== 'undefined'
+
+defineExpose({ pageSentinelRef, userSentinelRef, forumSentinelRef })
+
+function forumPostLink(post: any): string {
+  const threadId = Number(post?.threadId)
+  if (!Number.isInteger(threadId) || threadId <= 0) {
+    return '/forums'
+  }
+  const postId = Number(post?.postId ?? post?.id)
+  if (Number.isInteger(postId) && postId > 0) {
+    return `/forums/t/${threadId}?postId=${postId}`
+  }
+  return `/forums/t/${threadId}`
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function stripHtml(html: string | null | undefined): string {
+  if (!html) return ''
+  return html.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').replace(/&[a-zA-Z]+;/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+function highlightForumSnippet(html: string | null | undefined, query: string): string {
+  const text = stripHtml(html)
+  if (!text) return ''
+
+  const q = query.trim()
+  if (!q) return escapeHtml(text.slice(0, 200)) + (text.length > 200 ? '...' : '')
+
+  const lowerText = text.toLowerCase()
+  const lowerQ = q.toLowerCase()
+  const firstIdx = lowerText.indexOf(lowerQ)
+
+  if (firstIdx === -1) {
+    return escapeHtml(text.slice(0, 200)) + (text.length > 200 ? '...' : '')
+  }
+
+  const prefixLen = Math.min(firstIdx, 5)
+  const start = firstIdx - prefixLen
+  const snippetLen = 200
+  const end = Math.min(text.length, start + snippetLen)
+  const snippet = text.slice(start, end)
+
+  const lowerSnippet = snippet.toLowerCase()
+  let result = ''
+  let pos = 0
+  while (pos < snippet.length) {
+    const matchPos = lowerSnippet.indexOf(lowerQ, pos)
+    if (matchPos === -1) {
+      result += escapeHtml(snippet.slice(pos))
+      break
+    }
+    result += escapeHtml(snippet.slice(pos, matchPos))
+    result += `<span class="keyword">${escapeHtml(snippet.slice(matchPos, matchPos + q.length))}</span>`
+    pos = matchPos + q.length
+  }
+
+  if (start > 0) result = '...' + result
+  if (end < text.length) result += '...'
+
+  return result
+}
+
+function formatForumDate(dateStr: string | null | undefined): string {
+  if (!dateStr) return ''
+  const d = new Date(dateStr)
+  if (isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('zh-CN', { year: 'numeric', month: '2-digit', day: '2-digit' })
+}
+
+function setupPageObserver() {
+  if (!isClient || typeof IntersectionObserver === 'undefined') return
+  if (pageObserver) pageObserver.disconnect()
+  pageObserver = new IntersectionObserver((entries) => {
+    if (entries.some(entry => entry.isIntersecting)) {
+      emit('load-more-pages')
+    }
+  }, { rootMargin: '320px 0px' })
+  if (pageSentinelRef.value) pageObserver.observe(pageSentinelRef.value)
+}
+
+function setupUserObserver() {
+  if (!isClient || typeof IntersectionObserver === 'undefined') return
+  if (userObserver) userObserver.disconnect()
+  userObserver = new IntersectionObserver((entries) => {
+    if (entries.some(entry => entry.isIntersecting)) {
+      emit('load-more-users')
+    }
+  }, { rootMargin: '320px 0px' })
+  if (userSentinelRef.value) userObserver.observe(userSentinelRef.value)
+}
+
+function setupForumObserver() {
+  if (!isClient || typeof IntersectionObserver === 'undefined') return
+  if (forumObserver) forumObserver.disconnect()
+  forumObserver = new IntersectionObserver((entries) => {
+    if (entries.some(entry => entry.isIntersecting)) {
+      emit('load-more-forums')
+    }
+  }, { rootMargin: '320px 0px' })
+  if (forumSentinelRef.value) forumObserver.observe(forumSentinelRef.value)
+}
+
+watch(pageSentinelRef, (newEl, oldEl) => {
+  if (!isClient || !pageObserver) return
+  if (oldEl) pageObserver.unobserve(oldEl)
+  if (newEl) pageObserver.observe(newEl)
+})
+
+watch(userSentinelRef, (newEl, oldEl) => {
+  if (!isClient || !userObserver) return
+  if (oldEl) userObserver.unobserve(oldEl)
+  if (newEl) userObserver.observe(newEl)
+})
+
+watch(forumSentinelRef, (newEl, oldEl) => {
+  if (!isClient || !forumObserver) return
+  if (oldEl) forumObserver.unobserve(oldEl)
+  if (newEl) forumObserver.observe(newEl)
+})
+
+onMounted(() => {
+  setupPageObserver()
+  setupUserObserver()
+  setupForumObserver()
+})
+
+onBeforeUnmount(() => {
+  if (pageObserver) { pageObserver.disconnect(); pageObserver = null }
+  if (userObserver) { userObserver.disconnect(); userObserver = null }
+  if (forumObserver) { forumObserver.disconnect(); forumObserver = null }
+})
+</script>

--- a/frontend/pages/page/[wikidotId]/index.vue
+++ b/frontend/pages/page/[wikidotId]/index.vue
@@ -538,8 +538,9 @@ function goRevPage(n:number){
 }
 const revJumpPage = ref<number | null>(null)
 function jumpToRevPage(){
+  if (revJumpPage.value == null) return
   const raw = Number(revJumpPage.value)
-  if (!Number.isFinite(raw)) return
+  if (!Number.isFinite(raw) || raw < 1) return
   const target = Math.max(1, Math.min(revTotalPages.value, Math.trunc(raw)))
   revPage.value = target - 1
   revJumpPage.value = target
@@ -638,8 +639,9 @@ function nextVotePage(){ if (hasMoreVotes.value) voteOffset.value += votePageSiz
 function prevVotePage(){ voteOffset.value = Math.max(0, voteOffset.value - votePageSize.value) }
 const voteJumpPage = ref<number | null>(null)
 function jumpToVotePage(){
+  if (voteJumpPage.value == null) return
   const raw = Number(voteJumpPage.value)
-  if (!Number.isFinite(raw)) return
+  if (!Number.isFinite(raw) || raw < 1) return
   const target = Math.max(1, Math.min(voteTotalPages.value, Math.trunc(raw)))
   voteOffset.value = (target - 1) * votePageSize.value
   voteJumpPage.value = target

--- a/frontend/pages/page/[wikidotId]/index.vue
+++ b/frontend/pages/page/[wikidotId]/index.vue
@@ -108,85 +108,25 @@
         </div>
       </section>
 
-      <!-- Metrics (4 cards) -->
-      <section id="metrics" class="space-y-3">
-        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div class="flex items-center gap-2">
-            <h2 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">核心指标</h2>
-            <button
-              type="button"
-              class="inline-flex h-7 w-7 items-center justify-center rounded-full border border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:text-[var(--g-accent)] hover:border-[var(--g-accent-border)] dark:text-neutral-400 dark:hover:text-[var(--g-accent)]"
-              @click="copyAnchorLink('metrics')"
-              :title="copiedAnchorId === 'metrics' ? '已复制链接' : '复制该段落链接'"
-            >
-              <LucideIcon v-if="copiedAnchorId === 'metrics'" name="Check" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
-              <LucideIcon v-else name="Link" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
-            </button>
-          </div>
-          <span v-if="metricsUpdatedAt" class="text-xs text-neutral-500 dark:text-neutral-400">
-            更新于 {{ formatDate(metricsUpdatedAt) }}
-          </span>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-          <!-- 评分 -->
-          <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-3 bg-white dark:bg-neutral-900 shadow-sm">
-            <div class="flex items-start justify-between">
-              <div class="text-[12px] text-neutral-600 dark:text-neutral-400">评分</div>
-              <div class="text-lg font-bold text-neutral-900 dark:text-neutral-100" :title="ratingTooltip">
-                {{ totalScoreDisplay }}
-              </div>
-            </div>
-            <div class="mt-2 grid grid-cols-2 text-[11px]">
-              <div class="text-green-600 dark:text-green-400">↑ {{ upvotes }}</div>
-              <div class="text-red-600 dark:text-red-400 text-right">↓ {{ downvotes }}</div>
-            </div>
-            <div class="mt-2 h-1.5 w-full rounded bg-neutral-200 dark:bg-neutral-800 overflow-hidden flex">
-              <div class="h-full bg-[var(--g-accent)]" :style="{ width: upvotePct + '%' }" aria-hidden="true"></div>
-              <div class="h-full bg-red-500" :style="{ width: downvotePct + '%' }" aria-hidden="true"></div>
-            </div>
-          </div>
+      <!-- Metrics -->
+      <PageMetrics
+        :total-score-display="totalScoreDisplay"
+        :upvotes="upvotes"
+        :downvotes="downvotes"
+        :total-votes="totalVotes"
+        :upvote-pct="upvotePct"
+        :downvote-pct="downvotePct"
+        :like-ratio-pct="likeRatioPct"
+        :wilson-l-b="wilsonLB"
+        :controversy-idx="controversyIdx"
+        :rating-tooltip="ratingTooltip"
+        :vote-tooltip="voteTooltip"
+        :wilson-tooltip="wilsonTooltip"
+        :metrics-updated-at="metricsUpdatedAt"
+        :copied-anchor-id="copiedAnchorId"
+        @copy-anchor="copyAnchorLink"
+      />
 
-          <!-- 支持率 -->
-          <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-3 bg-white dark:bg-neutral-900 shadow-sm">
-            <div class="flex items-start justify-between">
-              <div class="text-[12px] text-neutral-600 dark:text-neutral-400">支持率</div>
-              <div class="text-lg font-bold text-neutral-900 dark:text-neutral-100" :title="voteTooltip">
-                {{ likeRatioPct.toFixed(0) }}%
-              </div>
-            </div>
-            <div class="mt-2 text-[11px] text-neutral-500 dark:text-neutral-400">总票数 {{ totalVotes }}</div>
-            <div class="mt-2 h-1.5 w-full rounded bg-neutral-200 dark:bg-neutral-800 overflow-hidden">
-              <div class="h-full bg-[var(--g-accent)]" :style="{ width: likeRatioPct + '%' }" aria-hidden="true"></div>
-            </div>
-          </div>
-
-          <!-- Wilson95 下界 -->
-          <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-3 bg-white dark:bg-neutral-900 shadow-sm">
-            <div class="flex items-start justify-between">
-              <div class="text-[12px] text-neutral-600 dark:text-neutral-400">Wilson 95% 下界</div>
-              <div class="text-lg font-bold text-neutral-900 dark:text-neutral-100" :title="wilsonTooltip">
-                {{ (wilsonLB * 100).toFixed(1) }}%
-              </div>
-            </div>
-            <div class="mt-2 text-[11px] text-neutral-500 dark:text-neutral-400">
-              在相同票数下更稳健的支持率估计
-            </div>
-            <div class="mt-2 h-1.5 w-full rounded bg-neutral-200 dark:bg-neutral-800 overflow-hidden">
-              <div class="h-full bg-[var(--g-accent)]" :style="{ width: Math.max(0, Math.min(100, wilsonLB * 100)) + '%' }" aria-hidden="true"></div>
-            </div>
-          </div>
-
-          <!-- 争议指数 -->
-          <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-3 bg-white dark:bg-neutral-900 shadow-sm">
-            <div class="flex items-start justify-between">
-              <div class="text-[12px] text-neutral-600 dark:text-neutral-400">争议指数</div>
-              <div class="text-lg font-bold text-neutral-900 dark:text-neutral-100">
-                {{ controversyIdx.toFixed(3) }}
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
       <!-- Chart -->
       <section
         v-if="ratingHistoryPending || ratingHistoryError || (Array.isArray(ratingHistory) && ratingHistory.length)"
@@ -231,190 +171,48 @@
       </section>
 
       <!-- Revisions -->
-      <section id="revisions" class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-4 bg-white dark:bg-neutral-900 shadow-sm min-h-[280px] flex flex-col">
-          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-4">
-            <div class="flex items-center gap-2">
-              <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">最近修订</h3>
-              <button
-                type="button"
-                class="inline-flex h-7 w-7 items-center justify-center rounded-full border border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:text-[var(--g-accent)] hover:border-[var(--g-accent-border)] dark:text-neutral-400 dark:hover:text-[var(--g-accent)]"
-                @click="copyAnchorLink('revisions')"
-                :title="copiedAnchorId === 'revisions' ? '已复制链接' : '复制该段落链接'"
-              >
-                <LucideIcon v-if="copiedAnchorId === 'revisions'" name="Check" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
-                <LucideIcon v-else name="Link" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
-              </button>
-            </div>
-            <div class="text-xs text-neutral-500 dark:text-neutral-400">{{ (revPage + 1) }} / {{ revTotalPages }}</div>
-          </div>
-
-          <div v-if="revisionsPending" class="flex-1 flex items-center justify-center text-neutral-500 dark:text-neutral-400">
-            正在加载修订记录…
-          </div>
-
-          <div v-else-if="revisionsError" class="flex-1 flex flex-col items-center justify-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
-            加载修订记录失败。
-            <button type="button" class="inline-flex items-center gap-1 text-[var(--g-accent)] hover:underline" @click="refreshRevisions()">重试</button>
-          </div>
-
-          <div v-else-if="!revisionsPaged || revisionsPaged.length === 0" class="flex-1 flex items-center justify-center text-neutral-500 dark:text-neutral-400">
-            暂无修订记录
-          </div>
-
-          <div v-else class="flex-1">
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
-              <div
-                v-for="rev in revisionsPaged"
-                :key="rev.revisionId || rev.wikidotId"
-                class="p-2 rounded border border-neutral-200 dark:border-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-800"
-              >
-                <div class="flex items-center justify-between gap-3">
-                  <div class="flex items-center gap-2 min-w-0">
-                    <span :class="['inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium shrink-0 w-[120px] justify-center', revisionTypeClass(rev.type)]">
-                      {{ formatRevisionType(rev.type) }}
-                    </span>
-                    <div class="min-w-0">
-                      <UserCard
-                        size="sm"
-                        :wikidot-id="rev.userWikidotId || null"
-                        :display-name="rev.userDisplayName || '(account deleted)'"
-                        :to="rev.userWikidotId ? `/user/${rev.userWikidotId}` : null"
-                        :avatar="true"
-                      />
-                    </div>
-                  </div>
-                  <div class="text-xs text-neutral-500 dark:text-neutral-400 whitespace-nowrap shrink-0">{{ formatRelativeTime(rev.timestamp) }}</div>
-                </div>
-                <div v-if="rev.comment" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;">{{ rev.comment }}</div>
-              </div>
-            </div>
-
-          </div>
-          <div v-if="revisionsPaged && revisionsPaged.length > 0" class="mt-3">
-            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <button @click="prevRevPage" :disabled="revPage === 0"
-                      class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
-              <div class="flex items-center gap-1">
-                <button
-                  v-for="n in revPageNumbers"
-                  :key="`rp-${n}`"
-                  @click="goRevPage(n)"
-                  :class="['text-xs px-2 py-1 rounded border', (revPage + 1 === n) ? 'bg-neutral-200 dark:bg-neutral-700 border-neutral-300 dark:border-neutral-700' : 'bg-neutral-100 dark:bg-neutral-800 border-neutral-200 dark:border-neutral-800']"
-                >{{ n }}</button>
-              </div>
-              <div class="hidden sm:flex items-center gap-1">
-                <input
-                  v-model.number="revJumpPage"
-                  type="number"
-                  :min="1"
-                  :max="revTotalPages"
-                  placeholder="页码"
-                  @keyup.enter="jumpToRevPage"
-                  class="w-16 text-xs px-2 py-1 rounded border border-neutral-300 dark:border-neutral-700 bg-neutral-100 dark:bg-neutral-800"
-                />
-                <button @click="jumpToRevPage" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">跳转</button>
-              </div>
-              <button @click="nextRevPage" :disabled="!hasMoreRevisions"
-                      class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
-            </div>
-          </div>
-
-          
-      </section>
+      <PageRevisions
+        :revisions="revisionsPaged"
+        :pending="revisionsPending"
+        :error="revisionsError"
+        :rev-page="revPage"
+        :rev-total-pages="revTotalPages"
+        :rev-page-numbers="revPageNumbers"
+        :has-more="hasMoreRevisions"
+        :jump-page="revJumpPage"
+        :copied-anchor-id="copiedAnchorId"
+        @copy-anchor="copyAnchorLink"
+        @refresh="refreshRevisions()"
+        @prev-page="prevRevPage"
+        @next-page="nextRevPage"
+        @go-page="goRevPage"
+        @jump="jumpToRevPage"
+        @update:jump-page="revJumpPage = $event"
+      />
 
       <!-- Recent Votes -->
-      <section id="votes" class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-4 bg-white dark:bg-neutral-900 shadow-sm min-h-[280px] flex flex-col">
-          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-4">
-            <div class="flex items-center gap-2">
-              <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">最近投票</h3>
-              <button
-                type="button"
-                class="inline-flex h-7 w-7 items-center justify-center rounded-full border border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:text-[var(--g-accent)] hover:border-[var(--g-accent-border)] dark:text-neutral-400 dark:hover:text-[var(--g-accent)]"
-                @click="copyAnchorLink('votes')"
-                :title="copiedAnchorId === 'votes' ? '已复制链接' : '复制该段落链接'"
-              >
-                <LucideIcon v-if="copiedAnchorId === 'votes'" name="Check" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
-                <LucideIcon v-else name="Link" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
-              </button>
-            </div>
-            <div class="text-xs text-neutral-500 dark:text-neutral-400">{{ currentVotePage }} / {{ voteTotalPages }}</div>
-          </div>
+      <PageVotes
+        :votes="recentVotes"
+        :pending="recentVotesPending"
+        :error="recentVotesError"
+        :offset="voteOffset"
+        :current-page="currentVotePage"
+        :total-pages="voteTotalPages"
+        :page-numbers="votePageNumbers"
+        :has-more="hasMoreVotes"
+        :jump-page="voteJumpPage"
+        :viewer-linked-id="viewerLinkedId"
+        :copied-anchor-id="copiedAnchorId"
+        @copy-anchor="copyAnchorLink"
+        @refresh="refreshRecentVotes()"
+        @prev-page="prevVotePage"
+        @next-page="nextVotePage"
+        @go-page="goVotePage"
+        @jump="jumpToVotePage"
+        @update:jump-page="voteJumpPage = $event"
+      />
 
-          <div v-if="recentVotesPending" class="flex-1 flex items-center justify-center text-neutral-500 dark:text-neutral-400">
-            正在加载投票记录…
-          </div>
-
-          <div v-else-if="recentVotesError" class="flex-1 flex flex-col items-center justify-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
-            加载投票记录失败。
-            <button type="button" class="inline-flex items-center gap-1 text-[var(--g-accent)] hover:underline" @click="refreshRecentVotes()">重试</button>
-          </div>
-
-          <div v-else-if="!recentVotes || recentVotes.length === 0" class="flex-1 flex items-center justify-center text-neutral-500 dark:text-neutral-400">
-            暂无投票
-          </div>
-
-          <div v-else class="flex-1">
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-2">
-              <div
-                v-for="v in recentVotes"
-                :key="`${v.timestamp}-${v.userId || v.userWikidotId}`"
-                :class="[
-                  'p-2 rounded',
-                  v.direction > 0 ? 'bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800/40' :
-                  v.direction < 0 ? 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/40' :
-                  'bg-neutral-50 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-800'
-                ]"
-              >
-                <div class="flex items-center gap-2">
-                  <div class="min-w-0 flex-1">
-                    <UserCard
-                      size="sm"
-                      :wikidot-id="v.userWikidotId || null"
-                      :display-name="v.userDisplayName || '(account deleted)'"
-                      :to="v.userWikidotId ? `/user/${v.userWikidotId}` : null"
-                      :avatar="true"
-                      :viewer-vote="viewerLinkedId != null && Number(v.userWikidotId || 0) === viewerLinkedId ? Number(v.direction || 0) : null"
-                    />
-                  </div>
-                  <div class="text-[11px] text-neutral-600 dark:text-neutral-400 whitespace-nowrap shrink-0 tabular-nums">{{ formatDateCompact(v.timestamp) }}</div>
-                </div>
-              </div>
-            </div>
-
-          </div>
-          <div v-if="recentVotes && recentVotes.length > 0" class="mt-3">
-            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <button @click="prevVotePage" :disabled="voteOffset === 0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
-              <div class="flex items-center gap-1">
-                <button
-                  v-for="n in votePageNumbers"
-                  :key="`vp-${n}`"
-                  @click="goVotePage(n)"
-                  :class="['text-xs px-2 py-1 rounded border', (currentVotePage === n) ? 'bg-neutral-200 dark:bg-neutral-700 border-neutral-300 dark:border-neutral-700' : 'bg-neutral-100 dark:bg-neutral-800 border-neutral-200 dark:border-neutral-800']"
-                >{{ n }}</button>
-              </div>
-              <div class="hidden sm:flex items-center gap-1">
-                <input
-                  v-model.number="voteJumpPage"
-                  type="number"
-                  :min="1"
-                  :max="voteTotalPages"
-                  placeholder="页码"
-                  @keyup.enter="jumpToVotePage"
-                  class="w-16 text-xs px-2 py-1 rounded border border-neutral-300 dark:border-neutral-700 bg-neutral-100 dark:bg-neutral-800"
-                />
-                <button @click="jumpToVotePage" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">跳转</button>
-              </div>
-              <button @click="nextVotePage" :disabled="!hasMoreVotes" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
-            </div>
-          </div>
-
-          
-      </section>
-
-      
-
-      <!-- Related Pages (Recommendations) -->
+      <!-- Related Pages -->
       <section id="related" class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-4">
           <div class="flex items-center gap-2">
@@ -477,344 +275,29 @@
         </div>
       </section>
 
-      <section
-        v-if="pageImagesPending || hasPageImages || pageImagesError"
-        id="page-images"
-        class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm"
-      >
-        <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div class="space-y-1">
-            <div class="flex items-center gap-2">
-              <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-200">相关图片</h3>
-              <button
-                type="button"
-                class="inline-flex h-7 w-7 items-center justify-center rounded-full border border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:text-[var(--g-accent)] hover:border-[var(--g-accent-border)] dark:text-neutral-400 dark:hover:text-[var(--g-accent)]"
-                @click="copyAnchorLink('page-images')"
-                :title="copiedAnchorId === 'page-images' ? '已复制链接' : '复制该段落链接'"
-              >
-                <LucideIcon v-if="copiedAnchorId === 'page-images'" name="Check" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
-                <LucideIcon v-else name="Link" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
-              </button>
-            </div>
-            <p v-if="hasPageImages" class="text-xs text-neutral-500 dark:text-neutral-400">
-              第 {{ pageImagePage }} / {{ pageImageTotalPages }} 页 · 展示 {{ pageImageRangeLabel }} · 共 {{ pageImages.length }} 张
-            </p>
-            <p v-else class="text-xs text-neutral-500 dark:text-neutral-400">
-              暂无可用图片资源。
-            </p>
-          </div>
-          <div v-if="hasPageImages" class="flex flex-wrap items-center gap-3 text-xs text-neutral-500 dark:text-neutral-400">
-            <div class="inline-flex items-center gap-2">
-              <span class="hidden sm:inline">每行数量</span>
-              <div class="inline-flex overflow-hidden rounded-full border border-neutral-200 dark:border-neutral-700 bg-neutral-100/60 dark:bg-neutral-800/60">
-                <button
-                  v-for="option in pageImageSizeOptions"
-                  :key="option.value"
-                  type="button"
-                  @click="pageImageColumns = option.value"
-                  :class="[
-                    'px-3 py-1 font-medium transition-colors',
-                    pageImageColumns === option.value
-                      ? 'bg-white dark:bg-neutral-700 text-[var(--g-accent)] shadow'
-                      : 'text-neutral-600 dark:text-neutral-300 hover:text-[var(--g-accent)]'
-                  ]"
-                >
-                  {{ option.label }} ({{ option.value }})
-                </button>
-              </div>
-            </div>
-            <div class="inline-flex items-center gap-2">
-              <button
-                type="button"
-                class="inline-flex items-center gap-1 rounded-full border border-neutral-200 dark:border-neutral-700 px-3 py-1 text-neutral-600 dark:text-neutral-300 hover:border-[var(--g-accent)] hover:text-[var(--g-accent)] disabled:opacity-40"
-                @click="pageImagePage = Math.max(1, pageImagePage - 1)"
-                :disabled="pageImagePage <= 1"
-              >上一页</button>
-              <button
-                type="button"
-                class="inline-flex items-center gap-1 rounded-full border border-neutral-200 dark:border-neutral-700 px-3 py-1 text-neutral-600 dark:text-neutral-300 hover:border-[var(--g-accent)] hover:text-[var(--g-accent)] disabled:opacity-40"
-                @click="pageImagePage = Math.min(pageImageTotalPages, pageImagePage + 1)"
-                :disabled="pageImagePage >= pageImageTotalPages"
-              >下一页</button>
-            </div>
-          </div>
-        </div>
-
-        <div v-if="pageImagesPending" class="mt-6 text-sm text-neutral-500 dark:text-neutral-400">正在加载图片…</div>
-        <div v-else-if="pageImagesError" class="mt-6 rounded-lg border border-dashed border-neutral-300 dark:border-neutral-700 bg-neutral-50/80 dark:bg-neutral-900/60 p-6 text-sm text-neutral-600 dark:text-neutral-400">
-          加载图片失败。
-          <button type="button" class="ml-2 inline-flex items-center gap-1 text-[var(--g-accent)] hover:underline" @click="refreshPageImages()">重试</button>
-        </div>
-        <div v-else-if="hasPageImages" class="page-images-grid mt-4" :style="pageImageGridStyle">
-          <figure
-            v-for="img in paginatedPageImages"
-            :key="img.imageKey"
-            class="group space-y-2"
-          >
-            <button
-              type="button"
-              class="page-image-trigger relative w-full overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-900/40"
-              :style="img.aspectStyle"
-              :title="`放大查看：${img.label || pageDisplayTitle}`"
-              @click="openPageImagePreview(img)"
-            >
-              <img
-                :src="img.imageSrc"
-                :srcset="img.imageSrcFull && img.imageSrc ? `${img.imageSrc} 1x, ${img.imageSrcFull} 2x` : undefined"
-                :alt="img.label || pageDisplayTitle"
-                loading="lazy"
-                class="absolute inset-0 h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.03]"
-              >
-              <span class="page-image-zoom-chip">点击放大</span>
-            </button>
-            <figcaption class="flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400">
-              <span class="min-w-0 flex-1 truncate">
-                {{ img.label || '图片资源' }}
-              </span>
-              <button
-                type="button"
-                class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-neutral-200 text-neutral-500 transition hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
-                :title="copiedPageImageKey === img.imageKey ? '已复制图片 URL' : '复制图片 URL'"
-                @click="copyPageImageUrl(img)"
-              >
-                <LucideIcon
-                  v-if="copiedPageImageKey === img.imageKey"
-                  name="Check"
-                  class="h-3.5 w-3.5"
-                  stroke-width="2"
-                  aria-hidden="true"
-                />
-                <LucideIcon
-                  v-else
-                  name="Copy"
-                  class="h-3.5 w-3.5"
-                  stroke-width="2"
-                  aria-hidden="true"
-                />
-              </button>
-            </figcaption>
-          </figure>
-        </div>
-        <div v-else class="mt-6 text-sm text-neutral-500 dark:text-neutral-400">暂无图片。</div>
-        <ImagePreviewDialog
-          v-if="pageImagePreviewItem"
-          v-model:open="pageImagePreviewOpen"
-          :src="pageImagePreviewItem.imageSrcFull || pageImagePreviewItem.imageSrc"
-          :alt="pageImagePreviewItem.label || pageDisplayTitle"
-          :title="pageImagePreviewItem.label || pageDisplayTitle"
-          :copy-url="pageImagePreviewItem.copyUrl"
-        />
-      </section>
+      <!-- Page Images -->
+      <PageImages
+        :images="pageImages"
+        :pending="pageImagesPending"
+        :error="pageImagesError"
+        :page-display-title="pageDisplayTitle"
+        :copied-anchor-id="copiedAnchorId"
+        @copy-anchor="copyAnchorLink"
+        @refresh="refreshPageImages()"
+      />
 
       <!-- Source Viewer -->
-      <section id="page-source" class="border border-neutral-200 dark:border-neutral-800 rounded-lg bg-white dark:bg-neutral-900 shadow-sm">
-        <header class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between px-6 pt-6">
-          <div class="flex items-center gap-2">
-            <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">页面源码</h3>
-            <button
-              type="button"
-              class="inline-flex h-7 w-7 items-center justify-center rounded-full border border-neutral-200 dark:border-neutral-700 text-neutral-500 hover:text-[var(--g-accent)] hover:border-[var(--g-accent-border)] dark:text-neutral-400 dark:hover:text-[var(--g-accent)]"
-              @click="copyAnchorLink('page-source')"
-              :title="copiedAnchorId === 'page-source' ? '已复制链接' : '复制该段落链接'"
-            >
-              <LucideIcon v-if="copiedAnchorId === 'page-source'" name="Check" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
-              <LucideIcon v-else name="Link" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
-            </button>
-          </div>
-          <div class="flex flex-wrap items-center gap-3">
-            <button @click="toggleDiffMode"
-                    class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700">
-              {{ diffMode ? '退出对比' : '对比版本' }}
-            </button>
-
-            <div v-if="!diffMode" class="flex items-center gap-2">
-              <label class="text-xs text-neutral-500 dark:text-neutral-400">页面版本:</label>
-              <select v-model="selectedVersion" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">
-                <option v-for="v in pageVersions" :key="v.pageVersionId" :value="v.pageVersionId">
-                  {{ v.validTo ? '历史' : '当前' }} · {{ formatDate(v.createdAt) }} · {{ v.title || '' }}
-                </option>
-              </select>
-            </div>
-
-            <div v-else class="diff-toolbar flex flex-col gap-2 text-xs text-neutral-600 dark:text-neutral-400 sm:flex-row sm:flex-wrap sm:items-stretch sm:gap-3">
-              <div class="diff-chip flex items-center gap-2 px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-100/70 dark:bg-neutral-800/60 shadow-sm sm:flex-[1_1_220px]">
-                <span class="diff-label text-neutral-500 dark:text-neutral-300">基准</span>
-                <select
-                  v-model="baseVersionId"
-                  class="diff-select flex-1 min-w-0 px-2 py-1 rounded border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-[var(--g-accent-border)]"
-                >
-                  <option v-for="v in orderedVersions" :key="`b-${v.pageVersionId}`" :value="v.pageVersionId">
-                    {{ v.validTo ? '历史' : '当前' }} · {{ formatDate(v.createdAt) }} · {{ v.title || '' }}
-                  </option>
-                </select>
-              </div>
-              <div class="diff-chip flex items-center gap-2 px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-100/70 dark:bg-neutral-800/60 shadow-sm sm:flex-[1_1_220px]">
-                <span class="diff-label text-neutral-500 dark:text-neutral-300">对比</span>
-                <select
-                  v-model="compareVersionId"
-                  class="diff-select flex-1 min-w-0 px-2 py-1 rounded border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-[var(--g-accent-border)]"
-                >
-                  <option v-for="v in orderedVersions" :key="`c-${v.pageVersionId}`" :value="v.pageVersionId">
-                    {{ v.validTo ? '历史' : '当前' }} · {{ formatDate(v.createdAt) }} · {{ v.title || '' }}
-                  </option>
-                </select>
-              </div>
-              <div class="diff-chip flex items-center gap-3 px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-100/70 dark:bg-neutral-800/60 shadow-sm sm:flex-[1_1_200px]">
-                <span class="diff-label text-neutral-500 dark:text-neutral-300">视图</span>
-                <div class="diff-view-toggle inline-flex items-center rounded-full bg-neutral-200/60 dark:bg-neutral-800/70 p-[3px]">
-                  <button
-                    type="button"
-                    :class="[
-                      'diff-view-toggle__btn px-3 py-1 rounded-full text-[11px] font-medium transition-colors',
-                      diffViewMode === 'unified'
-                        ? 'bg-white text-[var(--g-accent)] shadow-sm dark:bg-neutral-700'
-                        : 'text-neutral-600 hover:text-neutral-800 dark:text-neutral-300 dark:hover:text-neutral-100'
-                    ]"
-                    @click="diffViewMode = 'unified'"
-                  >
-                    合并
-                  </button>
-                  <button
-                    type="button"
-                    :class="[
-                      'diff-view-toggle__btn px-3 py-1 rounded-full text-[11px] font-medium transition-colors',
-                      diffViewMode === 'split'
-                        ? 'bg-white text-[var(--g-accent)] shadow-sm dark:bg-neutral-700'
-                        : 'text-neutral-600 hover:text-neutral-800 dark:text-neutral-300 dark:hover:text-neutral-100'
-                    ]"
-                    @click="diffViewMode = 'split'"
-                  >
-                    并排
-                  </button>
-                </div>
-              </div>
-              <div class="diff-chip diff-chip--context flex items-center gap-2 px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-100/70 dark:bg-neutral-800/60 shadow-sm sm:flex-[0_1_150px]">
-                <span class="diff-label text-neutral-500 dark:text-neutral-300">上下文</span>
-                <select
-                  v-model.number="diffContextLines"
-                  class="diff-select diff-select--narrow flex-none px-2 py-1 rounded border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-[var(--g-accent-border)]"
-                >
-                  <option :value="1">1</option>
-                  <option :value="2">2</option>
-                  <option :value="3">3</option>
-                  <option :value="5">5</option>
-                </select>
-              </div>
-              <div class="diff-chip diff-chip--toggles flex gap-2 px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-100/70 dark:bg-neutral-800/60 shadow-sm sm:flex-[1_1_220px]">
-                <span class="diff-label text-neutral-500 dark:text-neutral-300">显示</span>
-                <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-                  <label class="inline-flex items-center gap-2">
-                    <input type="checkbox" v-model="ignoreWhitespace" class="rounded">
-                    <span class="text-neutral-600 dark:text-neutral-300">忽略空白</span>
-                  </label>
-                  <label class="inline-flex items-center gap-2">
-                    <input type="checkbox" v-model="diffCollapseUnchanged" class="rounded">
-                    <span class="text-neutral-600 dark:text-neutral-300">折叠未变化</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-
-            <div class="flex items-center gap-2">
-              <button @click="copySource" :disabled="diffMode" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 disabled:opacity-50">
-                复制源码
-              </button>
-              <button @click="downloadSource" :disabled="diffMode" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 disabled:opacity-50">
-                下载源码
-              </button>
-            </div>
-          </div>
-        </header>
-
-        <div class="mt-4 border-t border-neutral-100 dark:border-neutral-800"></div>
-
-        <div v-if="!diffMode" class="px-6 pb-6">
-          <div class="mb-2 text-[11px] text-neutral-500 dark:text-neutral-400 flex flex-wrap items-center gap-x-2 gap-y-1">
-            <span>源码字符数 {{ sourceCharacterCount }}</span>
-            <span aria-hidden="true">·</span>
-            <span>文字字数 {{ textContentCharacterCount }}</span>
-          </div>
-          <pre class="source-code-block border border-neutral-200 dark:border-neutral-700 rounded bg-neutral-50 dark:bg-neutral-800 p-3 max-h-96 overflow-auto text-xs font-mono whitespace-pre-wrap select-text"
-               aria-label="页面源码内容">{{ displayedSource }}</pre>
-        </div>
-
-        <div v-else class="px-6 pb-6">
-          <div class="source-code-block border border-neutral-200 dark:border-neutral-700 rounded bg-neutral-50 dark:bg-neutral-800 overflow-hidden text-xs font-mono select-text">
-            <div v-if="diffLoading" class="px-3 py-4 text-neutral-500 dark:text-neutral-400">计算对比中…</div>
-            <div v-else-if="diffError" class="px-3 py-4 text-red-600 dark:text-red-400">{{ diffError }}</div>
-            <div v-else-if="!diffData" class="px-3 py-4 text-neutral-500 dark:text-neutral-400">尚未生成对比</div>
-            <template v-else>
-              <div class="flex flex-wrap items-center gap-3 px-3 py-2 text-[11px] text-neutral-600 dark:text-neutral-400 border-b border-neutral-200 dark:border-neutral-700 bg-white/60 dark:bg-neutral-900/40">
-                <span>变化 {{ diffSummary.blocks }} 处 · +{{ diffSummary.added }} / -{{ diffSummary.removed }}</span>
-                <span v-if="!diffHasChanges" class="text-neutral-500 dark:text-neutral-400">两个版本内容一致</span>
-              </div>
-              <div v-if="diffViewMode === 'unified'" class="diff-viewer-unified max-h-[28rem] overflow-auto">
-                <template v-for="row in diffUnifiedRows" :key="row.kind === 'fold' ? `fold-${row.id}` : row.key">
-                  <div v-if="row.kind === 'fold'" class="border-b border-neutral-200 dark:border-neutral-700 bg-neutral-100/60 dark:bg-neutral-800/60 px-3 py-2">
-                    <button type="button" @click="toggleDiffFold(row.id)"
-                            class="inline-flex items-center gap-1 text-[11px] text-neutral-600 dark:text-neutral-300">
-                      <span>{{ row.isExpanded ? '折叠' : '展开' }} {{ row.skipped }} 行未变化</span>
-                      <span v-if="row.oldRange || row.newRange" class="opacity-60">
-                        (旧 {{ formatRange(row.oldRange) }} / 新 {{ formatRange(row.newRange) }})
-                      </span>
-                    </button>
-                  </div>
-                  <div v-else
-                       :class="['grid grid-cols-[56px_56px_1fr] gap-2 px-3 py-1 border-b border-neutral-200 dark:border-neutral-800 whitespace-pre-wrap',
-                         row.type === 'added' ? 'bg-[var(--g-accent-soft)] dark:bg-[var(--g-accent-strong)] text-[var(--g-accent)]' :
-                         row.type === 'removed' ? 'bg-red-100/60 dark:bg-red-900/30 text-red-700 dark:text-red-300' :
-                         'text-neutral-800 dark:text-neutral-200']">
-                    <span class="text-right text-[10px] text-neutral-400">
-                      {{ row.oldLine ?? '' }}
-                    </span>
-                    <span class="text-right text-[10px] text-neutral-400">
-                      {{ row.newLine ?? '' }}
-                    </span>
-                    <span>{{ row.text || ' ' }}</span>
-                  </div>
-                </template>
-              </div>
-              <div v-else class="diff-viewer-split max-h-[28rem] overflow-auto">
-                <template v-for="row in diffSplitRows" :key="row.kind === 'fold' ? `fold-${row.id}` : row.key">
-                  <div v-if="row.kind === 'fold'" class="border-b border-neutral-200 dark:border-neutral-700 bg-neutral-100/60 dark:bg-neutral-800/60 px-3 py-2">
-                    <button type="button" @click="toggleDiffFold(row.id)"
-                            class="inline-flex items-center gap-1 text-[11px] text-neutral-600 dark:text-neutral-300">
-                      <span>{{ row.isExpanded ? '折叠' : '展开' }} {{ row.skipped }} 行未变化</span>
-                      <span v-if="row.oldRange || row.newRange" class="opacity-60">
-                        (旧 {{ formatRange(row.oldRange) }} / 新 {{ formatRange(row.newRange) }})
-                      </span>
-                    </button>
-                  </div>
-                  <div v-else class="grid gap-2 px-3 py-1 border-b border-neutral-200 dark:border-neutral-800 text-neutral-800 dark:text-neutral-200 sm:grid-cols-[56px_minmax(0,1fr)_56px_minmax(0,1fr)]">
-                    <div class="flex items-baseline justify-between sm:block text-[10px] text-neutral-400">
-                      <span class="sm:hidden text-neutral-500 mr-2">基准</span>
-                      <span>{{ row.left.line ?? '' }}</span>
-                    </div>
-                    <span :class="[
-                        'block whitespace-pre-wrap',
-                        row.changeType === 'removed' || row.changeType === 'modified'
-                          ? 'bg-red-100/60 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded'
-                          : '']">
-                      {{ row.left.text || ' ' }}
-                    </span>
-                    <div class="flex items-baseline justify-between sm:block text-[10px] text-neutral-400">
-                      <span class="sm:hidden text-neutral-500 mr-2">对比</span>
-                      <span>{{ row.right.line ?? '' }}</span>
-                    </div>
-                    <span :class="[
-                        'block whitespace-pre-wrap',
-                        row.changeType === 'added' || row.changeType === 'modified'
-                          ? 'bg-[var(--g-accent-soft)] dark:bg-[var(--g-accent-strong)] text-[var(--g-accent)] rounded'
-                          : '']">
-                      {{ row.right.text || ' ' }}
-                    </span>
-                  </div>
-                </template>
-              </div>
-            </template>
-          </div>
-        </div>
-      </section>
+      <PageSource
+        :wikidot-id="wikidotId"
+        :page-display-title="pageDisplayTitle"
+        :copied-anchor-id="copiedAnchorId"
+        :page-versions="pageVersions"
+        :displayed-source="displayedSource"
+        :source-character-count="sourceCharacterCount"
+        :text-content-character-count="textContentCharacterCount"
+        @copy-anchor="copyAnchorLink"
+        @version-change="onVersionChange"
+      />
 
       <!-- Forum Discussion Section -->
       <ForumsDiscussionSection
@@ -834,7 +317,11 @@ import { useAuth } from '~/composables/useAuth'
 import { useViewerVotes } from '~/composables/useViewerVotes'
 import { formatDateUtc8, formatDateIsoUtc8, diffUtc8CalendarDays } from '~/utils/timezone'
 import CollectionPicker from '~/components/collections/CollectionPicker.vue'
-import ImagePreviewDialog from '~/components/media/ImagePreviewDialog.vue'
+import PageMetrics from '~/components/page/PageMetrics.vue'
+import PageRevisions from '~/components/page/PageRevisions.vue'
+import PageVotes from '~/components/page/PageVotes.vue'
+import PageImages from '~/components/page/PageImages.vue'
+import PageSource from '~/components/page/PageSource.vue'
 import { normalizeBffBase, pickExternalAssetUrl, resolveWithFallback } from '~/utils/assetUrl'
 import { copyTextWithFallback } from '~/utils/clipboard'
 
@@ -975,8 +462,6 @@ const pageImages = computed<PageImageItem[]>(() => {
   }).filter((img): img is PageImageItem => img !== null)
 })
 
-const hasPageImages = computed(() => pageImages.value.length > 0)
-
 const primaryImageUrl = computed(() => {
   const firstImage = pageImages.value[0]
   if (firstImage?.imageSrc) return firstImage.imageSrc as string
@@ -1015,101 +500,8 @@ const canonicalUrl = computed(() => {
   return ''
 })
 
-const pageImageSizeOptions = [
-  { label: '小', value: 9 },
-  { label: '中', value: 6 },
-  { label: '大', value: 3 }
-]
-
-const pageImageColumns = ref<number>(6)
-type PageImagePreviewPayload = {
-  imageKey: string
-  label: string
-  imageSrc: string
-  imageSrcFull: string
-  copyUrl: string
-}
-const pageImagePreviewOpen = ref(false)
-const pageImagePreviewItem = ref<PageImagePreviewPayload | null>(null)
-const copiedPageImageKey = ref<string | null>(null)
-let pageImageCopyTimer: ReturnType<typeof setTimeout> | null = null
-const pageImageRows = computed(() => {
-  const cols = pageImageColumns.value
-  if (cols >= 9) return 5
-  if (cols >= 6) return 4
-  return 3
-})
-const pageImagesPerPage = computed(() => Math.max(1, pageImageColumns.value * pageImageRows.value))
-const pageImagePage = ref(1)
-const pageImageTotalPages = computed(() => {
-  if (!pageImages.value.length) return 1
-  return Math.max(1, Math.ceil(pageImages.value.length / pageImagesPerPage.value))
-})
-
-const paginatedPageImages = computed(() => {
-  const pageIndex = Math.max(1, Math.min(pageImagePage.value, pageImageTotalPages.value)) - 1
-  const start = pageIndex * pageImagesPerPage.value
-  return pageImages.value.slice(start, start + pageImagesPerPage.value)
-})
-
-const pageImageRangeLabel = computed(() => {
-  if (!pageImages.value.length) return '0'
-  const start = (Math.max(1, pageImagePage.value) - 1) * pageImagesPerPage.value + 1
-  const end = Math.min(pageImages.value.length, start + pageImagesPerPage.value - 1)
-  return `${start} - ${end}`
-})
-
-const pageImageGridStyle = computed(() => ({
-  '--columns': String(Math.max(1, Math.min(pageImageColumns.value, 12)))
-}))
-
-function openPageImagePreview(img: PageImageItem) {
-  pageImagePreviewItem.value = {
-    imageKey: img.imageKey,
-    label: img.label,
-    imageSrc: img.imageSrc,
-    imageSrcFull: img.imageSrcFull || img.imageSrc,
-    copyUrl: img.copyUrl || img.imageSrcFull || img.imageSrc
-  }
-  pageImagePreviewOpen.value = true
-}
-
-async function copyPageImageUrl(img: PageImageItem) {
-  const imageKey = img.imageKey
-  const target = (img.copyUrl || img.imageSrcFull || img.imageSrc || '').trim()
-  if (!imageKey || !target) return
-
-  const copied = await copyTextWithFallback(target, '请复制图片 URL')
-  if (!copied) return
-
-  copiedPageImageKey.value = imageKey
-  if (pageImageCopyTimer) clearTimeout(pageImageCopyTimer)
-  pageImageCopyTimer = setTimeout(() => {
-    if (copiedPageImageKey.value === imageKey) copiedPageImageKey.value = null
-  }, 1800)
-}
-
-watch(pageImages, () => {
-  if (pageImagePage.value > pageImageTotalPages.value) {
-    pageImagePage.value = pageImageTotalPages.value
-  }
-  if (pageImagePreviewItem.value) {
-    const exists = pageImages.value.some((img) => img.imageKey === pageImagePreviewItem.value?.imageKey)
-    if (!exists) {
-      pageImagePreviewOpen.value = false
-      pageImagePreviewItem.value = null
-    }
-  }
-})
-
-watch(pageImageColumns, () => {
-  pageImagePage.value = 1
-})
-
 watch(wikidotId, () => {
-  pageImagePreviewOpen.value = false
-  pageImagePreviewItem.value = null
-  copiedPageImageKey.value = null
+  // reset image-related state handled by PageImages component
 })
 
 const { data: stats, pending: statsPending } = await useAsyncData(
@@ -1117,8 +509,6 @@ const { data: stats, pending: statsPending } = await useAsyncData(
   () => $bff(`/stats/pages/${wikidotId.value}`),
   { watch: [() => route.params.wikidotId], server: false, lazy: true }
 )
-
-// rating history moved below after firstRev to decide dynamic granularity
 
 const pageSize = ref(3)
 const revPage = ref(0)
@@ -1165,7 +555,6 @@ const { data: firstRev, pending: firstRevPending } = await useAsyncData(
   { watch: [() => route.params.wikidotId], server: false, lazy: true }
 )
 
-// Dynamic granularity for rating history: day <= ~90d, week <= ~3y, else month
 const ratingGranularity = computed(() => {
   const first = firstRev.value && firstRev.value[0] && firstRev.value[0].timestamp
   const last = page.value?.updatedAt || page.value?.createdAt || ''
@@ -1174,10 +563,8 @@ const ratingGranularity = computed(() => {
   if (t0 && t1 && t1 > t0) {
     const days = (t1 - t0) / 86400000
     if (days <= 90) return 'day'
-    // Cap at week even for longer spans
     return 'week'
   }
-  // Default to week rather than month
   return 'week'
 })
 
@@ -1193,17 +580,12 @@ const { data: attributions, pending: attributionsPending } = await useAsyncData(
   { watch: [() => route.params.wikidotId], server: false, lazy: true }
 )
 
-// removed revision list for source selection
-
 const { data: voteDistribution, pending: voteDistributionPending } = await useAsyncData(
   () => `vote-dist-${wikidotId.value}`,
   () => $bff(`/pages/${wikidotId.value}/vote-distribution`),
   { watch: [() => route.params.wikidotId], server: false, lazy: true }
 )
 
-// removed related-records fetch
-
-// Recommendations (related pages) - 非阻塞加载
 const { data: relatedPages, pending: relatedPending, error: relatedError, refresh: refreshRelatedPages } = useAsyncData(
   () => `related-pages-${wikidotId.value}`,
   () => $bff(`/pages/${wikidotId.value}/recommendations`, { params: { limit: 6, strategy: 'both', diversity: 'simple' } }),
@@ -1222,20 +604,14 @@ watch(
 
 const votePageSize = ref(10)
 
-// Responsive page sizes: 3-5 for revisions, votes sized to whole rows to avoid partial pages
 function recalcPageSizes() {
   const w = window.innerWidth || 0
-  // determine columns used in votes grid
   const voteCols = w >= 1536 ? 5 : w >= 1280 ? 4 : w >= 1024 ? 3 : w >= 768 ? 2 : w >= 640 ? 2 : 2
   const revCols = w >= 1024 ? 3 : w >= 640 ? 2 : 1
-
-  // When fewer columns, increase rows to show more vertical content (mobile-friendly)
   const revRows = revCols <= 1 ? 7 : revCols === 2 ? 5 : 4
   pageSize.value = Math.max(1, revCols * revRows)
-
   const voteRows = voteCols <= 2 ? 10 : voteCols === 3 ? 8 : voteCols === 4 ? 7 : 6
   votePageSize.value = Math.max(voteCols, voteCols * voteRows)
-  // reset paginations when size changes
   revPage.value = 0
   voteOffset.value = 0
 }
@@ -1274,7 +650,6 @@ function jumpToVotePage(){
 }
 
 const selectedVersion = ref<number | null>(null)
-// removed revision selection; only page version is used
 const { data: latestSourceResp, pending: latestSourcePending } = await useAsyncData(
   () => `page-latest-source-${wikidotId.value}`,
   () => $bff(`/pages/${wikidotId.value}/source`),
@@ -1286,7 +661,8 @@ const latestSource = computed(() => {
   return s.source || null
 })
 
-watch(selectedVersion, async (ver) => {
+async function onVersionChange(ver: number | null) {
+  selectedVersion.value = ver
   if (ver == null) return
   try {
     const resp = await $bff(`/pages/${wikidotId.value}/versions/${ver}/source`)
@@ -1294,7 +670,7 @@ watch(selectedVersion, async (ver) => {
   } catch {
     ;(latestSourceResp as any).value = { source: null }
   }
-})
+}
 
 const displayedSource = computed(() => latestSource.value ?? '暂无源码')
 
@@ -1376,514 +752,6 @@ const { data: pageVersions, pending: pageVersionsPending } = await useAsyncData(
   () => $bff(`/pages/${wikidotId.value}/versions`, { params: { includeSource: false, limit: 100 } }),
   { watch: [() => route.params.wikidotId], server: false, lazy: true }
 )
-watch(pageVersions, (list:any[]) => {
-  if (Array.isArray(list) && list.length > 0) {
-    const current = list.find((v:any) => !v.validTo)
-    selectedVersion.value = (current || list[0]).pageVersionId
-  } else {
-    selectedVersion.value = null
-  }
-}, { immediate: true })
-
-// ===== Diff mode state =====
-const diffMode = ref(false)
-const baseVersionId = ref<number | null>(null)
-const compareVersionId = ref<number | null>(null)
-const ignoreWhitespace = ref(true)
-const diffLoading = ref(false)
-const diffError = ref<string | null>(null)
-const diffViewMode = ref<'unified' | 'split'>('unified')
-const diffCollapseUnchanged = ref(true)
-const diffContextLines = ref(3)
-const diffExpandedFoldIds = ref<string[]>([])
-let diffJobSeq = 0
-let diffScheduleHandle: ReturnType<typeof setTimeout> | null = null
-
-type DiffLineType = 'context' | 'added' | 'removed'
-interface DiffLine {
-  kind: DiffLineType
-  text: string
-  oldLine: number | null
-  newLine: number | null
-}
-interface DiffContextSegment {
-  type: 'context'
-  index: number
-  lines: DiffLine[]
-}
-interface DiffChangeSegment {
-  type: 'change'
-  index: number
-  removed: DiffLine[]
-  added: DiffLine[]
-}
-type DiffSegment = DiffContextSegment | DiffChangeSegment
-
-interface DiffPrepared {
-  lines: DiffLine[]
-  segments: DiffSegment[]
-  stats: { added: number; removed: number; blocks: number }
-}
-
-interface DiffFoldRow {
-  kind: 'fold'
-  id: string
-  skipped: number
-  oldRange: [number, number] | null
-  newRange: [number, number] | null
-  isExpanded: boolean
-}
-interface DiffUnifiedLineRow {
-  kind: 'line'
-  key: string
-  type: DiffLineType
-  text: string
-  oldLine: number | null
-  newLine: number | null
-}
-type DiffUnifiedRow = DiffUnifiedLineRow | DiffFoldRow
-
-interface DiffSplitCell {
-  text: string
-  line: number | null
-}
-interface DiffSplitLineRow {
-  kind: 'line'
-  key: string
-  left: DiffSplitCell
-  right: DiffSplitCell
-  changeType: 'context' | 'added' | 'removed' | 'modified'
-}
-type DiffSplitRow = DiffSplitLineRow | DiffFoldRow
-
-const diffData = ref<DiffPrepared | null>(null)
-
-const diffSummary = computed(() => diffData.value?.stats ?? { added: 0, removed: 0, blocks: 0 })
-const diffHasChanges = computed(() => diffSummary.value.blocks > 0)
-
-watch(diffCollapseUnchanged, () => {
-  diffExpandedFoldIds.value = []
-})
-watch(diffContextLines, (value) => {
-  const numeric = Number(value)
-  const normalized = Number.isFinite(numeric) ? Math.max(0, Math.min(20, Math.round(numeric))) : 0
-  if (normalized !== diffContextLines.value) {
-    diffContextLines.value = normalized
-    return
-  }
-  diffExpandedFoldIds.value = []
-})
-
-const diffUnifiedRows = computed<DiffUnifiedRow[]>(() => {
-  if (!diffData.value) return []
-  return buildUnifiedRows(diffData.value.segments, {
-    collapse: diffCollapseUnchanged.value,
-    context: Math.max(0, Math.min(20, Math.round(Number(diffContextLines.value) || 0))),
-    expanded: new Set(diffExpandedFoldIds.value),
-    hasChanges: diffHasChanges.value
-  })
-})
-
-const diffSplitRows = computed<DiffSplitRow[]>(() => {
-  if (!diffData.value) return []
-  return buildSplitRows(diffData.value.segments, {
-    collapse: diffCollapseUnchanged.value,
-    context: Math.max(0, Math.min(20, Math.round(Number(diffContextLines.value) || 0))),
-    expanded: new Set(diffExpandedFoldIds.value),
-    hasChanges: diffHasChanges.value
-  })
-})
-
-const orderedVersions = computed<any[]>(() => {
-  const list = Array.isArray(pageVersions.value) ? [...(pageVersions.value as any[])] : []
-  return list.sort((a:any, b:any) => {
-    const ta = new Date(a?.createdAt || 0).getTime()
-    const tb = new Date(b?.createdAt || 0).getTime()
-    return ta - tb // old -> new
-  })
-})
-
-function resetDiffResults(){
-  diffError.value = null
-  diffData.value = null
-  diffExpandedFoldIds.value = []
-}
-
-function toggleDiffMode(){
-  diffMode.value = !diffMode.value
-  if (diffMode.value) {
-    // entering diff: preselect sensible defaults (previous vs current)
-    const list = orderedVersions.value
-    if (list.length === 0) {
-      baseVersionId.value = null
-      compareVersionId.value = null
-    } else {
-      const currentId = selectedVersion.value
-      const idx = currentId != null ? list.findIndex((v:any) => v.pageVersionId === currentId) : list.length - 1
-      const prevIdx = Math.max(0, Math.min(list.length - 1, idx - 1))
-      const nextIdx = Math.max(0, Math.min(list.length - 1, idx))
-      baseVersionId.value = list[prevIdx]?.pageVersionId ?? null
-      compareVersionId.value = list[nextIdx]?.pageVersionId ?? null
-    }
-    resetDiffResults()
-    scheduleDiff()
-  } else {
-    // leaving diff
-    if (diffScheduleHandle) {
-      clearTimeout(diffScheduleHandle)
-      diffScheduleHandle = null
-    }
-    diffLoading.value = false
-    resetDiffResults()
-  }
-}
-
-watch([baseVersionId, compareVersionId, () => ignoreWhitespace.value], () => {
-  if (!diffMode.value) return
-  scheduleDiff()
-})
-
-// Cache fetched version sources to avoid repeated network calls
-const versionSourceCache = new Map<number, string | null>()
-
-async function getSourceForVersion(verId: number): Promise<string> {
-  if (versionSourceCache.has(verId)) {
-    return String(versionSourceCache.get(verId) || '')
-  }
-  const resp = await $bff(`/pages/${wikidotId.value}/versions/${verId}/source`)
-  const text = (resp && typeof resp.source === 'string') ? resp.source : ''
-  versionSourceCache.set(verId, text)
-  return text
-}
-
-async function runDiff(){
-  if (!diffMode.value) return
-  if (baseVersionId.value == null || compareVersionId.value == null) {
-    diffLoading.value = false
-    diffError.value = null
-    diffData.value = null
-    diffExpandedFoldIds.value = []
-    return
-  }
-  const jobId = ++diffJobSeq
-  diffLoading.value = true
-  diffError.value = null
-  diffData.value = null
-  diffExpandedFoldIds.value = []
-  try {
-    const [baseText, compareText] = await Promise.all([
-      getSourceForVersion(Number(baseVersionId.value)),
-      getSourceForVersion(Number(compareVersionId.value))
-    ])
-    const diffLib: any = await import('diff')
-    const parts = (diffLib?.diffLines || diffLib?.default?.diffLines)?.call(diffLib, String(baseText), String(compareText), {
-      ignoreWhitespace: !!ignoreWhitespace.value
-    }) || []
-    if (jobId !== diffJobSeq) return
-    diffData.value = Array.isArray(parts) ? prepareDiffData(parts) : { lines: [], segments: [], stats: { added: 0, removed: 0, blocks: 0 } }
-  } catch (e:any) {
-    if (jobId !== diffJobSeq) return
-    diffError.value = '对比失败'
-  } finally {
-    if (jobId === diffJobSeq) diffLoading.value = false
-  }
-}
-
-function scheduleDiff(immediate = false) {
-  if (!diffMode.value) return
-  if (diffScheduleHandle) {
-    clearTimeout(diffScheduleHandle)
-    diffScheduleHandle = null
-  }
-  if (immediate) {
-    runDiff()
-    return
-  }
-  diffScheduleHandle = setTimeout(() => {
-    diffScheduleHandle = null
-    runDiff()
-  }, 120)
-}
-
-interface BuildDiffViewOptions {
-  collapse: boolean
-  context: number
-  expanded: Set<string>
-  hasChanges: boolean
-}
-
-function prepareDiffData(parts: Array<{ value: string; added?: boolean; removed?: boolean }>): DiffPrepared {
-  let oldLine = 1
-  let newLine = 1
-  let added = 0
-  let removed = 0
-  const lines: DiffLine[] = []
-
-  parts.forEach((part) => {
-    const chunkLines = extractDiffLines(part)
-    chunkLines.forEach((text) => {
-      if (part?.added) {
-        lines.push({ kind: 'added', text, oldLine: null, newLine })
-        newLine += 1
-        added += 1
-      } else if (part?.removed) {
-        lines.push({ kind: 'removed', text, oldLine, newLine: null })
-        oldLine += 1
-        removed += 1
-      } else {
-        lines.push({ kind: 'context', text, oldLine, newLine })
-        oldLine += 1
-        newLine += 1
-      }
-    })
-  })
-
-  const segments = buildSegments(lines)
-  return {
-    lines,
-    segments,
-    stats: {
-      added,
-      removed,
-      blocks: segments.filter((seg) => seg.type === 'change').length
-    }
-  }
-}
-
-function extractDiffLines(part: { value?: string; added?: boolean; removed?: boolean; count?: number }): string[] {
-  const raw = String(part?.value ?? '').replace(/\r/g, '')
-  if (!raw) {
-    return part?.added || part?.removed ? [''] : []
-  }
-  const lines = raw.split('\n')
-  if (raw.endsWith('\n')) {
-    lines.pop()
-  }
-  return lines.length ? lines : ['']
-}
-
-function buildSegments(lines: DiffLine[]): DiffSegment[] {
-  type PendingSegment = { type: 'context'; lines: DiffLine[] } | { type: 'change'; removed: DiffLine[]; added: DiffLine[] }
-  const segments: PendingSegment[] = []
-  let contextBuffer: DiffLine[] = []
-  let removedBuffer: DiffLine[] = []
-  let addedBuffer: DiffLine[] = []
-
-  const pushContext = () => {
-    if (contextBuffer.length) {
-      segments.push({ type: 'context', lines: contextBuffer })
-      contextBuffer = []
-    }
-  }
-  const pushChange = () => {
-    if (removedBuffer.length || addedBuffer.length) {
-      segments.push({ type: 'change', removed: removedBuffer, added: addedBuffer })
-      removedBuffer = []
-      addedBuffer = []
-    }
-  }
-
-  lines.forEach((line) => {
-    if (line.kind === 'context') {
-      pushChange()
-      contextBuffer.push(line)
-    } else if (line.kind === 'removed') {
-      pushContext()
-      removedBuffer.push(line)
-    } else if (line.kind === 'added') {
-      pushContext()
-      addedBuffer.push(line)
-    }
-  })
-
-  pushChange()
-  pushContext()
-
-  return segments.map((seg, idx) => seg.type === 'context'
-    ? { type: 'context', index: idx, lines: seg.lines }
-    : { type: 'change', index: idx, removed: seg.removed, added: seg.added })
-}
-
-function buildUnifiedRows(segments: DiffSegment[], options: BuildDiffViewOptions): DiffUnifiedRow[] {
-  const rows: DiffUnifiedRow[] = []
-  if (!segments.length) return rows
-
-  const { collapse, context, expanded, hasChanges } = options
-  const changeAfter: boolean[] = new Array(segments.length).fill(false)
-  let seenChangeAhead = false
-  for (let i = segments.length - 1; i >= 0; i -= 1) {
-    changeAfter[i] = seenChangeAhead
-    if (segments[i].type === 'change') {
-      seenChangeAhead = true
-    }
-  }
-
-  let seenChange = false
-  let keyCounter = 0
-  const pushLine = (line: DiffLine, override?: DiffLineType) => {
-    rows.push({
-      kind: 'line',
-      key: `u-${keyCounter++}`,
-      type: override ?? line.kind,
-      text: line.text,
-      oldLine: line.oldLine,
-      newLine: line.newLine
-    })
-  }
-
-  segments.forEach((segment) => {
-    if (segment.type === 'change') {
-      seenChange = true
-      segment.removed.forEach((line) => pushLine(line, 'removed'))
-      segment.added.forEach((line) => pushLine(line, 'added'))
-      return
-    }
-
-    const lines = segment.lines
-    if (!collapse || !hasChanges) {
-      lines.forEach((line) => pushLine(line, 'context'))
-      return
-    }
-
-    const keepBefore = seenChange ? context : 0
-    const keepAfter = changeAfter[segment.index] ? context : 0
-    if (keepBefore + keepAfter >= lines.length) {
-      lines.forEach((line) => pushLine(line, 'context'))
-      return
-    }
-
-    const head = keepBefore > 0 ? lines.slice(0, keepBefore) : []
-    const tail = keepAfter > 0 ? lines.slice(lines.length - keepAfter) : []
-    const hidden = lines.slice(keepBefore, lines.length - keepAfter)
-
-    head.forEach((line) => pushLine(line, 'context'))
-    if (hidden.length) {
-      const foldRow = createFoldRow(`context-${segment.index}`, hidden, expanded)
-      rows.push(foldRow)
-      if (foldRow.isExpanded) {
-        hidden.forEach((line) => pushLine(line, 'context'))
-      }
-    }
-    tail.forEach((line) => pushLine(line, 'context'))
-  })
-
-  return rows
-}
-
-function buildSplitRows(segments: DiffSegment[], options: BuildDiffViewOptions): DiffSplitRow[] {
-  const rows: DiffSplitRow[] = []
-  if (!segments.length) return rows
-
-  const { collapse, context, expanded, hasChanges } = options
-  const changeAfter: boolean[] = new Array(segments.length).fill(false)
-  let seenChangeAhead = false
-  for (let i = segments.length - 1; i >= 0; i -= 1) {
-    changeAfter[i] = seenChangeAhead
-    if (segments[i].type === 'change') {
-      seenChangeAhead = true
-    }
-  }
-
-  let seenChange = false
-  let keyCounter = 0
-  const pushContextRow = (line: DiffLine) => {
-    rows.push({
-      kind: 'line',
-      key: `s-${keyCounter++}`,
-      left: { text: line.text, line: line.oldLine },
-      right: { text: line.text, line: line.newLine },
-      changeType: 'context'
-    })
-  }
-
-  segments.forEach((segment) => {
-    if (segment.type === 'change') {
-      seenChange = true
-      const maxLen = Math.max(segment.removed.length, segment.added.length)
-      for (let idx = 0; idx < maxLen; idx += 1) {
-        const leftLine = segment.removed[idx]
-        const rightLine = segment.added[idx]
-        const changeType: 'added' | 'removed' | 'modified' = leftLine && rightLine
-          ? 'modified'
-          : leftLine
-            ? 'removed'
-            : 'added'
-        rows.push({
-          kind: 'line',
-          key: `s-${keyCounter++}`,
-          left: { text: leftLine ? leftLine.text : '', line: leftLine?.oldLine ?? null },
-          right: { text: rightLine ? rightLine.text : '', line: rightLine?.newLine ?? null },
-          changeType
-        })
-      }
-      return
-    }
-
-    const lines = segment.lines
-    if (!collapse || !hasChanges) {
-      lines.forEach((line) => pushContextRow(line))
-      return
-    }
-
-    const keepBefore = seenChange ? context : 0
-    const keepAfter = changeAfter[segment.index] ? context : 0
-    if (keepBefore + keepAfter >= lines.length) {
-      lines.forEach((line) => pushContextRow(line))
-      return
-    }
-
-    const head = keepBefore > 0 ? lines.slice(0, keepBefore) : []
-    const tail = keepAfter > 0 ? lines.slice(lines.length - keepAfter) : []
-    const hidden = lines.slice(keepBefore, lines.length - keepAfter)
-
-    head.forEach((line) => pushContextRow(line))
-    if (hidden.length) {
-      const foldRow = createFoldRow(`context-${segment.index}`, hidden, expanded)
-      rows.push(foldRow)
-      if (foldRow.isExpanded) {
-        hidden.forEach((line) => pushContextRow(line))
-      }
-    }
-    tail.forEach((line) => pushContextRow(line))
-  })
-
-  return rows
-}
-
-function createFoldRow(id: string, lines: DiffLine[], expanded: Set<string>): DiffFoldRow {
-  return {
-    kind: 'fold',
-    id,
-    skipped: lines.length,
-    oldRange: rangeFromLines(lines, 'oldLine'),
-    newRange: rangeFromLines(lines, 'newLine'),
-    isExpanded: expanded.has(id)
-  }
-}
-
-function rangeFromLines(lines: DiffLine[], key: 'oldLine' | 'newLine'): [number, number] | null {
-  const values = lines
-    .map((line) => line[key])
-    .filter((value): value is number => typeof value === 'number')
-  if (!values.length) return null
-  return [values[0], values[values.length - 1]]
-}
-
-function toggleDiffFold(id: string) {
-  if (!id) return
-  if (diffExpandedFoldIds.value.includes(id)) {
-    diffExpandedFoldIds.value = diffExpandedFoldIds.value.filter((item) => item !== id)
-  } else {
-    diffExpandedFoldIds.value = [...diffExpandedFoldIds.value, id]
-  }
-}
-
-function formatRange(range: [number, number] | null): string {
-  if (!range) return '--'
-  const [start, end] = range
-  if (start == null || end == null) return '--'
-  return start === end ? String(start) : `${start}-${end}`
-}
 
 // ===== Derived & UI helpers =====
 const sourceUrlHttps = computed<string>(() => {
@@ -1916,53 +784,6 @@ const groupedAttributions = computed(() => {
 function formatDate(dateStr: string) {
   if (!dateStr) return 'N/A'
   return formatDateUtc8(dateStr, { year: 'numeric', month: 'short', day: 'numeric' }) || 'N/A'
-}
-function formatDateCompact(dateStr: string) {
-  if (!dateStr) return ''
-  return formatDateIsoUtc8(dateStr)
-}
-
-function formatRevisionType(type: string) {
-  const map:Record<string,string> = {
-    'PAGE_CREATED':'创建页面','PAGE_EDITED':'编辑内容','PAGE_RENAMED':'重命名','PAGE_DELETED':'删除','PAGE_RESTORED':'恢复','METADATA_CHANGED':'修改元数据','TAGS_CHANGED':'修改标签','SOURCE_CHANGED':'编辑内容'
-  }
-  return map[type] || type
-}
-function revisionTypeClass(type: string) {
-  const t = String(type || '')
-  if (t === 'PAGE_CREATED' || t === 'PAGE_RESTORED') {
-    return 'bg-[var(--g-accent-soft)] dark:bg-[var(--g-accent-strong)] text-[var(--g-accent)]'
-  }
-  if (t === 'PAGE_EDITED') {
-    return 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
-  }
-  if (t === 'PAGE_RENAMED') {
-    return 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400'
-  }
-  if (t === 'PAGE_DELETED') {
-    return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400'
-  }
-  if (t === 'METADATA_CHANGED') {
-    return 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
-  }
-  if (t === 'TAGS_CHANGED') {
-    return 'bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400'
-  }
-  if (t === 'SOURCE_CHANGED') {
-    return 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400'
-  }
-  return 'bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300'
-}
-function formatRecordCategory(category: string) {
-  const map:Record<string,string> = { rating:'评分', content:'内容', fact:'事实' }
-  return map[category] || category
-}
-function formatRecordType(type: string) {
-  const map:Record<string,string> = {
-    HIGHEST_RATED:'最高评分', FASTEST_RISING:'上升最快', MOST_CONTROVERSIAL:'最具争议', LONGEST_SOURCE:'最长源码',
-    LONGEST_CONTENT:'最长内容', MOST_COMPLEX:'最复杂'
-  }
-  return map[type] || type
 }
 
 async function copyAnchorLink(sectionId?: string) {
@@ -2005,7 +826,6 @@ function copyId(){
     setTimeout(() => { copiedId.value = false }, 1200)
   }).catch(() => {})
 }
-// removed share functionality
 
 const copiedSource = ref(false)
 async function copySourceUrl(){
@@ -2020,7 +840,7 @@ async function copySourceUrl(){
   }
 }
 
-// Tags - show all (ordered)
+// Tags
 const allTags = computed(() => orderTags(Array.isArray(page.value?.tags) ? page.value!.tags : []))
 
 // Votes derived
@@ -2076,7 +896,7 @@ const wilsonLB = computed(() => {
   const phat = upvotes.value / n
   const num = phat + (z*z)/(2*n) - z * Math.sqrt((phat*(1-phat) + (z*z)/(4*n))/n)
   const den = 1 + (z*z)/n
-  return Math.max(0, num/den) // 0..1
+  return Math.max(0, num/den)
 })
 
 // Tooltips
@@ -2084,38 +904,14 @@ const ratingTooltip = computed(() => `最近更新：${formatRelativeTime(page.v
 const voteTooltip = computed(() => `总票数：${totalVotes.value}`)
 const wilsonTooltip = computed(() => `基于 Wilson 区间的下界，结合票数与比例`)
 
-// Controversy index [0,1]
+// Controversy index
 const controversyIdx = computed(() => {
   const v = Number((stats as any).value?.controversy ?? 0)
   if (!Number.isFinite(v)) return 0
   return Math.max(0, Math.min(1, v))
 })
 
-// Copy / Download source
-function copySource(){
-  const text = displayedSource.value || ''
-  if (!text || text === '加载中...' || text === '暂无源码') return
-  navigator.clipboard?.writeText(text).catch(() => {})
-}
-function downloadSource(){
-  const text = displayedSource.value || ''
-  if (!text || text === '加载中...' || text === '暂无源码') return
-  try {
-    const blob = new Blob([text], { type: 'text/plain;charset=utf-8' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${pageDisplayTitle.value || 'source'}.txt`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-  } catch {
-    // Blob downloads can fail in restricted environments.
-  }
-}
-
-// Clean up (for any listeners we might add later)
+// Clean up
 function onMove(_e: MouseEvent) { /* reserved */ }
 onMounted(() => {
   const el = document.querySelector('svg')
@@ -2127,122 +923,9 @@ onBeforeUnmount(() => {
   const el = document.querySelector('svg')
   el?.removeEventListener('mousemove', onMove as any)
   window.removeEventListener('resize', recalcPageSizes)
-  if (diffScheduleHandle) {
-    clearTimeout(diffScheduleHandle)
-    diffScheduleHandle = null
-  }
   if (anchorCopyTimer) {
     clearTimeout(anchorCopyTimer)
     anchorCopyTimer = null
   }
-  if (pageImageCopyTimer) {
-    clearTimeout(pageImageCopyTimer)
-    pageImageCopyTimer = null
-  }
 })
 </script>
-
-<style scoped>
-.source-code-block,
-.source-code-block * {
-  user-select: text;
-  -webkit-user-select: text;
-}
-
-.diff-label {
-  white-space: nowrap;
-}
-
-.diff-chip {
-  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.diff-chip--toggles {
-  align-items: flex-start;
-}
-
-@media (min-width: 640px) {
-  .diff-chip--toggles {
-    align-items: center;
-  }
-}
-
-.diff-view-toggle__btn {
-  border: none;
-  cursor: pointer;
-}
-
-.diff-view-toggle__btn:focus-visible {
-  outline: 2px solid var(--g-accent-border);
-  outline-offset: 1px;
-}
-
-.diff-select--narrow {
-  max-width: 5.5rem;
-}
-
-@media (min-width: 640px) {
-  .diff-select--narrow {
-    max-width: 4.5rem;
-  }
-}
-
-.page-images-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(var(--columns, 6), minmax(0, 1fr));
-}
-
-.page-image-trigger {
-  display: block;
-  width: 100%;
-  padding: 0;
-  border-width: 1px;
-  text-align: left;
-  cursor: zoom-in;
-}
-
-.page-image-trigger:focus-visible {
-  outline: 2px solid var(--g-accent-border);
-  outline-offset: 1px;
-}
-
-.page-image-zoom-chip {
-  pointer-events: none;
-  position: absolute;
-  right: 0.5rem;
-  bottom: 0.5rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  background: rgba(15, 23, 42, 0.48);
-  padding: 0.15rem 0.5rem;
-  font-size: 10px;
-  line-height: 1.2;
-  color: rgba(248, 250, 252, 0.95);
-  opacity: 0.86;
-  transition: opacity 0.2s ease, transform 0.2s ease;
-}
-
-.group:hover .page-image-zoom-chip {
-  opacity: 1;
-  transform: translateY(-1px);
-}
-
-@media (max-width: 1024px) {
-  .page-images-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 640px) {
-  .page-images-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 420px) {
-  .page-images-grid {
-    grid-template-columns: repeat(1, minmax(0, 1fr));
-  }
-}
-</style>

--- a/frontend/pages/page/[wikidotId]/index.vue
+++ b/frontend/pages/page/[wikidotId]/index.vue
@@ -500,10 +500,6 @@ const canonicalUrl = computed(() => {
   return ''
 })
 
-watch(wikidotId, () => {
-  // reset image-related state handled by PageImages component
-})
-
 const { data: stats, pending: statsPending } = await useAsyncData(
   () => `stats-${wikidotId.value}`,
   () => $bff(`/stats/pages/${wikidotId.value}`),

--- a/frontend/pages/search.vue
+++ b/frontend/pages/search.vue
@@ -568,166 +568,42 @@
     </div>
 
     <!-- 搜索结果显示 -->
-    <div v-if="searchPerformed">
-      <div v-if="initialLoading" class="text-sm text-neutral-600 dark:text-neutral-400">搜索中…</div>
-      <div v-else-if="error" class="text-sm text-red-600 dark:text-red-400">搜索失败，请稍后重试</div>
-      <div v-else>
-        <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
-          <div v-if="searchForm.scope === 'forums'" class="text-sm text-neutral-600 dark:text-neutral-400">
-            找到讨论区帖子 <span class="font-semibold text-[var(--g-accent)]">{{ totalForums }}</span>
-          </div>
-          <div v-else class="text-sm text-neutral-600 dark:text-neutral-400">
-            找到用户 <span class="font-semibold text-[var(--g-accent)]">{{ totalUsers }}</span>
-            ，页面 <span class="font-semibold text-[var(--g-accent)]">{{ totalPages }}</span>
-          </div>
-          <!--
-          <button
-            type="button"
-            class="inline-flex items-center gap-2 rounded-full border border-neutral-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-neutral-600 shadow-sm transition hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900/70 dark:text-neutral-300"
-            :disabled="csvPending || pageResults.length === 0"
-            @click="exportCsv"
-          >
-            <LucideIcon name="Download" class="h-3.5 w-3.5" stroke-width="1.6" />
-            <span>{{ csvPending ? '导出中…' : '导出 CSV' }}</span>
-          </button>
-          -->
-        </div>
-
-        <div class="space-y-8">
-          <section v-if="(searchForm.scope==='both' || searchForm.scope==='users') && (totalUsers > 0 || usersLoading)" class="space-y-3">
-            <div class="flex items-center justify-between">
-              <div class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">用户</div>
-              <div class="text-[11px] text-neutral-400 dark:text-neutral-500">共 {{ totalUsers }}</div>
-            </div>
-            <div v-if="usersLoading && userResults.length === 0" class="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
-              <div v-for="i in 6" :key="`user-skel-${i}`" class="h-24 rounded-lg border border-neutral-200 bg-neutral-100/70 animate-pulse dark:border-neutral-800 dark:bg-neutral-800/40"></div>
-            </div>
-            <div v-else-if="userResults.length === 0" class="rounded-lg border border-dashed border-neutral-300 bg-neutral-50/80 px-4 py-6 text-sm text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/70 dark:text-neutral-300">
-              暂无用户符合条件。
-            </div>
-            <div v-else class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-              <UserCard
-                v-for="u in userResults"
-                :key="u.wikidotId || u.id"
-                size="md"
-                :wikidot-id="u.wikidotId"
-                :display-name="u.displayName"
-                :rank="u.rank"
-                :totals="{ totalRating: u.totalRating, works: u.pageCount }"
-              />
-            </div>
-            <div v-if="userLoadingMore" class="flex items-center justify-center text-xs text-neutral-500 dark:text-neutral-400">
-              正在载入更多用户…
-            </div>
-            <div v-else-if="userHasMore" class="flex flex-col items-center gap-2">
-              <button
-                type="button"
-                class="rounded-full border border-neutral-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-neutral-600 hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:bg-neutral-900/70 dark:text-neutral-300"
-                @click="loadMoreUsers"
-              >加载更多用户</button>
-              <div ref="userSentinelRef" class="h-1 w-full"></div>
-            </div>
-          </section>
-
-          <section v-if="(searchForm.scope==='both' || searchForm.scope==='pages')" class="space-y-4">
-            <div class="flex items-center justify-between">
-              <div class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">页面</div>
-              <div class="text-[11px] text-neutral-400 dark:text-neutral-500">共 {{ totalPages }}</div>
-            </div>
-            <div v-if="pagesLoading && pageResults.length === 0" class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-              <div v-for="i in 6" :key="`page-skel-${i}`" class="h-48 rounded-lg border border-neutral-200 bg-neutral-100/70 animate-pulse dark:border-neutral-800 dark:bg-neutral-800/40"></div>
-            </div>
-            <div v-else-if="pageResults.length === 0" class="rounded-lg border border-dashed border-neutral-300 bg-neutral-50/80 px-4 py-6 text-sm text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/70 dark:text-neutral-300">
-              暂无页面符合条件。
-            </div>
-            <div v-else>
-              <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-                <PageCard size="md" v-for="p in pageResults" :key="p.wikidotId || p.id" :p="p" />
-              </div>
-            </div>
-            <div v-if="pageLoadingMore" class="flex items-center justify-center text-xs text-neutral-500 dark:text-neutral-400">
-              正在载入更多页面…
-            </div>
-            <div v-else-if="pageHasMore" class="flex flex-col items-center gap-2">
-              <button
-                type="button"
-                class="rounded-full border border-neutral-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-neutral-600 hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:bg-neutral-900/70 dark:text-neutral-300"
-                @click="loadMorePages"
-              >加载更多页面</button>
-              <div ref="pageSentinelRef" class="h-1 w-full"></div>
-            </div>
-            <div v-else>
-              <div ref="pageSentinelRef" class="h-0 w-full"></div>
-            </div>
-          </section>
-          <section v-if="searchForm.scope==='forums'" class="space-y-4">
-            <div class="flex items-center justify-between">
-              <div class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">讨论区</div>
-              <div class="text-[11px] text-neutral-400 dark:text-neutral-500">共 {{ totalForums }}</div>
-            </div>
-            <div v-if="forumsLoading && forumResults.length === 0" class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-              <div v-for="i in 6" :key="`forum-skel-${i}`" class="h-36 rounded-lg border border-neutral-200 bg-neutral-100/70 animate-pulse dark:border-neutral-800 dark:bg-neutral-800/40"></div>
-            </div>
-            <div v-else-if="forumResults.length === 0" class="rounded-lg border border-dashed border-neutral-300 bg-neutral-50/80 px-4 py-6 text-sm text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/70 dark:text-neutral-300">
-              暂无讨论区帖子符合条件。
-            </div>
-            <div v-else class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-              <NuxtLink
-                v-for="post in forumResults"
-                :key="post.postId || `${post.threadId}-${post.createdAt}`"
-                :to="forumPostLink(post)"
-                class="block rounded-lg border border-neutral-200 bg-white p-4 shadow-sm transition hover:border-[var(--g-accent-border)] hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
-              >
-                <div class="flex items-start gap-3">
-                  <UserAvatar
-                    v-if="post.createdByWikidotId"
-                    :wikidot-id="post.createdByWikidotId"
-                    :name="post.createdByName"
-                    :size="32"
-                    class="shrink-0 mt-0.5"
-                  />
-                  <div class="min-w-0 flex-1 space-y-1.5">
-                    <h3 class="text-sm font-semibold text-neutral-800 dark:text-neutral-100 line-clamp-1">
-                      {{ post.title || post.threadTitle || '(无标题)' }}
-                    </h3>
-                    <div v-if="post.categoryTitle || post.threadTitle" class="text-xs text-neutral-500 dark:text-neutral-400 line-clamp-1">
-                      <span v-if="post.categoryTitle">{{ post.categoryTitle }}</span>
-                      <span v-if="post.categoryTitle && post.threadTitle"> › </span>
-                      <span v-if="post.threadTitle">{{ post.threadTitle }}</span>
-                    </div>
-                    <p class="text-xs text-neutral-600 dark:text-neutral-300 line-clamp-2" v-html="highlightForumSnippet(post.textHtml, searchForm.query)"></p>
-                    <div class="flex items-center gap-2 text-[11px] text-neutral-400 dark:text-neutral-500">
-                      <span v-if="post.createdByName" class="font-medium text-neutral-500 dark:text-neutral-400">{{ post.createdByName }}</span>
-                      <span v-if="post.createdAt">{{ formatForumDate(post.createdAt) }}</span>
-                    </div>
-                  </div>
-                </div>
-              </NuxtLink>
-            </div>
-            <div v-if="forumLoadingMore" class="flex items-center justify-center text-xs text-neutral-500 dark:text-neutral-400">
-              正在载入更多帖子…
-            </div>
-            <div v-else-if="forumHasMore" class="flex flex-col items-center gap-2">
-              <button
-                type="button"
-                class="rounded-full border border-neutral-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-neutral-600 hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:bg-neutral-900/70 dark:text-neutral-300"
-                @click="loadMoreForums"
-              >加载更多帖子</button>
-              <div ref="forumSentinelRef" class="h-1 w-full"></div>
-            </div>
-          </section>
-        </div>
-      </div>
-    </div>
+    <SearchResults
+      :search-performed="searchPerformed"
+      :initial-loading="initialLoading"
+      :error="error"
+      :scope="searchForm.scope"
+      :search-query="searchForm.query"
+      :user-results="userResults"
+      :page-results="pageResults"
+      :forum-results="forumResults"
+      :total-users="totalUsers"
+      :total-pages="totalPages"
+      :total-forums="totalForums"
+      :users-loading="usersLoading"
+      :pages-loading="pagesLoading"
+      :forums-loading="forumsLoading"
+      :user-loading-more="userLoadingMore"
+      :page-loading-more="pageLoadingMore"
+      :forum-loading-more="forumLoadingMore"
+      :user-has-more="userHasMore"
+      :page-has-more="pageHasMore"
+      :forum-has-more="forumHasMore"
+      @load-more-users="loadMoreUsers"
+      @load-more-pages="loadMorePages"
+      @load-more-forums="loadMoreForums"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { ref, watch, computed, onBeforeUnmount, nextTick } from 'vue'
+// onMounted removed — observers now live in SearchResults component
 import { useRoute, useRouter } from 'vue-router'
 import { useNuxtApp, useHead, useState } from 'nuxt/app'
 import { orderTags } from '~/composables/useTagOrder'
 import { useViewerVotes } from '~/composables/useViewerVotes'
+import SearchResults from '~/components/search/SearchResults.vue'
 
 const route = useRoute();
 const router = useRouter();
@@ -911,12 +787,6 @@ const searchCache = useState<{
   scrollY: 0
 }))
 const restoringScroll = ref(false)
-const pageSentinelRef = ref<HTMLElement | null>(null)
-const userSentinelRef = ref<HTMLElement | null>(null)
-const forumSentinelRef = ref<HTMLElement | null>(null)
-let pageObserver: IntersectionObserver | null = null
-let userObserver: IntersectionObserver | null = null
-let forumObserver: IntersectionObserver | null = null
 // CSV export temporarily disabled.
 // const csvPending = ref(false)
 const { hydratePages } = useViewerVotes()
@@ -1464,65 +1334,6 @@ async function loadMoreUsers() {
 }
 
 // ─── Forum search ────────────────────────────────
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-}
-
-function stripHtml(html: string | null | undefined): string {
-  if (!html) return ''
-  return html.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').replace(/&[a-zA-Z]+;/g, ' ').replace(/\s+/g, ' ').trim()
-}
-
-function highlightForumSnippet(html: string | null | undefined, query: string): string {
-  const text = stripHtml(html)
-  if (!text) return ''
-
-  const q = query.trim()
-  if (!q) return escapeHtml(text.slice(0, 200)) + (text.length > 200 ? '…' : '')
-
-  const lowerText = text.toLowerCase()
-  const lowerQ = q.toLowerCase()
-  const firstIdx = lowerText.indexOf(lowerQ)
-
-  if (firstIdx === -1) {
-    return escapeHtml(text.slice(0, 200)) + (text.length > 200 ? '…' : '')
-  }
-
-  // 前缀 3-5 个字符，确保关键词一定可见
-  const prefixLen = Math.min(firstIdx, 5)
-  const start = firstIdx - prefixLen
-  const snippetLen = 200
-  const end = Math.min(text.length, start + snippetLen)
-  const snippet = text.slice(start, end)
-
-  // 高亮片段内所有匹配
-  const lowerSnippet = snippet.toLowerCase()
-  let result = ''
-  let pos = 0
-  while (pos < snippet.length) {
-    const matchPos = lowerSnippet.indexOf(lowerQ, pos)
-    if (matchPos === -1) {
-      result += escapeHtml(snippet.slice(pos))
-      break
-    }
-    result += escapeHtml(snippet.slice(pos, matchPos))
-    result += `<span class="keyword">${escapeHtml(snippet.slice(matchPos, matchPos + q.length))}</span>`
-    pos = matchPos + q.length
-  }
-
-  if (start > 0) result = '…' + result
-  if (end < text.length) result += '…'
-
-  return result
-}
-
-function formatForumDate(dateStr: string | null | undefined): string {
-  if (!dateStr) return ''
-  const d = new Date(dateStr)
-  if (isNaN(d.getTime())) return ''
-  return d.toLocaleDateString('zh-CN', { year: 'numeric', month: '2-digit', day: '2-digit' })
-}
-
 function normalizeForumPost(post: any) {
   const postId = Number(post?.postId ?? post?.id)
   const threadId = Number(post?.threadId)
@@ -1531,18 +1342,6 @@ function normalizeForumPost(post: any) {
     postId: Number.isInteger(postId) && postId > 0 ? postId : null,
     threadId: Number.isInteger(threadId) && threadId > 0 ? threadId : null,
   }
-}
-
-function forumPostLink(post: any): string {
-  const threadId = Number(post?.threadId)
-  if (!Number.isInteger(threadId) || threadId <= 0) {
-    return '/forums'
-  }
-  const postId = Number(post?.postId ?? post?.id)
-  if (Number.isInteger(postId) && postId > 0) {
-    return `/forums/t/${threadId}?postId=${postId}`
-  }
-  return `/forums/t/${threadId}`
 }
 
 async function fetchForumPosts(params: Record<string, any> | null = null, options: { append?: boolean } = {}) {
@@ -1644,63 +1443,6 @@ async function loadMoreForums() {
 //   }
 // }
 
-function setupPageObserver() {
-  if (!isClient || typeof IntersectionObserver === 'undefined') return
-  if (pageObserver) pageObserver.disconnect()
-  pageObserver = new IntersectionObserver((entries) => {
-    if (entries.some(entry => entry.isIntersecting)) {
-      void loadMorePages()
-    }
-  }, { rootMargin: '320px 0px' })
-  if (pageSentinelRef.value) pageObserver.observe(pageSentinelRef.value)
-}
-
-function setupUserObserver() {
-  if (!isClient || typeof IntersectionObserver === 'undefined') return
-  if (userObserver) userObserver.disconnect()
-  userObserver = new IntersectionObserver((entries) => {
-    if (entries.some(entry => entry.isIntersecting)) {
-      void loadMoreUsers()
-    }
-  }, { rootMargin: '320px 0px' })
-  if (userSentinelRef.value) userObserver.observe(userSentinelRef.value)
-}
-
-function setupForumObserver() {
-  if (!isClient || typeof IntersectionObserver === 'undefined') return
-  if (forumObserver) forumObserver.disconnect()
-  forumObserver = new IntersectionObserver((entries) => {
-    if (entries.some(entry => entry.isIntersecting)) {
-      void loadMoreForums()
-    }
-  }, { rootMargin: '320px 0px' })
-  if (forumSentinelRef.value) forumObserver.observe(forumSentinelRef.value)
-}
-
-watch(pageSentinelRef, (newEl, oldEl) => {
-  if (!isClient || !pageObserver) return
-  if (oldEl) pageObserver.unobserve(oldEl)
-  if (newEl) pageObserver.observe(newEl)
-})
-
-watch(userSentinelRef, (newEl, oldEl) => {
-  if (!isClient || !userObserver) return
-  if (oldEl) userObserver.unobserve(oldEl)
-  if (newEl) userObserver.observe(newEl)
-})
-
-watch(forumSentinelRef, (newEl, oldEl) => {
-  if (!isClient || !forumObserver) return
-  if (oldEl) forumObserver.unobserve(oldEl)
-  if (newEl) forumObserver.observe(newEl)
-})
-
-onMounted(() => {
-  setupPageObserver()
-  setupUserObserver()
-  setupForumObserver()
-})
-
 onBeforeUnmount(() => {
   if (tagSearchTimeout) {
     clearTimeout(tagSearchTimeout)
@@ -1713,18 +1455,6 @@ onBeforeUnmount(() => {
   if (authorSearchTimeout) {
     clearTimeout(authorSearchTimeout)
     authorSearchTimeout = null
-  }
-  if (pageObserver) {
-    pageObserver.disconnect()
-    pageObserver = null
-  }
-  if (userObserver) {
-    userObserver.disconnect()
-    userObserver = null
-  }
-  if (forumObserver) {
-    forumObserver.disconnect()
-    forumObserver = null
   }
   if (isClient) {
     searchCache.value.scrollY = window.scrollY


### PR DESCRIPTION
## 概要

拆分前端最大的页面文件为独立子组件，提升代码可维护性。

### pages/page/[wikidotId]/index.vue (2248 → 931 行，-58%)
提取 5 个子组件：
- `components/page/PageSource.vue` — 源码查看器 + 完整 diff 对比逻辑（~830行，最大收益）
- `components/page/PageImages.vue` — 图片画廊、分页、预览弹窗
- `components/page/PageRevisions.vue` — 修订历史列表与分页
- `components/page/PageVotes.vue` — 投票列表与分页
- `components/page/PageMetrics.vue` — 核心指标卡片（评分/支持率/Wilson95/争议指数）

### pages/search.vue (1953 → 1683 行，-14%)
提取 1 个子组件：
- `components/search/SearchResults.vue` — 搜索结果展示（用户/页面/讨论区三类），IntersectionObserver 无限滚动

### 设计原则
- 所有 `useAsyncData` 数据获取保留在页面级
- 子组件通过 props 接收数据、emit 传递事件
- 不改变任何业务逻辑，纯 UI 拆分
- 保持 SSR 兼容性

## 测试计划
- [x] `npm run build` 构建通过
- [ ] 页面详情页功能验证（评分、修订、投票分页、源码对比、图片画廊）
- [ ] 搜索页功能验证（用户/页面/讨论区搜索、无限滚动加载）