### PR TITLE
refactor: 拆分用户详情页和集换交易面板为子组件

### DIFF
--- a/frontend/components/gacha/GachaTradePanel.vue
+++ b/frontend/components/gacha/GachaTradePanel.vue
@@ -596,6 +596,23 @@ function formatAccountDisplayName(
   return `用户-${rawId.slice(0, 8)}`
 }
 
+function listingRemainingLabel(listing: TradeListing) {
+  if (listing.status !== 'OPEN' || listing.remaining <= 0) return tradeStatusLabel(listing.status)
+  if (!listing.expiresAt) return '无期限'
+  const now = clientNow.value
+  if (!now) return formatDateCompact(listing.expiresAt) || '无'
+  const expiresTs = new Date(listing.expiresAt).getTime()
+  if (!Number.isFinite(expiresTs)) return formatDateCompact(listing.expiresAt) || '无'
+  const diffMs = expiresTs - now
+  if (diffMs <= 0) return '已到期'
+  const diffMin = Math.max(1, Math.ceil(diffMs / 60_000))
+  if (diffMin < 60) return `剩${diffMin}m`
+  const diffH = Math.ceil(diffMin / 60)
+  if (diffH < 48) return `剩${diffH}h`
+  const diffD = Math.ceil(diffH / 24)
+  return `剩${diffD}d`
+}
+
 function buyRequestRemainingLabel(br: BuyRequest) {
   if (br.status !== 'OPEN') return buyRequestStatusLabelMap[br.status]
   if (!br.expiresAt) return '无期限'
@@ -765,6 +782,7 @@ watch([brSortMode, brRarityFilter], () => {
         :filtered-trade-card-options="filteredTradeCardOptions"
         :visible-trade-card-options="visibleTradeCardOptions"
         :rarity-groups="rarityGroups"
+        :trade-create-search="tradeCreateSearch"
         :normalized-create-search="normalizedCreateSearch"
         :trade-selection-key="tradeSelectionKey"
         :selected-trade-card-option="selectedTradeCardOption"
@@ -853,7 +871,7 @@ watch([brSortMode, brRarityFilter], () => {
                 :class="tradeStatusChipClassMap[listing.status]"
               >{{ tradeStatusLabel(listing.status) }}</span>
               <span class="trade-item-row__price">{{ formatTokens(listing.unitPrice) }}T <span class="trade-item-row__qty">× {{ listing.remaining }}/{{ listing.quantity }}</span></span>
-              <span class="trade-item-row__time">{{ buyRequestRemainingLabel({ status: listing.status, expiresAt: listing.expiresAt } as any) }}</span>
+              <span class="trade-item-row__time">{{ listingRemainingLabel(listing) }}</span>
             </div>
           </button>
         </div>

--- a/frontend/components/gacha/GachaTradePanel.vue
+++ b/frontend/components/gacha/GachaTradePanel.vue
@@ -2,6 +2,7 @@
 /**
  * 集换 tab 面板。
  * 从 index.vue 提取，包含发布挂牌、我的挂牌、公共挂牌三个区域。
+ * 模板已拆分到 trade/ 子组件：TradeSellForm, TradeListings, TradeBuyForm, TradeDetail
  */
 import { computed, ref, watch } from 'vue'
 import { onBeforeUnmount, onMounted } from 'vue'
@@ -13,21 +14,14 @@ import { tradeStatusLabelMap, tradeStatusChipClassMap, buyRequestStatusLabelMap,
 import type { BuyRequestSortMode } from '~/utils/gachaConstants'
 import { usePageAuthors } from '~/composables/usePageAuthors'
 import { resolveAuthorSearchText } from '~/utils/gachaAuthorSearch'
-import GachaRarityFilter from '~/components/gacha/GachaRarityFilter.vue'
-import GachaAffixChip from '~/components/gacha/GachaAffixChip.vue'
-import GachaCard from '~/components/gacha/GachaCard.vue'
 import GachaCardMini from '~/components/gacha/GachaCardMini.vue'
-import GachaPagination from '~/components/gacha/GachaPagination.vue'
+import GachaAffixChip from '~/components/gacha/GachaAffixChip.vue'
 import { UiButton } from '~/components/ui/button'
-import { UiInput } from '~/components/ui/input'
 import { UiSelectRoot, UiSelectTrigger, UiSelectContent, UiSelectItem } from '~/components/ui/select'
-import {
-  UiDialogRoot,
-  UiDialogPortal,
-  UiDialogOverlay,
-  UiDialogContent,
-  UiDialogClose
-} from '~/components/ui/dialog'
+import TradeSellForm from '~/components/gacha/trade/TradeSellForm.vue'
+import TradeListings from '~/components/gacha/trade/TradeListings.vue'
+import TradeBuyForm from '~/components/gacha/trade/TradeBuyForm.vue'
+import TradeDetail from '~/components/gacha/trade/TradeDetail.vue'
 
 // ─── 类型 ────────────────────────────────────────────────
 
@@ -216,18 +210,6 @@ function closeBuyRequestDetail() {
   selectedBuyRequest.value = null
 }
 
-function handleMyListingDialogChange(nextOpen: boolean) {
-  if (!nextOpen) closeMyListingDetail()
-}
-
-function handlePublicListingDialogChange(nextOpen: boolean) {
-  if (!nextOpen) closeListingDetail()
-}
-
-function handleBuyRequestDialogChange(nextOpen: boolean) {
-  if (!nextOpen) closeBuyRequestDetail()
-}
-
 const buyRequestFulfillCandidates = computed(() => {
   const br = selectedBuyRequest.value
   if (!br || br.status !== 'OPEN' || br.buyerId === props.userId) return []
@@ -264,8 +246,8 @@ function handleFulfillBuyRequestFromDetail() {
 
 // ─── 求购创建表单状态 ──────────────────────────────
 const brSelectedPage = ref<PageCatalogEntry | null>(null)
-const brSelectedVariantIds = ref<string[]>([])       // empty = 任意画面
-const brSelectedCoatings = ref<AffixVisualStyle[]>([])  // empty = 任意镀层
+const brSelectedVariantIds = ref<string[]>([])
+const brSelectedCoatings = ref<AffixVisualStyle[]>([])
 const brTokenOffer = ref<number>(0)
 const brExpiresHours = ref<number>(72)
 const brOfferedCards = ref<Array<{ stackKey: string; cardId: string; affixSignature?: string; quantity: number }>>([])
@@ -317,18 +299,15 @@ const brDerivedPayloads = computed<BuyRequestDraft[]>(() => {
   const page = brSelectedPage.value
   const firstVariantId = page.variants[0]?.id
   if (!firstVariantId) return []
-  // No specific variants → PAGE level (single request)
   if (brSelectedVariantIds.value.length === 0) {
     return [{ targetCardId: firstVariantId, matchLevel: 'PAGE' }]
   }
-  // Specific variants, no coatings → IMAGE_VARIANT for each
   if (brSelectedCoatings.value.length === 0) {
     return brSelectedVariantIds.value.map((vid) => ({
       targetCardId: vid,
       matchLevel: 'IMAGE_VARIANT'
     }))
   }
-  // Specific variants + specific coatings → COATING for each combo
   return brSelectedVariantIds.value.flatMap((vid) =>
     brSelectedCoatings.value.map((coating) => ({
       targetCardId: vid,
@@ -385,10 +364,6 @@ function brSetOfferedQuantity(stackKey: string, qty: number) {
   }
 }
 
-function brFindOfferedOption(stackKey: string) {
-  return props.cardOptions.find((item) => item.stackKey === stackKey) ?? null
-}
-
 const brCanSubmit = computed(() => {
   if (!brSelectedPage.value) return false
   if (brDerivedPayloads.value.length === 0) return false
@@ -420,7 +395,6 @@ function handleCreateBuyRequest() {
 function brSelectPage(entry: PageCatalogEntry) {
   brSelectedPage.value = entry
   brSelectedCoatings.value = []
-  // Auto-select variant if only one exists
   if (entry.variants.length === 1) {
     brSelectedVariantIds.value = [entry.variants[0]!.id]
   } else {
@@ -441,7 +415,6 @@ function brToggleVariant(variantId: string) {
   } else {
     brSelectedVariantIds.value.push(variantId)
   }
-  // Clear coatings when variants change to empty
   if (brSelectedVariantIds.value.length === 0) {
     brSelectedCoatings.value = []
   }
@@ -493,23 +466,6 @@ function emitBrQuery() {
   })
 }
 
-function buyRequestRemainingLabel(br: BuyRequest) {
-  if (br.status !== 'OPEN') return buyRequestStatusLabelMap[br.status]
-  if (!br.expiresAt) return '无期限'
-  const now = clientNow.value
-  if (!now) return formatDateCompact(br.expiresAt) || '无'
-  const expiresTs = new Date(br.expiresAt).getTime()
-  if (!Number.isFinite(expiresTs)) return formatDateCompact(br.expiresAt) || '无'
-  const diffMs = expiresTs - now
-  if (diffMs <= 0) return '已到期'
-  const diffMin = Math.max(1, Math.ceil(diffMs / 60_000))
-  if (diffMin < 60) return `剩${diffMin}m`
-  const diffH = Math.ceil(diffMin / 60)
-  if (diffH < 48) return `剩${diffH}h`
-  const diffD = Math.ceil(diffH / 24)
-  return `剩${diffD}d`
-}
-
 // ─── 衍生数据 ────────────────────────────────────────────
 
 const selectedTradeCardOption = computed(() =>
@@ -518,8 +474,6 @@ const selectedTradeCardOption = computed(() =>
 
 const normalizedCreateSearch = computed(() => tradeCreateSearch.value.trim().toLowerCase())
 
-// Pre-compute search text for each card option once when props change,
-// avoiding repeated string builds + toLowerCase on every keystroke.
 const cardSearchIndex = computed(() => {
   const index = new Map<string, string>()
   for (const item of props.cardOptions) {
@@ -539,7 +493,6 @@ const filteredTradeCardOptions = computed(() => {
   })
 })
 
-// Rarity group boundaries for the filtered list (used for group headers)
 type RarityGroup = { rarity: Rarity; startIndex: number; count: number }
 const rarityGroups = computed<RarityGroup[]>(() => {
   const items = filteredTradeCardOptions.value
@@ -560,7 +513,6 @@ const rarityGroups = computed<RarityGroup[]>(() => {
   return groups
 })
 
-// Progressive pagination — slice the filtered list to pickerVisibleCount
 const visibleTradeCardOptions = computed(() =>
   filteredTradeCardOptions.value.slice(0, pickerVisibleCount.value)
 )
@@ -576,17 +528,6 @@ function pickerLoadMore() {
     pickerVisibleCount.value + PICKER_PAGE_SIZE,
     filteredTradeCardOptions.value.length
   )
-}
-
-// Find which rarity group the current visible boundary sits in
-function pickerNextGroupLabel(): string {
-  const nextIdx = pickerVisibleCount.value
-  for (const g of rarityGroups.value) {
-    if (nextIdx >= g.startIndex && nextIdx < g.startIndex + g.count) {
-      return rarityLabel(g.rarity)
-    }
-  }
-  return ''
 }
 
 const tradeQuantityMax = computed(() =>
@@ -644,29 +585,6 @@ onBeforeUnmount(() => {
   clearMarketQueryTimer()
 })
 
-function listingRemainingLabel(listing: TradeListing) {
-  if (listing.status !== 'OPEN' || listing.remaining <= 0) return tradeStatusLabel(listing.status)
-  if (!listing.expiresAt) return '无期限'
-
-  const now = clientNow.value
-  if (!now) return formatDateCompact(listing.expiresAt) || '无'
-
-  const expiresTs = new Date(listing.expiresAt).getTime()
-  if (!Number.isFinite(expiresTs)) return formatDateCompact(listing.expiresAt) || '无'
-
-  const diffMs = expiresTs - now
-  if (diffMs <= 0) return '已到期'
-
-  const diffMin = Math.max(1, Math.ceil(diffMs / 60_000))
-  if (diffMin < 60) return `剩${diffMin}m`
-
-  const diffH = Math.ceil(diffMin / 60)
-  if (diffH < 48) return `剩${diffH}h`
-
-  const diffD = Math.ceil(diffH / 24)
-  return `剩${diffD}d`
-}
-
 function formatAccountDisplayName(
   account: { id: string; displayName: string | null; linkedWikidotId: number | null } | null | undefined,
   fallbackId?: string | null
@@ -676,6 +594,23 @@ function formatAccountDisplayName(
   const rawId = String(fallbackId || account?.id || '').trim()
   if (!rawId) return '未知用户'
   return `用户-${rawId.slice(0, 8)}`
+}
+
+function buyRequestRemainingLabel(br: BuyRequest) {
+  if (br.status !== 'OPEN') return buyRequestStatusLabelMap[br.status]
+  if (!br.expiresAt) return '无期限'
+  const now = clientNow.value
+  if (!now) return formatDateCompact(br.expiresAt) || '无'
+  const expiresTs = new Date(br.expiresAt).getTime()
+  if (!Number.isFinite(expiresTs)) return formatDateCompact(br.expiresAt) || '无'
+  const diffMs = expiresTs - now
+  if (diffMs <= 0) return '已到期'
+  const diffMin = Math.max(1, Math.ceil(diffMs / 60_000))
+  if (diffMin < 60) return `剩${diffMin}m`
+  const diffH = Math.ceil(diffMin / 60)
+  if (diffH < 48) return `剩${diffH}h`
+  const diffD = Math.ceil(diffH / 24)
+  return `剩${diffD}d`
 }
 
 function resetFilters() {
@@ -824,207 +759,54 @@ watch([brSortMode, brRarityFilter], () => {
 
     <!-- ═══ 挂牌 Tab ═══ -->
     <div v-if="activeSubTab === 'market'" class="mt-4 space-y-4">
-      <!-- 折叠式发布表单 -->
-      <div>
-        <button
-          type="button"
-          class="trade-collapse-toggle"
-          @click="showCreateForm = !showCreateForm"
-        >
-          <span>{{ showCreateForm ? '收起发布' : '发布挂牌' }}</span>
-          <span class="trade-collapse-toggle__icon" :class="{ 'trade-collapse-toggle__icon--open': showCreateForm }">&#9662;</span>
-        </button>
+      <TradeSellForm
+        :inventory-loading="inventoryLoading"
+        :card-options="cardOptions"
+        :filtered-trade-card-options="filteredTradeCardOptions"
+        :visible-trade-card-options="visibleTradeCardOptions"
+        :rarity-groups="rarityGroups"
+        :normalized-create-search="normalizedCreateSearch"
+        :trade-selection-key="tradeSelectionKey"
+        :selected-trade-card-option="selectedTradeCardOption"
+        :trade-quantity="tradeQuantity"
+        :trade-quantity-max="tradeQuantityMax"
+        :trade-unit-price="tradeUnitPrice"
+        :trade-expires-hours="tradeExpiresHours"
+        :submitting="submitting"
+        :picker-has-more="pickerHasMore"
+        :picker-remaining-count="pickerRemainingCount"
+        :show-create-form="showCreateForm"
+        @update:show-create-form="showCreateForm = $event"
+        @update:trade-create-search="tradeCreateSearch = $event"
+        @update:trade-selection-key="tradeSelectionKey = $event"
+        @update:trade-quantity="tradeQuantity = $event"
+        @update:trade-unit-price="tradeUnitPrice = $event"
+        @update:trade-expires-hours="tradeExpiresHours = $event"
+        @create="handleCreate"
+        @picker-load-more="pickerLoadMore"
+      />
 
-        <Transition name="trade-collapse">
-          <article v-if="showCreateForm" class="mt-2 rounded-lg border border-neutral-200/75 bg-neutral-50/75 p-4 dark:border-neutral-800/70 dark:bg-neutral-900/55">
-            <p class="text-[11px] text-neutral-500 dark:text-neutral-400">仅可上架未放置、且当前可用的库存数量。</p>
-
-            <div v-if="inventoryLoading && !cardOptions.length" class="gacha-empty mt-3">
-              正在加载可上架卡片...
-            </div>
-
-            <div v-else-if="!cardOptions.length" class="gacha-empty mt-3">
-              当前无可上架卡片。你可以先抽卡或从放置槽中撤下卡片。
-            </div>
-
-            <form v-else class="mt-3 space-y-3" @submit.prevent="handleCreate">
-              <div class="space-y-2">
-                <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-neutral-500 dark:text-neutral-400">
-                  <span>选择卡片</span>
-                  <span>当前可选 {{ filteredTradeCardOptions.length }} 种</span>
-                </div>
-                <!-- Rarity group summary -->
-                <div v-if="rarityGroups.length > 1 && !normalizedCreateSearch" class="flex flex-wrap gap-1">
-                  <span
-                    v-for="g in rarityGroups"
-                    :key="`rg-${g.rarity}`"
-                    class="picker-rarity-tag"
-                    :class="`picker-rarity-tag--${g.rarity.toLowerCase()}`"
-                  >{{ rarityLabel(g.rarity) }} {{ g.count }}</span>
-                </div>
-                <p v-if="inventoryLoading" class="text-[11px] text-neutral-500 dark:text-neutral-400">
-                  正在后台同步可上架库存...
-                </p>
-                <UiInput
-                  v-model.trim="tradeCreateSearch"
-                  type="search"
-                  placeholder="搜索可上架卡片（标题 / 标签 / 作者 / ID）"
-                  class="w-full"
-                />
-                <div class="picker-scroll-area">
-                  <p v-if="!filteredTradeCardOptions.length" class="gacha-empty py-4">
-                    当前筛选条件下没有可上架卡片。
-                  </p>
-                  <div v-else class="trade-create-grid gacha-card-grid--mini">
-                    <button
-                      v-for="item in visibleTradeCardOptions"
-                      :key="`trade-card-${item.stackKey}`"
-                      type="button"
-                      class="trade-create-card"
-                      :class="{ 'trade-create-card--selected': tradeSelectionKey === item.stackKey }"
-                      :aria-pressed="tradeSelectionKey === item.stackKey"
-                      @click="tradeSelectionKey = item.stackKey"
-                    >
-                      <GachaCardMini
-                        :title="item.title"
-                        :rarity="item.rarity"
-                        :image-url="item.imageUrl || undefined"
-                        :retired="item.isRetired"
-                        :affix-visual-style="item.affixVisualStyle"
-                        :affix-label="item.affixLabel"
-                      >
-                        <template #meta>
-                          <span class="trade-remaining-chip">可上架 {{ item.availableCount }}</span>
-                        </template>
-                      </GachaCardMini>
-                    </button>
-                  </div>
-                  <button
-                    v-if="pickerHasMore"
-                    type="button"
-                    class="picker-load-more-btn"
-                    @click="pickerLoadMore()"
-                  >
-                    加载更多（剩余 {{ pickerRemainingCount }}{{ pickerNextGroupLabel() ? `，下批为 ${pickerNextGroupLabel()}` : '' }}）
-                  </button>
-                </div>
-              </div>
-
-              <p v-if="selectedTradeCardOption" class="text-[11px] text-neutral-500 dark:text-neutral-400">
-                已选 {{ selectedTradeCardOption.title }} · {{ rarityLabel(selectedTradeCardOption.rarity) }} · 词条 {{ selectedTradeCardOption.affixSignature || 'NONE' }} · 可上架 {{ selectedTradeCardOption.availableCount }}
-              </p>
-
-              <div class="grid gap-2 sm:grid-cols-3">
-                <label class="space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
-                  <span>数量</span>
-                  <UiInput v-model.number="tradeQuantity" type="number" min="1" :max="tradeQuantityMax" step="1" />
-                </label>
-                <label class="space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
-                  <span>单价 Token</span>
-                  <UiInput v-model.number="tradeUnitPrice" type="number" min="1" max="1000000" step="1" />
-                </label>
-                <label class="space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
-                  <span>有效期（小时）</span>
-                  <UiInput v-model.number="tradeExpiresHours" type="number" min="1" :max="24 * 30" step="1" />
-                </label>
-              </div>
-
-              <p class="text-[11px] text-neutral-500 dark:text-neutral-400">
-                挂牌总价 {{ formatTokens(Math.max(1, Number(tradeQuantity || 1)) * Math.max(1, Number(tradeUnitPrice || 1))) }} Token · 预计到期 {{ tradeExpiresHours }} 小时后
-              </p>
-
-              <div class="flex flex-wrap gap-2">
-                <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="tradeExpiresHours = 24">24h</UiButton>
-                <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="tradeExpiresHours = 72">72h</UiButton>
-                <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="tradeExpiresHours = 168">168h</UiButton>
-              </div>
-
-              <UiButton type="submit" class="w-full py-2.5 text-sm" :disabled="submitting || !selectedTradeCardOption">
-                {{ submitting ? '上架中...' : '提交并确认' }}
-              </UiButton>
-            </form>
-          </article>
-        </Transition>
-      </div>
-
-      <!-- 搜索 / 排序 -->
-      <div class="grid gap-2 md:grid-cols-[minmax(0,1fr),minmax(160px,200px),minmax(180px,230px),auto]">
-        <UiInput
-          v-model.trim="tradeSearch"
-          type="search"
-          placeholder="搜索卡片名 / 标签 / 作者 / 卖家"
-          class="w-full"
-        />
-        <UiSelectRoot v-model="tradeSearchMode">
-          <UiSelectTrigger placeholder="搜索模式" />
-          <UiSelectContent>
-            <UiSelectItem value="ALL">全字段搜索</UiSelectItem>
-            <UiSelectItem value="CARD">仅卡片</UiSelectItem>
-            <UiSelectItem value="SELLER">仅卖家</UiSelectItem>
-          </UiSelectContent>
-        </UiSelectRoot>
-        <UiSelectRoot v-model="tradeSortMode">
-          <UiSelectTrigger placeholder="排序方式" />
-          <UiSelectContent>
-            <UiSelectItem value="LATEST">按上架时间（新到旧）</UiSelectItem>
-            <UiSelectItem value="RARITY_DESC">按稀有度（高到低）</UiSelectItem>
-            <UiSelectItem value="PRICE_ASC">按单价（低到高）</UiSelectItem>
-            <UiSelectItem value="PRICE_DESC">按单价（高到低）</UiSelectItem>
-            <UiSelectItem value="TOTAL_ASC">按总价（低到高）</UiSelectItem>
-            <UiSelectItem value="TOTAL_DESC">按总价（高到低）</UiSelectItem>
-          </UiSelectContent>
-        </UiSelectRoot>
-        <UiButton variant="outline" class="h-9" @click="resetFilters">重置</UiButton>
-      </div>
-
-      <div class="mt-2">
-        <GachaRarityFilter
-          v-model="tradeRarityFilter"
-          :options="tradeRarityFilterOptions"
-          all-label="全部品质"
-        />
-      </div>
-
-      <p class="mt-2 text-[11px] text-neutral-500 dark:text-neutral-400">
-        显示 {{ visiblePublicListings.length }} / {{ publicTotal }} 条
-      </p>
-
-      <p v-if="!publicListings.length" class="gacha-empty mt-3">当前筛选条件下没有可购买挂牌。</p>
-      <div v-else class="mt-3">
-        <div class="gacha-trade-item-grid">
-          <button
-            v-for="listing in visiblePublicListings"
-            :key="`public-trade-${listing.id}`"
-            type="button"
-            class="trade-item-row"
-            @click="openListingDetail(listing)"
-          >
-            <div class="trade-item-row__card">
-              <GachaCardMini
-                :title="listing.card.title"
-                :rarity="listing.card.rarity"
-                :image-url="listing.card.imageUrl || undefined"
-                :retired="listing.card.isRetired"
-                :affix-visual-style="listing.card.affixVisualStyle || listing.affixBreakdown?.[0]?.affixVisualStyle"
-                :affix-label="listing.card.affixLabel || listing.affixBreakdown?.[0]?.affixLabel"
-                :hide-footer="true"
-              />
-            </div>
-            <div class="trade-item-row__info">
-              <span class="trade-item-row__user">{{ formatAccountDisplayName(listing.seller, listing.sellerId) }}</span>
-              <span class="trade-item-row__price">{{ formatTokens(listing.unitPrice) }}T <span class="trade-item-row__qty">× {{ listing.remaining }}张</span></span>
-              <span class="trade-item-row__time">{{ listingRemainingLabel(listing) }}</span>
-            </div>
-          </button>
-        </div>
-      </div>
-
-      <GachaPagination
-        :current="tradePublicPage"
-        :total="publicTotal"
+      <TradeListings
+        :public-listings="visiblePublicListings"
+        :public-total="publicTotal"
+        :loading="loading"
+        :public-loading-more="publicLoadingMore"
+        :trade-search="tradeSearch"
+        :trade-search-mode="tradeSearchMode"
+        :trade-sort-mode="tradeSortMode"
+        :trade-rarity-filter="tradeRarityFilter"
+        :trade-rarity-filter-options="tradeRarityFilterOptions"
+        :trade-public-page="tradePublicPage"
         :page-size="TRADE_PAGE_SIZE"
-        :loading="loading || publicLoadingMore"
-        @change="(p: number) => { tradePublicPage = p; emit('trade-page-change', p) }"
+        :client-now="clientNow"
+        :user-id="userId"
+        @update:trade-search="tradeSearch = $event"
+        @update:trade-search-mode="tradeSearchMode = $event"
+        @update:trade-sort-mode="tradeSortMode = $event"
+        @update:trade-rarity-filter="tradeRarityFilter = $event"
+        @reset-filters="resetFilters"
+        @open-listing-detail="openListingDetail"
+        @trade-page-change="(p) => { tradePublicPage = p; emit('trade-page-change', p) }"
       />
     </div>
 
@@ -1071,7 +853,7 @@ watch([brSortMode, brRarityFilter], () => {
                 :class="tradeStatusChipClassMap[listing.status]"
               >{{ tradeStatusLabel(listing.status) }}</span>
               <span class="trade-item-row__price">{{ formatTokens(listing.unitPrice) }}T <span class="trade-item-row__qty">× {{ listing.remaining }}/{{ listing.quantity }}</span></span>
-              <span class="trade-item-row__time">{{ listingRemainingLabel(listing) }}</span>
+              <span class="trade-item-row__time">{{ buyRequestRemainingLabel({ status: listing.status, expiresAt: listing.expiresAt } as any) }}</span>
             </div>
           </button>
         </div>
@@ -1115,1523 +897,198 @@ watch([brSortMode, brRarityFilter], () => {
     </div>
 
     <!-- ═══ 求购 Tab ═══ -->
-    <div v-else-if="activeSubTab === 'buyRequest'" class="mt-4 space-y-4">
-      <!-- 折叠式发布求购表单 -->
-      <div>
-        <button
-          type="button"
-          class="trade-collapse-toggle"
-          @click="showBuyRequestForm = !showBuyRequestForm"
-        >
-          <span>{{ showBuyRequestForm ? '收起求购' : '发布求购' }}</span>
-          <span class="trade-collapse-toggle__icon" :class="{ 'trade-collapse-toggle__icon--open': showBuyRequestForm }">&#9662;</span>
-        </button>
-
-        <Transition name="trade-collapse">
-          <article v-if="showBuyRequestForm" class="mt-2 rounded-lg border border-cyan-200/60 bg-cyan-50/40 p-4 dark:border-cyan-800/50 dark:bg-cyan-950/30">
-            <p class="mt-1 text-[10px] text-neutral-500 dark:text-neutral-400">指定想要的卡片，可使用 Token 或自己的卡牌出价。</p>
-
-            <div class="mt-3 space-y-3">
-              <!-- Step 1: 搜索页面 -->
-              <div class="space-y-1.5">
-                <div class="flex items-center justify-between">
-                  <span class="text-[11px] text-neutral-500 dark:text-neutral-400">想要的页面</span>
-                  <button
-                    v-if="brSelectedPage"
-                    type="button"
-                    class="text-[10px] text-cyan-600 hover:text-cyan-800 dark:text-cyan-400 dark:hover:text-cyan-200"
-                    @click="brClearSelection"
-                  >重新选择</button>
-                </div>
-                <template v-if="!brSelectedPage">
-                  <UiInput
-                    v-model.trim="brTargetSearch"
-                    type="search"
-                    placeholder="搜索页面名 / 标签 / 作者"
-                    class="w-full"
-                  />
-                  <div class="max-h-[14rem] overflow-y-auto pr-1">
-                    <p v-if="!brFilteredCatalog.length" class="gacha-empty py-3 text-[11px]">未找到匹配的页面。</p>
-                    <div v-else class="gacha-card-grid--mini">
-                      <button
-                        v-for="entry in brFilteredCatalog.slice(0, 30)"
-                        :key="`br-page-${entry.pageId ?? entry.variants[0]?.id}`"
-                        type="button"
-                        class="trade-create-card"
-                        @click="brSelectPage(entry)"
-                      >
-                      <GachaCardMini
-                          :title="entry.title"
-                          :rarity="entry.rarity"
-                          :image-url="entry.variants[0]?.imageUrl || undefined"
-                          :retired="entry.isRetired"
-                          :hide-footer="true"
-                        />
-                      </button>
-                    </div>
-                  </div>
-                </template>
-                <p v-else class="text-[11px] text-cyan-700 dark:text-cyan-200">
-                  已选: {{ brSelectedPage.title }} · {{ rarityLabel(brSelectedPage.rarity) }}
-                  <span v-if="brSelectedPage.variants.length > 1" class="text-neutral-400">（{{ brSelectedPage.variants.length }} 个画面）</span>
-                </p>
-              </div>
-
-              <!-- Step 2: 画面选择（多画面时显示，使用 GachaCard mini 可视化） -->
-              <div v-if="brSelectedPage && brSelectedPage.variants.length > 1" class="space-y-1.5">
-                <div class="flex items-center justify-between">
-                  <span class="text-[11px] text-neutral-500 dark:text-neutral-400">选择画面（可多选）</span>
-                  <span class="flex gap-2">
-                    <button
-                      v-if="brSelectedVariantIds.length > 0"
-                      type="button"
-                      class="text-[10px] text-cyan-600 hover:text-cyan-800 dark:text-cyan-400 dark:hover:text-cyan-200"
-                      @click="brClearVariants"
-                    >任意画面</button>
-                    <button
-                      v-if="brSelectedVariantIds.length < brSelectedPage.variants.length"
-                      type="button"
-                      class="text-[10px] text-cyan-600 hover:text-cyan-800 dark:text-cyan-400 dark:hover:text-cyan-200"
-                      @click="brSelectAllVariants"
-                    >全选</button>
-                  </span>
-                </div>
-                <div class="gacha-card-grid--mini">
-                  <button
-                    v-for="v in brSelectedPage.variants"
-                    :key="`br-variant-${v.id}`"
-                    type="button"
-                    class="trade-create-card"
-                    :class="{ 'trade-create-card--selected': brSelectedVariantIds.includes(v.id) }"
-                    @click="brToggleVariant(v.id)"
-                  >
-                    <GachaCardMini
-                      :title="brSelectedPage.title"
-                      :rarity="brSelectedPage.rarity"
-                      :image-url="v.imageUrl || undefined"
-                      :retired="v.isRetired"
-                      :hide-footer="true"
-                    />
-                  </button>
-                </div>
-                <p class="text-[10px] text-neutral-400 dark:text-neutral-500">
-                  {{ brSelectedVariantIds.length === 0 ? '未选择 = 接受任意画面（PAGE 级匹配）' : `已选 ${brSelectedVariantIds.length} 个画面` }}
-                </p>
-              </div>
-
-              <!-- Step 3: 镀层选择（选了具体画面才能指定镀层，可多选） -->
-              <div v-if="brSelectedPage && brSelectedVariantIds.length > 0" class="space-y-1.5">
-                <span class="text-[11px] text-neutral-500 dark:text-neutral-400">镀层要求（可多选，不选 = 任意镀层）</span>
-                <div class="flex flex-wrap gap-1.5">
-                  <button
-                    v-for="style in coatingOptions"
-                    :key="`br-coat-${style}`"
-                    type="button"
-                    class="br-match-btn"
-                    :class="{ 'br-match-btn--active': brSelectedCoatings.includes(style) }"
-                    @click="brToggleCoating(style)"
-                  >
-                    {{ coatingStyleLabelMap[style] }}
-                  </button>
-                </div>
-                <p v-if="brSelectedCoatings.length > 0" class="text-[10px] text-neutral-400 dark:text-neutral-500">
-                  已选 {{ brSelectedCoatings.length }} 种镀层
-                </p>
-              </div>
-
-              <!-- 匹配级别提示 -->
-              <p v-if="brSelectedPage" class="rounded-lg bg-neutral-100/80 px-2.5 py-1.5 text-[10px] text-neutral-500 dark:bg-neutral-800/60 dark:text-neutral-400">
-                <template v-if="brDerivedPayloads.length === 1">
-                  匹配级别: <span class="font-semibold text-cyan-700 dark:text-cyan-300">{{ buyRequestMatchLevelLabelMap[brDerivedPayloads[0]!.matchLevel] }}</span>
-                  — {{ brDerivedMatchLevelLabel }}
-                </template>
-                <template v-else>
-                  将创建 <span class="font-semibold text-cyan-700 dark:text-cyan-300">{{ brDerivedPayloads.length }}</span> 个求购（每个出价相同）
-                  — {{ brDerivedMatchLevelLabel }}
-                </template>
-              </p>
-
-              <!-- Token 出价 -->
-              <label class="block space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
-                <span>Token 出价（可为 0）</span>
-                <UiInput v-model.number="brTokenOffer" type="number" min="0" max="500000" step="1" />
-              </label>
-
-              <!-- 提供卡牌 -->
-              <div class="space-y-1.5">
-                <span class="text-[11px] text-neutral-500 dark:text-neutral-400">
-                  提供的卡牌（可选，{{ brOfferedCards.length }} 张已选）
-                </span>
-                <UiInput
-                  v-model.trim="brOfferedSearch"
-                  type="search"
-                  placeholder="搜索可提供的卡牌（标题 / 标签 / 作者）"
-                  class="w-full"
-                />
-                <div v-if="inventoryLoading && !cardOptions.length" class="text-[11px] text-neutral-500 dark:text-neutral-400">
-                  正在加载库存...
-                </div>
-                <div v-else class="max-h-[12rem] overflow-y-auto pr-1">
-                  <div v-if="brFilteredTradeCardOptions.length" class="gacha-card-grid--mini">
-                    <button
-                      v-for="item in brFilteredTradeCardOptions.slice(0, 30)"
-                      :key="`br-offer-${item.stackKey}`"
-                      type="button"
-                      class="trade-create-card"
-                      :class="{ 'trade-create-card--selected': brOfferedCards.some((c) => c.stackKey === item.stackKey) }"
-                      @click="brToggleOfferedCard(item)"
-                    >
-                      <GachaCardMini
-                        :title="item.title"
-                        :rarity="item.rarity"
-                        :image-url="item.imageUrl || undefined"
-                        :retired="item.isRetired"
-                        :affix-visual-style="item.affixVisualStyle"
-                        :affix-label="item.affixLabel"
-                      >
-                        <template #meta>
-                          <span class="trade-remaining-chip">可选 {{ item.availableCount }}</span>
-                        </template>
-                      </GachaCardMini>
-                    </button>
-                  </div>
-                </div>
-                <!-- 已选卡牌及数量设置 -->
-                <div v-if="brOfferedCards.length > 0" class="flex flex-wrap gap-2 pt-1">
-                  <div
-                    v-for="oc in brOfferedCards"
-                    :key="`br-oc-${oc.stackKey}`"
-                    class="flex items-center gap-1 rounded-lg border border-cyan-200/60 bg-white/80 px-2 py-1 text-[10px] dark:border-cyan-700/50 dark:bg-neutral-900/60"
-                  >
-                    <span class="max-w-[80px] truncate text-neutral-700 dark:text-neutral-200">
-                      {{ brFindOfferedOption(oc.stackKey)?.title ?? oc.cardId.slice(0, 8) }} · {{ oc.affixSignature || 'NONE' }}
-                    </span>
-                    <input
-                      type="number"
-                      :value="oc.quantity"
-                      min="1"
-                      :max="brFindOfferedOption(oc.stackKey)?.availableCount ?? 99"
-                      class="w-10 rounded border border-neutral-200 bg-transparent px-1 py-0 text-center text-[10px] dark:border-neutral-700"
-                      @input="brSetOfferedQuantity(oc.stackKey, Number(($event.target as HTMLInputElement).value || 1))"
-                    />
-                    <button type="button" class="text-neutral-400 hover:text-red-500" @click="brRemoveOfferedCard(oc.stackKey)">×</button>
-                  </div>
-                </div>
-              </div>
-
-              <!-- 有效期 -->
-              <label class="block space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
-                <span>有效期（小时）</span>
-                <UiInput v-model.number="brExpiresHours" type="number" min="1" :max="24 * 30" step="1" />
-              </label>
-
-              <div class="flex flex-wrap gap-2">
-                <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="brExpiresHours = 24">24h</UiButton>
-                <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="brExpiresHours = 72">72h</UiButton>
-                <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="brExpiresHours = 168">168h</UiButton>
-              </div>
-
-              <UiButton class="w-full py-2.5 text-sm" :disabled="buyRequestSubmitting || !brCanSubmit" @click="handleCreateBuyRequest">
-                {{ buyRequestSubmitting ? '提交中...' : '发布求购' }}
-              </UiButton>
-            </div>
-          </article>
-        </Transition>
-      </div>
-
-      <!-- 公共求购浏览 -->
-      <article class="rounded-lg border border-neutral-200/75 bg-neutral-50/75 p-4 dark:border-neutral-800/70 dark:bg-neutral-900/55">
-        <header class="flex flex-wrap items-center justify-between gap-2">
-          <h4 class="text-xs font-semibold text-neutral-700 dark:text-neutral-200">
-            公共求购
-          </h4>
-          <UiButton variant="outline" size="sm" :disabled="buyRequestLoading" @click="emit('refresh-buy-requests', { resetPublic: true })">
-            {{ buyRequestLoading ? '刷新中...' : '刷新' }}
-          </UiButton>
-        </header>
-
-        <!-- 可接单筛选开关 -->
-        <div v-if="userId" class="mt-2">
-          <button
-            type="button"
-            class="br-fulfillable-toggle"
-            :class="{ 'br-fulfillable-toggle--active': brShowFulfillableOnly }"
-            @click="toggleFulfillableOnly"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="br-fulfillable-toggle__icon"><path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" /></svg>
-            仅显示我可接的求购
-          </button>
-        </div>
-
-        <div class="mt-2 grid gap-2 md:grid-cols-[minmax(0,1fr),minmax(160px,200px),auto]">
-          <UiInput v-model.trim="brSearchInput" type="search" placeholder="搜索卡片名 / 作者 / 买家" class="w-full" />
-          <UiSelectRoot v-model="brSortMode">
-            <UiSelectTrigger placeholder="排序方式" />
-            <UiSelectContent>
-              <UiSelectItem value="LATEST">按发布时间</UiSelectItem>
-              <UiSelectItem value="RARITY_DESC">按稀有度</UiSelectItem>
-              <UiSelectItem value="TOKEN_DESC">按出价降序</UiSelectItem>
-              <UiSelectItem value="TOKEN_ASC">按出价升序</UiSelectItem>
-              <UiSelectItem value="EXPIRY_ASC">按到期时间</UiSelectItem>
-            </UiSelectContent>
-          </UiSelectRoot>
-          <UiButton variant="outline" class="h-9" @click="brResetFilters">重置</UiButton>
-        </div>
-        <div class="mt-2">
-          <GachaRarityFilter v-model="brRarityFilter" :options="tradeRarityFilterOptions" all-label="全部品质" />
-        </div>
-
-        <p class="mt-2 text-[11px] text-neutral-500 dark:text-neutral-400">
-          显示 {{ visibleBuyRequests.length }}{{ brShowFulfillableOnly ? ` (可接)` : '' }} / {{ buyRequestPublicTotal }} 条
-        </p>
-
-        <p v-if="!displayedBuyRequests.length" class="gacha-empty mt-3">
-          {{ brShowFulfillableOnly ? '当前没有你可以接的求购。' : '当前没有公开求购。' }}
-        </p>
-        <div v-else class="mt-3 gacha-trade-item-grid">
-          <button
-            v-for="br in visibleBuyRequests"
-            :key="`public-br-${br.id}`"
-            type="button"
-            class="trade-item-row"
-            @click="openBuyRequestDetail(br)"
-          >
-            <div class="trade-item-row__card">
-              <GachaCardMini
-                :title="br.targetCard.title"
-                :rarity="br.targetCard.rarity"
-                :image-url="br.targetCard.imageUrl || undefined"
-                :retired="br.targetCard.isRetired"
-                :hide-footer="true"
-              />
-            </div>
-            <div class="trade-item-row__info">
-              <span class="trade-item-row__user">{{ formatAccountDisplayName(br.buyer, br.buyerId) }}</span>
-              <span class="trade-item-row__price">{{ br.tokenOffer > 0 ? `${formatTokens(br.tokenOffer)}T` : '' }}{{ br.tokenOffer > 0 && br.offeredCards.length > 0 ? ' + ' : '' }}{{ br.offeredCards.length > 0 ? `${br.offeredCards.length}卡` : '' }}</span>
-              <span class="flex items-center gap-1">
-                <span class="trade-item-row__time">{{ buyRequestRemainingLabel(br) }}</span>
-                <span class="br-match-chip">{{ buyRequestMatchLevelShortMap[br.matchLevel] }}</span>
-              </span>
-            </div>
-          </button>
-        </div>
-
-        <div v-if="hasMoreBrLocal" class="mt-3 flex items-center justify-center">
-          <UiButton variant="outline" size="sm" @click="brVisibleCount += BR_PAGE_SIZE">
-            显示更多已加载求购（剩余 {{ displayedBuyRequests.length - brVisibleCount }} 条）
-          </UiButton>
-        </div>
-
-        <GachaPagination
-          :current="buyRequestPublicPage"
-          :total="buyRequestPublicTotal"
-          :page-size="40"
-          :loading="buyRequestPublicLoadingMore || buyRequestLoading"
-          @change="(p: number) => { buyRequestPublicPage = p; emit('buy-request-page-change', p) }"
-        />
-      </article>
+    <div v-else-if="activeSubTab === 'buyRequest'" class="mt-4">
+      <TradeBuyForm
+        :show-buy-request-form="showBuyRequestForm"
+        :br-selected-page="brSelectedPage"
+        :br-selected-variant-ids="brSelectedVariantIds"
+        :br-selected-coatings="brSelectedCoatings"
+        :br-token-offer="brTokenOffer"
+        :br-expires-hours="brExpiresHours"
+        :br-offered-cards="brOfferedCards"
+        :br-target-search="brTargetSearch"
+        :br-offered-search="brOfferedSearch"
+        :br-filtered-catalog="brFilteredCatalog"
+        :br-filtered-trade-card-options="brFilteredTradeCardOptions"
+        :br-derived-payloads="brDerivedPayloads"
+        :br-derived-match-level-label="brDerivedMatchLevelLabel"
+        :br-can-submit="brCanSubmit"
+        :buy-request-submitting="buyRequestSubmitting"
+        :inventory-loading="inventoryLoading"
+        :card-options="cardOptions"
+        :coating-options="coatingOptions"
+        :public-buy-requests="displayedBuyRequests"
+        :visible-buy-requests="visibleBuyRequests"
+        :has-more-br-local="hasMoreBrLocal"
+        :buy-request-public-total="buyRequestPublicTotal"
+        :buy-request-public-page="buyRequestPublicPage"
+        :buy-request-loading="buyRequestLoading"
+        :buy-request-public-loading-more="buyRequestPublicLoadingMore"
+        :br-search-input="brSearchInput"
+        :br-sort-mode="brSortMode"
+        :br-rarity-filter="brRarityFilter"
+        :trade-rarity-filter-options="tradeRarityFilterOptions"
+        :br-show-fulfillable-only="brShowFulfillableOnly"
+        :user-id="userId"
+        :client-now="clientNow"
+        :br-page-size="BR_PAGE_SIZE"
+        @update:show-buy-request-form="showBuyRequestForm = $event"
+        @update:br-target-search="brTargetSearch = $event"
+        @update:br-offered-search="brOfferedSearch = $event"
+        @update:br-token-offer="brTokenOffer = $event"
+        @update:br-expires-hours="brExpiresHours = $event"
+        @update:br-search-input="brSearchInput = $event"
+        @update:br-sort-mode="brSortMode = $event"
+        @update:br-rarity-filter="brRarityFilter = $event"
+        @br-select-page="brSelectPage"
+        @br-clear-selection="brClearSelection"
+        @br-toggle-variant="brToggleVariant"
+        @br-select-all-variants="brSelectAllVariants"
+        @br-clear-variants="brClearVariants"
+        @br-toggle-coating="brToggleCoating"
+        @br-toggle-offered-card="brToggleOfferedCard"
+        @br-remove-offered-card="brRemoveOfferedCard"
+        @br-set-offered-quantity="brSetOfferedQuantity"
+        @create-buy-request="handleCreateBuyRequest"
+        @open-buy-request-detail="openBuyRequestDetail"
+        @toggle-fulfillable-only="toggleFulfillableOnly"
+        @br-reset-filters="brResetFilters"
+        @br-load-more-local="brVisibleCount += BR_PAGE_SIZE"
+        @buy-request-page-change="(p) => { buyRequestPublicPage = p; emit('buy-request-page-change', p) }"
+        @refresh-buy-requests="emit('refresh-buy-requests', { resetPublic: true })"
+      />
     </div>
 
-    <!-- 挂牌详情弹窗 -->
-    <UiDialogRoot :open="!!selectedMyListing" @update:open="handleMyListingDialogChange">
-      <UiDialogPortal>
-        <UiDialogOverlay />
-        <UiDialogContent class="max-w-lg p-0">
-          <template v-if="selectedMyListing">
-            <header class="flex items-start justify-between gap-3 border-b border-neutral-200/60 px-5 py-4 dark:border-neutral-800/70">
-              <div class="min-w-0">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-cyan-700 dark:text-cyan-200">My Listing</p>
-                <h3 class="mt-1 truncate text-lg font-semibold text-neutral-900 dark:text-neutral-50">{{ selectedMyListing.card.title }}</h3>
-                <p class="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">
-                  {{ rarityLabel(selectedMyListing.card.rarity) }} · {{ tradeStatusLabel(selectedMyListing.status) }}
-                </p>
-              </div>
-              <UiDialogClose as-child>
-                <UiButton variant="ghost" size="sm" class="h-9 w-9 rounded-full p-0" aria-label="关闭">X</UiButton>
-              </UiDialogClose>
-            </header>
-
-            <div class="max-h-[calc(100vh-7rem)] max-h-[calc(100dvh-7rem)] overflow-y-auto px-5 pb-5 pt-4">
-              <div class="grid gap-4 sm:grid-cols-[150px_minmax(0,1fr)] sm:items-start">
-                <div class="trade-detail-mini-card">
-                  <GachaCard
-                    :title="selectedMyListing.card.title"
-                    :rarity="selectedMyListing.card.rarity"
-                    :tags="selectedMyListing.card.tags ?? []"
-                    :wikidot-id="selectedMyListing.card.wikidotId"
-                    :authors="selectedMyListing.card.authors"
-                    :image-url="selectedMyListing.card.imageUrl || undefined"
-                    :retired="selectedMyListing.card.isRetired"
-                    variant="mini"
-                    :hide-footer="true"
-                    :affix-visual-style="selectedMyListing.card.affixVisualStyle || selectedMyListing.affixBreakdown?.[0]?.affixVisualStyle"
-                    :affix-signature="selectedMyListing.card.affixSignature || selectedMyListing.affixBreakdown?.[0]?.affixSignature"
-                    :affix-styles="selectedMyListing.card.affixStyles || selectedMyListing.affixBreakdown?.[0]?.affixStyles"
-                    :affix-style-counts="selectedMyListing.card.affixStyleCounts || selectedMyListing.affixBreakdown?.[0]?.affixStyleCounts"
-                    :affix-label="selectedMyListing.card.affixLabel || selectedMyListing.affixBreakdown?.[0]?.affixLabel"
-                  />
-                </div>
-
-                <div class="space-y-3">
-                  <dl class="grid grid-cols-2 gap-2 text-xs">
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">单价</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatTokens(selectedMyListing.unitPrice) }} Token</dd>
-                    </div>
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">总价</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatTokens(listingTotalPrice(selectedMyListing)) }} Token</dd>
-                    </div>
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">剩余数量</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ selectedMyListing.remaining }} / {{ selectedMyListing.quantity }}</dd>
-                    </div>
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">到期时间</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatDateCompact(selectedMyListing.expiresAt) || '无' }}</dd>
-                    </div>
-                    <div
-                      v-if="selectedMyListing.status === 'SOLD'"
-                      class="rounded-xl border border-emerald-200/80 bg-emerald-50/80 px-2.5 py-2 dark:border-emerald-700/70 dark:bg-emerald-900/20"
-                    >
-                      <dt class="text-emerald-700 dark:text-emerald-300">成交买家</dt>
-                      <dd class="mt-0.5 font-semibold text-emerald-900 dark:text-emerald-100">
-                        {{ formatAccountDisplayName(selectedMyListing.buyer, selectedMyListing.buyerId) }}
-                      </dd>
-                    </div>
-                    <div
-                      v-if="selectedMyListing.status === 'SOLD'"
-                      class="rounded-xl border border-emerald-200/80 bg-emerald-50/80 px-2.5 py-2 dark:border-emerald-700/70 dark:bg-emerald-900/20"
-                    >
-                      <dt class="text-emerald-700 dark:text-emerald-300">成交时间</dt>
-                      <dd class="mt-0.5 font-semibold text-emerald-900 dark:text-emerald-100">
-                        {{ formatDateCompact(selectedMyListing.soldAt) || '未知' }}
-                      </dd>
-                    </div>
-                  </dl>
-
-                  <div v-if="selectedMyListing.affixBreakdown?.length" class="flex flex-wrap gap-1.5 text-[10px]">
-                    <template
-                      v-for="entry in selectedMyListing.affixBreakdown"
-                      :key="`my-detail-bd-${entry.affixSignature || entry.affixVisualStyle}`"
-                    >
-                      <GachaAffixChip
-                        v-for="part in resolveAffixParts(entry)"
-                        :key="`my-detail-bd-${entry.affixSignature || entry.affixVisualStyle}-${part.style}-${part.count}`"
-                        :style="part.style"
-                        :count="part.count"
-                        :show-glyph="true"
-                        :suffix="`x${entry.count}`"
-                      />
-                    </template>
-                  </div>
-
-                  <div class="flex items-center gap-2 pt-1">
-                    <span
-                      class="inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold"
-                      :class="tradeStatusChipClassMap[selectedMyListing.status]"
-                    >
-                      {{ tradeStatusLabel(selectedMyListing.status) }}
-                    </span>
-                    <span class="text-[11px] text-neutral-500 dark:text-neutral-400">
-                      上架 {{ formatDateCompact(selectedMyListing.createdAt) }}
-                    </span>
-                  </div>
-
-                  <UiButton
-                    v-if="selectedMyListing.status === 'OPEN' && selectedMyListing.remaining > 0"
-                    class="w-full"
-                    variant="outline"
-                    :disabled="cancellingId === selectedMyListing.id"
-                    @click="emit('cancel', selectedMyListing.id); closeMyListingDetail()"
-                  >
-                    {{ cancellingId === selectedMyListing.id ? '撤销中...' : '撤销挂牌' }}
-                  </UiButton>
-                </div>
-              </div>
-            </div>
-          </template>
-        </UiDialogContent>
-      </UiDialogPortal>
-    </UiDialogRoot>
-
-    <UiDialogRoot :open="!!selectedPublicListing" @update:open="handlePublicListingDialogChange">
-      <UiDialogPortal>
-        <UiDialogOverlay />
-        <UiDialogContent class="max-w-lg p-0">
-          <template v-if="selectedPublicListing">
-            <header class="flex items-start justify-between gap-3 border-b border-neutral-200/60 px-5 py-4 dark:border-neutral-800/70">
-              <div class="min-w-0">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-cyan-700 dark:text-cyan-200">Trade Listing</p>
-                <h3 class="mt-1 truncate text-lg font-semibold text-neutral-900 dark:text-neutral-50">{{ selectedPublicListing.card.title }}</h3>
-                <p class="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">
-                  {{ rarityLabel(selectedPublicListing.card.rarity) }} · 卖家 {{ formatAccountDisplayName(selectedPublicListing.seller, selectedPublicListing.sellerId) }}
-                </p>
-              </div>
-              <UiDialogClose as-child>
-                <UiButton variant="ghost" size="sm" class="h-9 w-9 rounded-full p-0" aria-label="关闭">X</UiButton>
-              </UiDialogClose>
-            </header>
-
-            <div class="max-h-[calc(100vh-7rem)] max-h-[calc(100dvh-7rem)] overflow-y-auto px-5 pb-5 pt-4">
-              <div class="grid gap-4 sm:grid-cols-[150px_minmax(0,1fr)] sm:items-start">
-                <div class="trade-detail-mini-card">
-                  <GachaCard
-                    :title="selectedPublicListing.card.title"
-                    :rarity="selectedPublicListing.card.rarity"
-                    :tags="selectedPublicListing.card.tags ?? []"
-                    :wikidot-id="selectedPublicListing.card.wikidotId"
-                    :authors="selectedPublicListing.card.authors"
-                    :image-url="selectedPublicListing.card.imageUrl || undefined"
-                    :retired="selectedPublicListing.card.isRetired"
-                    variant="mini"
-                    :hide-footer="true"
-                    :affix-visual-style="selectedPublicListing.card.affixVisualStyle || selectedPublicListing.affixBreakdown?.[0]?.affixVisualStyle"
-                    :affix-signature="selectedPublicListing.card.affixSignature || selectedPublicListing.affixBreakdown?.[0]?.affixSignature"
-                    :affix-styles="selectedPublicListing.card.affixStyles || selectedPublicListing.affixBreakdown?.[0]?.affixStyles"
-                    :affix-style-counts="selectedPublicListing.card.affixStyleCounts || selectedPublicListing.affixBreakdown?.[0]?.affixStyleCounts"
-                    :affix-label="selectedPublicListing.card.affixLabel || selectedPublicListing.affixBreakdown?.[0]?.affixLabel"
-                  />
-                </div>
-
-                <div class="space-y-3">
-                  <dl class="grid grid-cols-2 gap-2 text-xs">
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">单价</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatTokens(selectedPublicListing.unitPrice) }} Token</dd>
-                    </div>
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">总价</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatTokens(listingTotalPrice(selectedPublicListing)) }} Token</dd>
-                    </div>
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">剩余数量</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ selectedPublicListing.remaining }} / {{ selectedPublicListing.quantity }}</dd>
-                    </div>
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">到期时间</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatDateCompact(selectedPublicListing.expiresAt) || '无' }}</dd>
-                    </div>
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">卖家</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">
-                        {{ formatAccountDisplayName(selectedPublicListing.seller, selectedPublicListing.sellerId) }}
-                      </dd>
-                    </div>
-                  </dl>
-
-                  <div v-if="selectedPublicListing.affixBreakdown?.length" class="flex flex-wrap gap-1.5 text-[10px]">
-                    <template
-                      v-for="entry in selectedPublicListing.affixBreakdown"
-                      :key="`detail-bd-${entry.affixSignature || entry.affixVisualStyle}`"
-                    >
-                      <GachaAffixChip
-                        v-for="part in resolveAffixParts(entry)"
-                        :key="`detail-bd-${entry.affixSignature || entry.affixVisualStyle}-${part.style}-${part.count}`"
-                        :style="part.style"
-                        :count="part.count"
-                        :show-glyph="true"
-                        :suffix="`x${entry.count}`"
-                      />
-                    </template>
-                  </div>
-
-                  <div class="flex items-center gap-2 pt-1">
-                    <span
-                      class="inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold"
-                      :class="tradeStatusChipClassMap[selectedPublicListing.status]"
-                    >
-                      {{ tradeStatusLabel(selectedPublicListing.status) }}
-                    </span>
-                    <span class="text-[11px] text-neutral-500 dark:text-neutral-400">
-                      上架 {{ formatDateCompact(selectedPublicListing.createdAt) }}
-                    </span>
-                  </div>
-
-                  <UiButton
-                    class="w-full"
-                    :disabled="buyingId === selectedPublicListing.id || selectedPublicListing.sellerId === userId || selectedPublicListing.status !== 'OPEN' || selectedPublicListing.remaining <= 0"
-                    @click="emit('buy', selectedPublicListing.id); closeListingDetail()"
-                  >
-                    <span v-if="buyingId === selectedPublicListing.id">购买中...</span>
-                    <span v-else-if="selectedPublicListing.sellerId === userId">这是我的挂牌</span>
-                    <span v-else>购买 · {{ formatTokens(selectedPublicListing.unitPrice) }} Token</span>
-                  </UiButton>
-                </div>
-              </div>
-            </div>
-          </template>
-        </UiDialogContent>
-      </UiDialogPortal>
-    </UiDialogRoot>
-
-    <!-- 求购详情弹窗 -->
-    <UiDialogRoot :open="!!selectedBuyRequest" @update:open="handleBuyRequestDialogChange">
-      <UiDialogPortal>
-        <UiDialogOverlay />
-        <UiDialogContent class="max-w-xl p-0">
-          <template v-if="selectedBuyRequest">
-            <header class="flex items-start justify-between gap-3 border-b border-neutral-200/60 px-5 py-4 dark:border-neutral-800/70">
-              <div class="min-w-0">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-cyan-700 dark:text-cyan-200">Buy Request</p>
-                <h3 class="mt-1 truncate text-lg font-semibold text-neutral-900 dark:text-neutral-50">求购: {{ selectedBuyRequest.targetCard.title }}</h3>
-                <p class="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">
-                  {{ rarityLabel(selectedBuyRequest.targetCard.rarity) }} · 买家 {{ formatAccountDisplayName(selectedBuyRequest.buyer, selectedBuyRequest.buyerId) }}
-                </p>
-              </div>
-              <UiDialogClose as-child>
-                <UiButton variant="ghost" size="sm" class="h-9 w-9 rounded-full p-0" aria-label="关闭">X</UiButton>
-              </UiDialogClose>
-            </header>
-
-            <div class="br-detail-body">
-              <div class="br-detail-layout">
-                <div class="br-detail-card">
-                  <GachaCard
-                    :title="selectedBuyRequest.targetCard.title"
-                    :rarity="selectedBuyRequest.targetCard.rarity"
-                    :tags="selectedBuyRequest.targetCard.tags ?? []"
-                    :wikidot-id="selectedBuyRequest.targetCard.wikidotId"
-                    :authors="selectedBuyRequest.targetCard.authors"
-                    :image-url="selectedBuyRequest.targetCard.imageUrl || undefined"
-                    :retired="selectedBuyRequest.targetCard.isRetired"
-                    variant="mini"
-                    :hide-footer="true"
-                  />
-                </div>
-
-                <div class="space-y-3">
-                  <dl class="br-detail-stats">
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">Token 出价</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">
-                        {{ selectedBuyRequest.tokenOffer > 0 ? `${formatTokens(selectedBuyRequest.tokenOffer)} Token` : '无' }}
-                      </dd>
-                    </div>
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">提供卡牌</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">
-                        {{ selectedBuyRequest.offeredCards.length > 0 ? `${selectedBuyRequest.offeredCards.length} 种` : '无' }}
-                      </dd>
-                    </div>
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">到期时间</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatDateCompact(selectedBuyRequest.expiresAt) || '无' }}</dd>
-                    </div>
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">状态</dt>
-                      <dd class="mt-0.5">
-                        <span class="inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold" :class="buyRequestStatusChipClassMap[selectedBuyRequest.status]">
-                          {{ buyRequestStatusLabelMap[selectedBuyRequest.status] }}
-                        </span>
-                      </dd>
-                    </div>
-                    <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
-                      <dt class="text-neutral-500 dark:text-neutral-400">匹配要求</dt>
-                      <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">
-                        {{ buyRequestMatchLevelLabelMap[selectedBuyRequest.matchLevel] }}
-                        <span v-if="selectedBuyRequest.matchLevel === 'COATING' && selectedBuyRequest.requiredCoating" class="text-[10px] font-normal text-neutral-500 dark:text-neutral-400">
-                          · {{ coatingStyleLabelMap[selectedBuyRequest.requiredCoating] }}
-                        </span>
-                      </dd>
-                    </div>
-                  </dl>
-
-                  <div v-if="selectedBuyRequest.offeredCards.length > 0" class="space-y-1.5">
-                    <span class="text-[10px] font-semibold text-neutral-500 dark:text-neutral-400">提供的卡牌</span>
-                    <div class="flex flex-wrap gap-2">
-                      <div
-                        v-for="oc in selectedBuyRequest.offeredCards"
-                        :key="`br-detail-oc-${oc.id}`"
-                        class="flex items-center gap-1.5 rounded-lg border border-neutral-200/60 bg-white/70 px-2 py-1 dark:border-neutral-700/60 dark:bg-neutral-800/60"
-                      >
-                        <img v-if="oc.card.imageUrl" :src="oc.card.imageUrl" class="h-6 w-6 rounded object-cover" loading="lazy" />
-                        <span class="max-w-[100px] truncate text-[10px] font-medium text-neutral-700 dark:text-neutral-200">{{ oc.card.title }}</span>
-                        <span class="text-[9px] text-neutral-500 dark:text-neutral-400">x{{ oc.quantity }}</span>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div
-                    v-if="selectedBuyRequest.status === 'OPEN' && selectedBuyRequest.buyerId !== userId"
-                    class="space-y-1.5"
-                  >
-                    <div class="flex items-center justify-between gap-2">
-                      <span class="text-[10px] font-semibold text-neutral-500 dark:text-neutral-400">选择要提供的卡牌</span>
-                      <span v-if="buyRequestFulfillCandidates.length > 1" class="text-[10px] text-neutral-500 dark:text-neutral-400">
-                        可选 {{ buyRequestFulfillCandidates.length }} 种
-                      </span>
-                    </div>
-                    <p
-                      v-if="inventoryLoading && !cardOptions.length"
-                      class="text-[11px] text-neutral-500 dark:text-neutral-400"
-                    >
-                      正在加载你的可交付库存...
-                    </p>
-                    <div v-else-if="buyRequestFulfillCandidates.length > 0" class="br-fulfill-grid">
-                      <button
-                        v-for="item in buyRequestFulfillCandidates"
-                        :key="`br-fulfill-candidate-${item.stackKey}`"
-                        type="button"
-                        class="trade-create-card"
-                        :class="{ 'trade-create-card--selected': selectedFulfillStackKey === item.stackKey }"
-                        @click="selectedFulfillStackKey = item.stackKey"
-                      >
-                        <GachaCardMini
-                          :title="item.title"
-                          :rarity="item.rarity"
-                          :image-url="item.imageUrl || undefined"
-                          :retired="item.isRetired"
-                          :affix-visual-style="item.affixVisualStyle"
-                          :affix-label="item.affixLabel"
-                        >
-                          <template #meta>
-                            <span class="trade-remaining-chip">可交付 {{ item.availableCount }}</span>
-                          </template>
-                        </GachaCardMini>
-                      </button>
-                    </div>
-                    <p v-else class="text-[11px] text-neutral-500 dark:text-neutral-400">
-                      暂无可直接交付库存，将由系统自动尝试释放符合条件的卡牌。
-                    </p>
-                  </div>
-
-                </div>
-              </div>
-
-              <!-- Sticky action buttons -->
-              <div
-                v-if="selectedBuyRequest.status === 'OPEN'"
-                class="br-detail-actions"
-              >
-                <UiButton
-                  v-if="selectedBuyRequest.buyerId !== userId"
-                  class="w-full"
-                  :disabled="buyRequestFulfillingId === selectedBuyRequest.id"
-                  @click="handleFulfillBuyRequestFromDetail"
-                >
-                  {{
-                    buyRequestFulfillingId === selectedBuyRequest.id
-                      ? '接受中...'
-                      : buyRequestFulfillCandidates.length > 1
-                        ? '选择并接受求购'
-                        : '接受求购（出售目标卡）'
-                  }}
-                </UiButton>
-
-                <UiButton
-                  v-if="selectedBuyRequest.buyerId === userId"
-                  class="w-full"
-                  variant="outline"
-                  :disabled="buyRequestCancelId === selectedBuyRequest.id"
-                  @click="emit('cancel-buy-request', selectedBuyRequest.id); closeBuyRequestDetail()"
-                >
-                  {{ buyRequestCancelId === selectedBuyRequest.id ? '取消中...' : '取消求购' }}
-                </UiButton>
-              </div>
-            </div>
-          </template>
-        </UiDialogContent>
-      </UiDialogPortal>
-    </UiDialogRoot>
+    <!-- 详情弹窗 -->
+    <TradeDetail
+      :selected-my-listing="selectedMyListing"
+      :cancelling-id="cancellingId"
+      :selected-public-listing="selectedPublicListing"
+      :buying-id="buyingId"
+      :user-id="userId"
+      :selected-buy-request="selectedBuyRequest"
+      :buy-request-fulfill-candidates="buyRequestFulfillCandidates"
+      :selected-fulfill-stack-key="selectedFulfillStackKey"
+      :buy-request-fulfilling-id="buyRequestFulfillingId"
+      :buy-request-cancel-id="buyRequestCancelId"
+      :inventory-loading="inventoryLoading"
+      :card-options-length="cardOptions.length"
+      @close-my-listing="closeMyListingDetail"
+      @close-public-listing="closeListingDetail"
+      @close-buy-request="closeBuyRequestDetail"
+      @cancel-listing="(id) => emit('cancel', id)"
+      @buy-listing="(id) => emit('buy', id)"
+      @update:selected-fulfill-stack-key="selectedFulfillStackKey = $event"
+      @fulfill-buy-request="handleFulfillBuyRequestFromDetail"
+      @cancel-buy-request="(id) => emit('cancel-buy-request', id)"
+    />
   </section>
 </template>
 
-<style scoped>
-.trade-sub-tab {
-  flex: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  border-radius: 0.5rem;
-  padding: 0.4rem 0.75rem;
-  font-size: 12px;
-  font-weight: 600;
-  color: rgb(100 116 139);
-  cursor: pointer;
-  transition: all 0.15s ease;
-  border: none;
-  background: transparent;
-}
-
-.trade-sub-tab:hover {
-  color: rgb(51 65 85);
-  background: rgba(255, 255, 255, 0.6);
-}
-
-.trade-sub-tab--active {
-  background: white;
-  color: rgb(15 23 42);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
-}
-
-html.dark .trade-sub-tab {
-  color: rgb(148 163 184);
-}
-
-html.dark .trade-sub-tab:hover {
-  color: rgb(226 232 240);
-  background: rgba(255, 255, 255, 0.06);
-}
-
-html.dark .trade-sub-tab--active {
-  background: rgba(30, 41, 59, 0.9);
-  color: rgb(241 245 249);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-}
-
-.trade-sub-tab__badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 16px;
-  height: 16px;
-  padding: 0 4px;
-  border-radius: 999px;
-  font-size: 9px;
-  font-weight: 700;
-  background: rgba(14, 116, 144, 0.12);
-  color: rgb(14 116 144);
-}
-
-html.dark .trade-sub-tab__badge {
-  background: rgba(34, 211, 238, 0.15);
-  color: rgb(103 232 249);
-}
-
-.trade-create-card {
-  position: relative;
-  display: block;
-  width: 100%;
-  min-width: 0;
-  border-radius: 0.9rem;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: rgba(255, 255, 255, 0.72);
-  padding: 0.22rem;
-  text-align: left;
-  cursor: pointer;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
-}
-
-.trade-create-card:hover {
-  border-color: rgba(14, 116, 144, 0.35);
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
-  transform: translateY(-1px);
-}
-
-.trade-create-card--selected {
-  border-color: rgba(14, 116, 144, 0.55);
-  box-shadow:
-    0 0 0 4px rgba(14, 116, 144, 0.22),
-    0 0 0 1px rgba(14, 116, 144, 0.12),
-    0 8px 20px rgba(8, 145, 178, 0.16);
-}
-
-html.dark .trade-create-card {
-  border-color: rgba(100, 116, 139, 0.45);
-  background: rgba(15, 23, 42, 0.62);
-}
-
-html.dark .trade-create-card:hover {
-  border-color: rgba(34, 211, 238, 0.45);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.28);
-}
-
-html.dark .trade-create-card--selected {
-  border-color: rgba(34, 211, 238, 0.62);
-  box-shadow:
-    0 0 0 4px rgba(34, 211, 238, 0.22),
-    0 0 0 1px rgba(34, 211, 238, 0.2),
-    0 10px 22px rgba(6, 182, 212, 0.18);
-}
-
-.trade-price-chip {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  border: 1px solid rgba(245, 158, 11, 0.4);
-  background: rgba(245, 158, 11, 0.1);
-  color: rgb(180 83 9);
-  font-size: 10px;
-  font-weight: 700;
-  padding: 1px 6px;
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
-}
-
-html.dark .trade-price-chip {
-  border-color: rgba(251, 191, 36, 0.45);
-  background: rgba(245, 158, 11, 0.15);
-  color: rgb(252 211 77);
-}
-
-.trade-meta-cluster {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  min-width: 0;
-}
-
-.trade-seller-chip {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  border: 1px solid rgba(14, 116, 144, 0.3);
-  background: rgba(236, 254, 255, 0.8);
-  color: rgb(14 116 144);
-  font-size: 9px;
-  font-weight: 600;
-  padding: 1px 6px;
-  max-width: 88px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-html.dark .trade-seller-chip {
-  border-color: rgba(34, 211, 238, 0.36);
-  background: rgba(8, 47, 73, 0.62);
-  color: rgb(103 232 249);
-}
-
-.trade-remaining-chip {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(248, 250, 252, 0.8);
-  color: rgb(100 116 139);
-  font-size: 9px;
-  font-weight: 600;
-  padding: 1px 5px;
-  white-space: nowrap;
-}
-
-html.dark .trade-remaining-chip {
-  border-color: rgba(100, 116, 139, 0.45);
-  background: rgba(15, 23, 42, 0.7);
-  color: rgb(148 163 184);
-}
-
-.trade-expire-chip {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  border: 1px solid rgba(14, 116, 144, 0.28);
-  background: rgba(236, 254, 255, 0.72);
-  color: rgb(14 116 144);
-  font-size: 9px;
-  font-weight: 700;
-  padding: 1px 5px;
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
-}
-
-html.dark .trade-expire-chip {
-  border-color: rgba(34, 211, 238, 0.32);
-  background: rgba(8, 47, 73, 0.65);
-  color: rgb(103 232 249);
-}
-
-.trade-create-grid {
-  align-items: stretch;
-}
-
-/* ── Picker scroll area ── */
-
-.picker-scroll-area {
-  max-height: 22rem;
-  overflow-y: auto;
-  padding-right: 2px;
-}
-
-.picker-load-more-btn {
-  display: block;
-  width: 100%;
-  margin-top: 8px;
-  padding: 8px 0;
-  border-radius: 0.6rem;
-  border: 1px solid rgba(14, 116, 144, 0.25);
-  background: rgba(236, 254, 255, 0.4);
-  color: rgb(14 116 144);
-  font-size: 11px;
-  font-weight: 600;
-  text-align: center;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.picker-load-more-btn:hover {
-  border-color: rgba(14, 116, 144, 0.45);
-  background: rgba(236, 254, 255, 0.7);
-  box-shadow: 0 2px 8px rgba(8, 145, 178, 0.08);
-}
-
-html.dark .picker-load-more-btn {
-  border-color: rgba(34, 211, 238, 0.25);
-  background: rgba(8, 47, 73, 0.4);
-  color: rgb(103 232 249);
-}
-
-html.dark .picker-load-more-btn:hover {
-  border-color: rgba(34, 211, 238, 0.45);
-  background: rgba(8, 47, 73, 0.6);
-}
-
-/* ── Rarity group tags ── */
-
-.picker-rarity-tag {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  padding: 1px 7px;
-  font-size: 10px;
-  font-weight: 600;
-  border: 1px solid;
-}
-
-.picker-rarity-tag--gold { border-color: rgba(245, 158, 11, 0.35); background: rgba(245, 158, 11, 0.08); color: rgb(180 83 9); }
-.picker-rarity-tag--purple { border-color: rgba(124, 58, 237, 0.3); background: rgba(124, 58, 237, 0.06); color: rgb(109 40 217); }
-.picker-rarity-tag--blue { border-color: rgba(37, 99, 235, 0.3); background: rgba(37, 99, 235, 0.06); color: rgb(29 78 216); }
-.picker-rarity-tag--green { border-color: rgba(5, 150, 105, 0.3); background: rgba(5, 150, 105, 0.06); color: rgb(4 120 87); }
-.picker-rarity-tag--white { border-color: rgba(148, 163, 184, 0.35); background: rgba(148, 163, 184, 0.06); color: rgb(100 116 139); }
-
-html.dark .picker-rarity-tag--gold { border-color: rgba(251, 191, 36, 0.4); background: rgba(245, 158, 11, 0.12); color: rgb(252 211 77); }
-html.dark .picker-rarity-tag--purple { border-color: rgba(167, 139, 250, 0.4); background: rgba(124, 58, 237, 0.12); color: rgb(196 181 253); }
-html.dark .picker-rarity-tag--blue { border-color: rgba(96, 165, 250, 0.4); background: rgba(37, 99, 235, 0.12); color: rgb(147 197 253); }
-html.dark .picker-rarity-tag--green { border-color: rgba(52, 211, 153, 0.4); background: rgba(5, 150, 105, 0.12); color: rgb(110 231 183); }
-html.dark .picker-rarity-tag--white { border-color: rgba(148, 163, 184, 0.4); background: rgba(148, 163, 184, 0.1); color: rgb(148 163 184); }
-
-.trade-my-grid {
-  align-items: stretch;
-}
-
-.trade-detail-mini-card {
-  width: 100%;
-  max-width: 150px;
-  margin-inline: auto;
-}
-
-.trade-detail-mini-card > * {
-  width: 100%;
-}
-
-.br-target-pick {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 6px;
-  border-radius: 0.5rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(255, 255, 255, 0.7);
-  cursor: pointer;
-  text-align: left;
-  transition: border-color 0.12s ease, box-shadow 0.12s ease;
-  min-width: 0;
-}
-
-.br-target-pick:hover {
-  border-color: rgba(14, 116, 144, 0.35);
-}
-
-.br-target-pick--selected {
-  border-color: rgba(14, 116, 144, 0.6);
-  box-shadow: 0 0 0 2px rgba(14, 116, 144, 0.18);
-}
-
-html.dark .br-target-pick {
-  border-color: rgba(100, 116, 139, 0.4);
-  background: rgba(15, 23, 42, 0.6);
-}
-
-html.dark .br-target-pick:hover {
-  border-color: rgba(34, 211, 238, 0.4);
-}
-
-html.dark .br-target-pick--selected {
-  border-color: rgba(34, 211, 238, 0.6);
-  box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.18);
-}
-
-.br-target-pick__img {
-  width: 28px;
-  height: 28px;
-  border-radius: 4px;
-  object-fit: cover;
-  flex-shrink: 0;
-}
-
-.br-target-pick__placeholder {
-  width: 28px;
-  height: 28px;
-  border-radius: 4px;
-  background: rgba(148, 163, 184, 0.15);
-  flex-shrink: 0;
-}
-
-.br-target-pick__title {
-  font-size: 10px;
-  font-weight: 500;
-  color: rgb(51 65 85);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-}
-
-html.dark .br-target-pick__title {
-  color: rgb(226 232 240);
-}
-
-/* ── 折叠按钮 ── */
-
-.trade-collapse-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 14px;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(14, 116, 144, 0.3);
-  background: rgba(236, 254, 255, 0.5);
-  color: rgb(14 116 144);
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.trade-collapse-toggle:hover {
-  border-color: rgba(14, 116, 144, 0.5);
-  background: rgba(236, 254, 255, 0.8);
-  box-shadow: 0 2px 8px rgba(8, 145, 178, 0.1);
-}
-
-html.dark .trade-collapse-toggle {
-  border-color: rgba(34, 211, 238, 0.3);
-  background: rgba(8, 47, 73, 0.5);
-  color: rgb(103 232 249);
-}
-
-html.dark .trade-collapse-toggle:hover {
-  border-color: rgba(34, 211, 238, 0.5);
-  background: rgba(8, 47, 73, 0.7);
-}
-
-.trade-collapse-toggle__icon {
-  display: inline-block;
-  font-size: 10px;
-  transition: transform 0.2s ease;
-}
-
-.trade-collapse-toggle__icon--open {
-  transform: rotate(180deg);
-}
-
-/* ── 折叠过渡 ── */
-
-.trade-collapse-enter-active,
-.trade-collapse-leave-active {
-  transition: all 0.25s ease;
-  overflow: hidden;
-}
-
-.trade-collapse-enter-from,
-.trade-collapse-leave-to {
-  opacity: 0;
-  max-height: 0;
-  margin-top: 0;
-}
-
-.trade-collapse-enter-to,
-.trade-collapse-leave-from {
-  opacity: 1;
-  max-height: 2000px;
-}
-
-/* ── 横向行布局：左 MiniCard + 右信息 ── */
-
-.gacha-trade-item-grid {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.trade-item-row {
-  display: flex;
-  align-items: stretch;
-  gap: 8px;
-  padding: 6px;
-  border-radius: 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  background: rgba(255, 255, 255, 0.6);
-  cursor: pointer;
-  text-align: left;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.12s ease;
-  min-width: 0;
-  content-visibility: auto;
-  contain-intrinsic-size: auto 80px;
-}
-
-.trade-item-row:hover {
-  border-color: rgba(14, 116, 144, 0.4);
-  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.08);
-  transform: translateY(-1px);
-}
-
-html.dark .trade-item-row {
-  border-color: rgba(100, 116, 139, 0.35);
-  background: rgba(15, 23, 42, 0.5);
-}
-
-html.dark .trade-item-row:hover {
-  border-color: rgba(34, 211, 238, 0.45);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.3);
-}
-
-.trade-item-row__card {
-  flex: 0 0 72px;
-  min-width: 0;
-}
-
-.trade-item-row__card > * {
-  width: 100%;
-  height: 100%;
-}
-
-.trade-item-row__info {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 3px;
-  min-width: 0;
-  padding: 2px 0;
-}
-
-.trade-item-row__user {
-  font-size: 11px;
-  font-weight: 600;
-  color: rgb(14 116 144);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-html.dark .trade-item-row__user {
-  color: rgb(103 232 249);
-}
-
-.trade-item-row__price {
-  font-size: 12px;
-  font-weight: 700;
-  color: rgb(180 83 9);
-  font-variant-numeric: tabular-nums;
-}
-
-html.dark .trade-item-row__price {
-  color: rgb(252 211 77);
-}
-
-.trade-item-row__qty {
-  font-size: 10px;
-  font-weight: 500;
-  color: rgb(100 116 139);
-}
-
-html.dark .trade-item-row__qty {
-  color: rgb(148 163 184);
-}
-
-.trade-item-row__time {
-  font-size: 10px;
-  font-weight: 600;
-  color: rgb(71 85 105);
-  font-variant-numeric: tabular-nums;
-}
-
-html.dark .trade-item-row__time {
-  color: rgb(148 163 184);
-}
-
-/* ── Fulfillable row highlight ── */
-
-.trade-item-row--fulfillable {
-  border-color: rgba(16, 185, 129, 0.35);
-  background: rgba(16, 185, 129, 0.05);
-}
-
-.trade-item-row--fulfillable:hover {
-  border-color: rgba(16, 185, 129, 0.55);
-  box-shadow: 0 4px 14px rgba(16, 185, 129, 0.12);
-}
-
-html.dark .trade-item-row--fulfillable {
-  border-color: rgba(52, 211, 153, 0.3);
-  background: rgba(16, 185, 129, 0.06);
-}
-
-html.dark .trade-item-row--fulfillable:hover {
-  border-color: rgba(52, 211, 153, 0.5);
-  box-shadow: 0 4px 14px rgba(16, 185, 129, 0.15);
-}
-
-/* ── Fulfillable badge (prominent) ── */
-
-.trade-item-row__fulfillable-badge {
-  display: inline-flex;
-  align-self: flex-start;
-  align-items: center;
-  gap: 3px;
-  border-radius: 999px;
-  border: 1px solid rgba(16, 185, 129, 0.5);
-  background: rgba(16, 185, 129, 0.12);
-  color: rgb(5 150 105);
-  font-size: 10px;
-  font-weight: 700;
-  padding: 2px 8px;
-  white-space: nowrap;
-}
-
-html.dark .trade-item-row__fulfillable-badge {
-  border-color: rgba(52, 211, 153, 0.5);
-  background: rgba(16, 185, 129, 0.18);
-  color: rgb(110 231 183);
-}
-
-/* ── Header fulfillable count badge ── */
-
-.br-fulfillable-header-badge {
-  display: inline-flex;
-  align-items: center;
-  margin-left: 6px;
-  border-radius: 999px;
-  border: 1px solid rgba(16, 185, 129, 0.4);
-  background: rgba(16, 185, 129, 0.1);
-  color: rgb(5 150 105);
-  font-size: 10px;
-  font-weight: 700;
-  padding: 1px 7px;
-}
-
-html.dark .br-fulfillable-header-badge {
-  border-color: rgba(52, 211, 153, 0.4);
-  background: rgba(16, 185, 129, 0.15);
-  color: rgb(110 231 183);
-}
-
-/* ── Fulfillable filter toggle ── */
-
-.br-fulfillable-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 5px 12px;
-  border-radius: 0.6rem;
-  border: 1px solid rgba(16, 185, 129, 0.3);
-  background: rgba(16, 185, 129, 0.06);
-  color: rgb(5 150 105);
-  font-size: 11px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.br-fulfillable-toggle:hover {
-  border-color: rgba(16, 185, 129, 0.5);
-  background: rgba(16, 185, 129, 0.12);
-}
-
-.br-fulfillable-toggle--active {
-  border-color: rgba(16, 185, 129, 0.6);
-  background: rgba(16, 185, 129, 0.15);
-  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.12);
-}
-
-html.dark .br-fulfillable-toggle {
-  border-color: rgba(52, 211, 153, 0.3);
-  background: rgba(16, 185, 129, 0.08);
-  color: rgb(110 231 183);
-}
-
-html.dark .br-fulfillable-toggle:hover {
-  border-color: rgba(52, 211, 153, 0.5);
-  background: rgba(16, 185, 129, 0.15);
-}
-
-html.dark .br-fulfillable-toggle--active {
-  border-color: rgba(52, 211, 153, 0.6);
-  background: rgba(16, 185, 129, 0.2);
-  box-shadow: 0 0 0 2px rgba(52, 211, 153, 0.12);
-}
-
-.br-fulfillable-toggle__icon {
-  width: 12px;
-  height: 12px;
-}
-
-.br-match-btn {
-  display: inline-flex;
-  align-items: center;
-  padding: 4px 10px;
-  border-radius: 0.5rem;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(255, 255, 255, 0.7);
-  color: rgb(100 116 139);
-  font-size: 11px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.br-match-btn:hover {
-  border-color: rgba(14, 116, 144, 0.4);
-  color: rgb(14 116 144);
-}
-
-.br-match-btn--active {
-  border-color: rgba(14, 116, 144, 0.6);
-  background: rgba(14, 116, 144, 0.08);
-  color: rgb(14 116 144);
-  font-weight: 600;
-  box-shadow: 0 0 0 2px rgba(14, 116, 144, 0.12);
-}
-
-html.dark .br-match-btn {
-  border-color: rgba(100, 116, 139, 0.4);
-  background: rgba(15, 23, 42, 0.6);
-  color: rgb(148 163 184);
-}
-
-html.dark .br-match-btn:hover {
-  border-color: rgba(34, 211, 238, 0.4);
-  color: rgb(103 232 249);
-}
-
-html.dark .br-match-btn--active {
-  border-color: rgba(34, 211, 238, 0.6);
-  background: rgba(34, 211, 238, 0.1);
-  color: rgb(103 232 249);
-  box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.12);
-}
-
-.br-match-chip {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  border: 1px solid rgba(139, 92, 246, 0.3);
-  background: rgba(139, 92, 246, 0.08);
-  color: rgb(139 92 246);
-  font-size: 8px;
-  font-weight: 700;
-  padding: 0px 4px;
-  white-space: nowrap;
-}
-
-html.dark .br-match-chip {
-  border-color: rgba(167, 139, 250, 0.35);
-  background: rgba(139, 92, 246, 0.15);
-  color: rgb(196 181 253);
-}
-
-@media (min-width: 640px) {
-  .gacha-trade-item-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1024px) {
-  .gacha-trade-item-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1440px) {
-  .gacha-trade-item-grid {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-  }
-}
-
-/* ── Buy-request detail dialog ── */
-
-.br-detail-body {
-  max-height: calc(100vh - 7rem);
-  max-height: calc(100dvh - 7rem);
-  overflow-y: auto;
-  padding: 1rem 1.25rem 1.25rem;
-}
-
-.br-detail-layout {
-  display: grid;
-  gap: 12px;
-  align-items: start;
-}
-
-.br-detail-card {
-  width: 100%;
-  max-width: 140px;
-  margin-inline: auto;
-}
-
-.br-detail-card > * {
-  width: 100%;
-}
-
-@media (min-width: 640px) {
-  .br-detail-layout {
-    gap: 16px;
-    grid-template-columns: 160px minmax(0, 1fr);
-  }
-
-  .br-detail-card {
-    max-width: none;
-    margin-inline: 0;
-  }
-}
-
-.br-detail-stats {
-  display: grid;
-  gap: 6px;
-  grid-template-columns: 1fr;
-  font-size: 12px;
-}
-
-@media (min-width: 640px) {
-  .br-detail-stats {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
-  }
-}
-
-.br-detail-actions {
-  position: sticky;
-  bottom: 0;
-  padding-top: 12px;
-  background: linear-gradient(to bottom, transparent, var(--g-surface-card) 6px);
-}
-
-.br-fulfill-grid {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  align-items: stretch;
-}
-
-.br-fulfill-grid > * {
-  display: flex;
-  height: 100%;
-  width: 100%;
-  min-width: 0;
-}
-
-.br-fulfill-grid > * > * {
-  width: 100%;
-  height: 100%;
-}
-
-@media (min-width: 640px) {
-  .br-fulfill-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
+<style>
+/* Trade panel styles - NOT scoped so child components in trade/ can inherit them */
+.trade-bazaar .trade-sub-tab { flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 4px; border-radius: 0.5rem; padding: 0.4rem 0.75rem; font-size: 12px; font-weight: 600; color: rgb(100 116 139); cursor: pointer; transition: all 0.15s ease; border: none; background: transparent; }
+.trade-bazaar .trade-sub-tab:hover { color: rgb(51 65 85); background: rgba(255, 255, 255, 0.6); }
+.trade-bazaar .trade-sub-tab--active { background: white; color: rgb(15 23 42); box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08); }
+html.dark .trade-bazaar .trade-sub-tab { color: rgb(148 163 184); }
+html.dark .trade-bazaar .trade-sub-tab:hover { color: rgb(226 232 240); background: rgba(255, 255, 255, 0.06); }
+html.dark .trade-bazaar .trade-sub-tab--active { background: rgba(30, 41, 59, 0.9); color: rgb(241 245 249); box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3); }
+.trade-bazaar .trade-sub-tab__badge { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px; font-size: 9px; font-weight: 700; background: rgba(14, 116, 144, 0.12); color: rgb(14 116 144); }
+html.dark .trade-bazaar .trade-sub-tab__badge { background: rgba(34, 211, 238, 0.15); color: rgb(103 232 249); }
+
+.trade-bazaar .trade-create-card { position: relative; display: block; width: 100%; min-width: 0; border-radius: 0.9rem; border: 1px solid rgba(148, 163, 184, 0.24); background: rgba(255, 255, 255, 0.72); padding: 0.22rem; text-align: left; cursor: pointer; transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease; }
+.trade-bazaar .trade-create-card:hover { border-color: rgba(14, 116, 144, 0.35); box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08); transform: translateY(-1px); }
+.trade-bazaar .trade-create-card--selected { border-color: rgba(14, 116, 144, 0.55); box-shadow: 0 0 0 4px rgba(14, 116, 144, 0.22), 0 0 0 1px rgba(14, 116, 144, 0.12), 0 8px 20px rgba(8, 145, 178, 0.16); }
+html.dark .trade-bazaar .trade-create-card { border-color: rgba(100, 116, 139, 0.45); background: rgba(15, 23, 42, 0.62); }
+html.dark .trade-bazaar .trade-create-card:hover { border-color: rgba(34, 211, 238, 0.45); box-shadow: 0 4px 14px rgba(0, 0, 0, 0.28); }
+html.dark .trade-bazaar .trade-create-card--selected { border-color: rgba(34, 211, 238, 0.62); box-shadow: 0 0 0 4px rgba(34, 211, 238, 0.22), 0 0 0 1px rgba(34, 211, 238, 0.2), 0 10px 22px rgba(6, 182, 212, 0.18); }
+
+.trade-bazaar .trade-remaining-chip { display: inline-flex; align-items: center; border-radius: 999px; border: 1px solid rgba(148, 163, 184, 0.35); background: rgba(248, 250, 252, 0.8); color: rgb(100 116 139); font-size: 9px; font-weight: 600; padding: 1px 5px; white-space: nowrap; }
+html.dark .trade-bazaar .trade-remaining-chip { border-color: rgba(100, 116, 139, 0.45); background: rgba(15, 23, 42, 0.7); color: rgb(148 163 184); }
+
+.trade-bazaar .trade-create-grid { align-items: stretch; }
+
+.trade-bazaar .picker-scroll-area { max-height: 22rem; overflow-y: auto; padding-right: 2px; }
+.trade-bazaar .picker-load-more-btn { display: block; width: 100%; margin-top: 8px; padding: 8px 0; border-radius: 0.6rem; border: 1px solid rgba(14, 116, 144, 0.25); background: rgba(236, 254, 255, 0.4); color: rgb(14 116 144); font-size: 11px; font-weight: 600; text-align: center; cursor: pointer; transition: all 0.15s ease; }
+.trade-bazaar .picker-load-more-btn:hover { border-color: rgba(14, 116, 144, 0.45); background: rgba(236, 254, 255, 0.7); box-shadow: 0 2px 8px rgba(8, 145, 178, 0.08); }
+html.dark .trade-bazaar .picker-load-more-btn { border-color: rgba(34, 211, 238, 0.25); background: rgba(8, 47, 73, 0.4); color: rgb(103 232 249); }
+html.dark .trade-bazaar .picker-load-more-btn:hover { border-color: rgba(34, 211, 238, 0.45); background: rgba(8, 47, 73, 0.6); }
+
+.trade-bazaar .picker-rarity-tag { display: inline-flex; align-items: center; border-radius: 999px; padding: 1px 7px; font-size: 10px; font-weight: 600; border: 1px solid; }
+.trade-bazaar .picker-rarity-tag--gold { border-color: rgba(245, 158, 11, 0.35); background: rgba(245, 158, 11, 0.08); color: rgb(180 83 9); }
+.trade-bazaar .picker-rarity-tag--purple { border-color: rgba(124, 58, 237, 0.3); background: rgba(124, 58, 237, 0.06); color: rgb(109 40 217); }
+.trade-bazaar .picker-rarity-tag--blue { border-color: rgba(37, 99, 235, 0.3); background: rgba(37, 99, 235, 0.06); color: rgb(29 78 216); }
+.trade-bazaar .picker-rarity-tag--green { border-color: rgba(5, 150, 105, 0.3); background: rgba(5, 150, 105, 0.06); color: rgb(4 120 87); }
+.trade-bazaar .picker-rarity-tag--white { border-color: rgba(148, 163, 184, 0.35); background: rgba(148, 163, 184, 0.06); color: rgb(100 116 139); }
+html.dark .trade-bazaar .picker-rarity-tag--gold { border-color: rgba(251, 191, 36, 0.4); background: rgba(245, 158, 11, 0.12); color: rgb(252 211 77); }
+html.dark .trade-bazaar .picker-rarity-tag--purple { border-color: rgba(167, 139, 250, 0.4); background: rgba(124, 58, 237, 0.12); color: rgb(196 181 253); }
+html.dark .trade-bazaar .picker-rarity-tag--blue { border-color: rgba(96, 165, 250, 0.4); background: rgba(37, 99, 235, 0.12); color: rgb(147 197 253); }
+html.dark .trade-bazaar .picker-rarity-tag--green { border-color: rgba(52, 211, 153, 0.4); background: rgba(5, 150, 105, 0.12); color: rgb(110 231 183); }
+html.dark .trade-bazaar .picker-rarity-tag--white { border-color: rgba(148, 163, 184, 0.4); background: rgba(148, 163, 184, 0.1); color: rgb(148 163 184); }
+
+.trade-bazaar .trade-detail-mini-card { width: 100%; max-width: 150px; margin-inline: auto; }
+.trade-bazaar .trade-detail-mini-card > * { width: 100%; }
+
+.trade-bazaar .trade-collapse-toggle { display: inline-flex; align-items: center; gap: 6px; padding: 6px 14px; border-radius: 0.75rem; border: 1px solid rgba(14, 116, 144, 0.3); background: rgba(236, 254, 255, 0.5); color: rgb(14 116 144); font-size: 12px; font-weight: 600; cursor: pointer; transition: all 0.15s ease; }
+.trade-bazaar .trade-collapse-toggle:hover { border-color: rgba(14, 116, 144, 0.5); background: rgba(236, 254, 255, 0.8); box-shadow: 0 2px 8px rgba(8, 145, 178, 0.1); }
+html.dark .trade-bazaar .trade-collapse-toggle { border-color: rgba(34, 211, 238, 0.3); background: rgba(8, 47, 73, 0.5); color: rgb(103 232 249); }
+html.dark .trade-bazaar .trade-collapse-toggle:hover { border-color: rgba(34, 211, 238, 0.5); background: rgba(8, 47, 73, 0.7); }
+.trade-bazaar .trade-collapse-toggle__icon { display: inline-block; font-size: 10px; transition: transform 0.2s ease; }
+.trade-bazaar .trade-collapse-toggle__icon--open { transform: rotate(180deg); }
+
+.trade-bazaar .trade-collapse-enter-active, .trade-bazaar .trade-collapse-leave-active { transition: all 0.25s ease; overflow: hidden; }
+.trade-bazaar .trade-collapse-enter-from, .trade-bazaar .trade-collapse-leave-to { opacity: 0; max-height: 0; margin-top: 0; }
+.trade-bazaar .trade-collapse-enter-to, .trade-bazaar .trade-collapse-leave-from { opacity: 1; max-height: 2000px; }
+
+.trade-bazaar .gacha-trade-item-grid { display: grid; gap: 8px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.trade-bazaar .trade-item-row { display: flex; align-items: stretch; gap: 8px; padding: 6px; border-radius: 0.85rem; border: 1px solid rgba(148, 163, 184, 0.22); background: rgba(255, 255, 255, 0.6); cursor: pointer; text-align: left; transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.12s ease; min-width: 0; content-visibility: auto; contain-intrinsic-size: auto 80px; }
+.trade-bazaar .trade-item-row:hover { border-color: rgba(14, 116, 144, 0.4); box-shadow: 0 4px 14px rgba(15, 23, 42, 0.08); transform: translateY(-1px); }
+html.dark .trade-bazaar .trade-item-row { border-color: rgba(100, 116, 139, 0.35); background: rgba(15, 23, 42, 0.5); }
+html.dark .trade-bazaar .trade-item-row:hover { border-color: rgba(34, 211, 238, 0.45); box-shadow: 0 4px 14px rgba(0, 0, 0, 0.3); }
+.trade-bazaar .trade-item-row__card { flex: 0 0 72px; min-width: 0; }
+.trade-bazaar .trade-item-row__card > * { width: 100%; height: 100%; }
+.trade-bazaar .trade-item-row__info { flex: 1; display: flex; flex-direction: column; justify-content: center; gap: 3px; min-width: 0; padding: 2px 0; }
+.trade-bazaar .trade-item-row__user { font-size: 11px; font-weight: 600; color: rgb(14 116 144); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+html.dark .trade-bazaar .trade-item-row__user { color: rgb(103 232 249); }
+.trade-bazaar .trade-item-row__price { font-size: 12px; font-weight: 700; color: rgb(180 83 9); font-variant-numeric: tabular-nums; }
+html.dark .trade-bazaar .trade-item-row__price { color: rgb(252 211 77); }
+.trade-bazaar .trade-item-row__qty { font-size: 10px; font-weight: 500; color: rgb(100 116 139); }
+html.dark .trade-bazaar .trade-item-row__qty { color: rgb(148 163 184); }
+.trade-bazaar .trade-item-row__time { font-size: 10px; font-weight: 600; color: rgb(71 85 105); font-variant-numeric: tabular-nums; }
+html.dark .trade-bazaar .trade-item-row__time { color: rgb(148 163 184); }
+
+.trade-bazaar .br-fulfillable-toggle { display: inline-flex; align-items: center; gap: 5px; padding: 5px 12px; border-radius: 0.6rem; border: 1px solid rgba(16, 185, 129, 0.3); background: rgba(16, 185, 129, 0.06); color: rgb(5 150 105); font-size: 11px; font-weight: 600; cursor: pointer; transition: all 0.15s ease; }
+.trade-bazaar .br-fulfillable-toggle:hover { border-color: rgba(16, 185, 129, 0.5); background: rgba(16, 185, 129, 0.12); }
+.trade-bazaar .br-fulfillable-toggle--active { border-color: rgba(16, 185, 129, 0.6); background: rgba(16, 185, 129, 0.15); box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.12); }
+html.dark .trade-bazaar .br-fulfillable-toggle { border-color: rgba(52, 211, 153, 0.3); background: rgba(16, 185, 129, 0.08); color: rgb(110 231 183); }
+html.dark .trade-bazaar .br-fulfillable-toggle:hover { border-color: rgba(52, 211, 153, 0.5); background: rgba(16, 185, 129, 0.15); }
+html.dark .trade-bazaar .br-fulfillable-toggle--active { border-color: rgba(52, 211, 153, 0.6); background: rgba(16, 185, 129, 0.2); box-shadow: 0 0 0 2px rgba(52, 211, 153, 0.12); }
+.trade-bazaar .br-fulfillable-toggle__icon { width: 12px; height: 12px; }
+
+.trade-bazaar .br-match-btn { display: inline-flex; align-items: center; padding: 4px 10px; border-radius: 0.5rem; border: 1px solid rgba(148, 163, 184, 0.3); background: rgba(255, 255, 255, 0.7); color: rgb(100 116 139); font-size: 11px; font-weight: 500; cursor: pointer; transition: all 0.15s ease; }
+.trade-bazaar .br-match-btn:hover { border-color: rgba(14, 116, 144, 0.4); color: rgb(14 116 144); }
+.trade-bazaar .br-match-btn--active { border-color: rgba(14, 116, 144, 0.6); background: rgba(14, 116, 144, 0.08); color: rgb(14 116 144); font-weight: 600; box-shadow: 0 0 0 2px rgba(14, 116, 144, 0.12); }
+html.dark .trade-bazaar .br-match-btn { border-color: rgba(100, 116, 139, 0.4); background: rgba(15, 23, 42, 0.6); color: rgb(148 163 184); }
+html.dark .trade-bazaar .br-match-btn:hover { border-color: rgba(34, 211, 238, 0.4); color: rgb(103 232 249); }
+html.dark .trade-bazaar .br-match-btn--active { border-color: rgba(34, 211, 238, 0.6); background: rgba(34, 211, 238, 0.1); color: rgb(103 232 249); box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.12); }
+
+.trade-bazaar .br-match-chip { display: inline-flex; align-items: center; border-radius: 999px; border: 1px solid rgba(139, 92, 246, 0.3); background: rgba(139, 92, 246, 0.08); color: rgb(139 92 246); font-size: 8px; font-weight: 700; padding: 0px 4px; white-space: nowrap; }
+html.dark .trade-bazaar .br-match-chip { border-color: rgba(167, 139, 250, 0.35); background: rgba(139, 92, 246, 0.15); color: rgb(196 181 253); }
+
+@media (min-width: 640px) { .trade-bazaar .gacha-trade-item-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+@media (min-width: 1024px) { .trade-bazaar .gacha-trade-item-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); } }
+@media (min-width: 1440px) { .trade-bazaar .gacha-trade-item-grid { grid-template-columns: repeat(5, minmax(0, 1fr)); } }
+
+.trade-bazaar .br-detail-body { max-height: calc(100vh - 7rem); max-height: calc(100dvh - 7rem); overflow-y: auto; padding: 1rem 1.25rem 1.25rem; }
+.trade-bazaar .br-detail-layout { display: grid; gap: 12px; align-items: start; }
+.trade-bazaar .br-detail-card { width: 100%; max-width: 140px; margin-inline: auto; }
+.trade-bazaar .br-detail-card > * { width: 100%; }
+@media (min-width: 640px) { .trade-bazaar .br-detail-layout { gap: 16px; grid-template-columns: 160px minmax(0, 1fr); } .trade-bazaar .br-detail-card { max-width: none; margin-inline: 0; } }
+.trade-bazaar .br-detail-stats { display: grid; gap: 6px; grid-template-columns: 1fr; font-size: 12px; }
+@media (min-width: 640px) { .trade-bazaar .br-detail-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; } }
+.trade-bazaar .br-detail-actions { position: sticky; bottom: 0; padding-top: 12px; background: linear-gradient(to bottom, transparent, var(--g-surface-card) 6px); }
+.trade-bazaar .br-fulfill-grid { display: grid; gap: 8px; grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: stretch; }
+.trade-bazaar .br-fulfill-grid > * { display: flex; height: 100%; width: 100%; min-width: 0; }
+.trade-bazaar .br-fulfill-grid > * > * { width: 100%; height: 100%; }
+@media (min-width: 640px) { .trade-bazaar .br-fulfill-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
 </style>

--- a/frontend/components/gacha/trade/TradeBuyForm.vue
+++ b/frontend/components/gacha/trade/TradeBuyForm.vue
@@ -35,7 +35,7 @@ type BuyRequestDraft =
   | { targetCardId: string; matchLevel: 'IMAGE_VARIANT' }
   | { targetCardId: string; matchLevel: 'COATING'; requiredCoating: AffixVisualStyle }
 
-defineProps<{
+const props = defineProps<{
   // Form state
   showBuyRequestForm: boolean
   brSelectedPage: PageCatalogEntry | null
@@ -114,9 +114,9 @@ function formatAccountDisplayName(
 function buyRequestRemainingLabel(br: BuyRequest, now: number | null) {
   if (br.status !== 'OPEN') return buyRequestStatusLabelMap[br.status]
   if (!br.expiresAt) return '无期限'
-  if (!now) return '无'
+  if (!now) return formatDateCompact(br.expiresAt) || '无'
   const expiresTs = new Date(br.expiresAt).getTime()
-  if (!Number.isFinite(expiresTs)) return '无'
+  if (!Number.isFinite(expiresTs)) return formatDateCompact(br.expiresAt) || '无'
   const diffMs = expiresTs - now
   if (diffMs <= 0) return '已到期'
   const diffMin = Math.max(1, Math.ceil(diffMs / 60_000))

--- a/frontend/components/gacha/trade/TradeBuyForm.vue
+++ b/frontend/components/gacha/trade/TradeBuyForm.vue
@@ -1,0 +1,454 @@
+<script setup lang="ts">
+import type { AffixVisualStyle, Rarity, BuyRequest, PageCatalogEntry, BuyRequestMatchLevel } from '~/types/gacha'
+import { formatTokens } from '~/utils/gachaFormatters'
+import { rarityLabel } from '~/utils/gachaRarity'
+import { buyRequestStatusLabelMap, buyRequestStatusChipClassMap, buyRequestMatchLevelLabelMap, buyRequestMatchLevelShortMap, coatingStyleLabelMap } from '~/utils/gachaConstants'
+import type { BuyRequestSortMode } from '~/utils/gachaConstants'
+import GachaCardMini from '~/components/gacha/GachaCardMini.vue'
+import GachaRarityFilter from '~/components/gacha/GachaRarityFilter.vue'
+import GachaPagination from '~/components/gacha/GachaPagination.vue'
+import { UiButton } from '~/components/ui/button'
+import { UiInput } from '~/components/ui/input'
+import { UiSelectRoot, UiSelectTrigger, UiSelectContent, UiSelectItem } from '~/components/ui/select'
+
+interface TradeCardOption {
+  stackKey: string
+  cardId: string
+  title: string
+  rarity: Rarity
+  imageUrl: string | null
+  isRetired?: boolean
+  wikidotId?: number | null
+  pageId?: number | null
+  tags?: string[]
+  authors?: Array<{ name: string; wikidotId: number | null }> | null
+  availableCount: number
+  affixSignature?: string
+  affixStyles?: AffixVisualStyle[]
+  affixStyleCounts?: Partial<Record<AffixVisualStyle, number>>
+  affixVisualStyle?: AffixVisualStyle
+  affixLabel?: string
+}
+
+type BuyRequestDraft =
+  | { targetCardId: string; matchLevel: 'PAGE' }
+  | { targetCardId: string; matchLevel: 'IMAGE_VARIANT' }
+  | { targetCardId: string; matchLevel: 'COATING'; requiredCoating: AffixVisualStyle }
+
+defineProps<{
+  // Form state
+  showBuyRequestForm: boolean
+  brSelectedPage: PageCatalogEntry | null
+  brSelectedVariantIds: string[]
+  brSelectedCoatings: AffixVisualStyle[]
+  brTokenOffer: number
+  brExpiresHours: number
+  brOfferedCards: Array<{ stackKey: string; cardId: string; affixSignature?: string; quantity: number }>
+  brTargetSearch: string
+  brOfferedSearch: string
+  brFilteredCatalog: PageCatalogEntry[]
+  brFilteredTradeCardOptions: TradeCardOption[]
+  brDerivedPayloads: BuyRequestDraft[]
+  brDerivedMatchLevelLabel: string
+  brCanSubmit: boolean
+  buyRequestSubmitting: boolean
+  inventoryLoading: boolean
+  cardOptions: TradeCardOption[]
+  coatingOptions: AffixVisualStyle[]
+  // Public listings
+  publicBuyRequests: BuyRequest[]
+  visibleBuyRequests: BuyRequest[]
+  hasMoreBrLocal: boolean
+  buyRequestPublicTotal: number
+  buyRequestPublicPage: number
+  buyRequestLoading: boolean
+  buyRequestPublicLoadingMore: boolean
+  brSearchInput: string
+  brSortMode: BuyRequestSortMode
+  brRarityFilter: Rarity | 'ALL'
+  tradeRarityFilterOptions: Array<Rarity | 'ALL'>
+  brShowFulfillableOnly: boolean
+  userId: string | null
+  clientNow: number | null
+  brPageSize: number
+}>()
+
+const emit = defineEmits<{
+  'update:showBuyRequestForm': [val: boolean]
+  'update:brTargetSearch': [val: string]
+  'update:brOfferedSearch': [val: string]
+  'update:brTokenOffer': [val: number]
+  'update:brExpiresHours': [val: number]
+  'update:brSearchInput': [val: string]
+  'update:brSortMode': [val: BuyRequestSortMode]
+  'update:brRarityFilter': [val: Rarity | 'ALL']
+  'br-select-page': [entry: PageCatalogEntry]
+  'br-clear-selection': []
+  'br-toggle-variant': [variantId: string]
+  'br-select-all-variants': []
+  'br-clear-variants': []
+  'br-toggle-coating': [style: AffixVisualStyle]
+  'br-toggle-offered-card': [item: TradeCardOption]
+  'br-remove-offered-card': [stackKey: string]
+  'br-set-offered-quantity': [stackKey: string, qty: number]
+  'create-buy-request': []
+  'open-buy-request-detail': [br: BuyRequest]
+  'toggle-fulfillable-only': []
+  'br-reset-filters': []
+  'br-load-more-local': []
+  'buy-request-page-change': [page: number]
+  'refresh-buy-requests': []
+}>()
+
+function formatAccountDisplayName(
+  account: { id: string; displayName: string | null; linkedWikidotId: number | null } | null | undefined,
+  fallbackId?: string | null
+) {
+  if (account?.displayName) return account.displayName
+  if (account?.linkedWikidotId) return `WID:${account.linkedWikidotId}`
+  const rawId = String(fallbackId || account?.id || '').trim()
+  if (!rawId) return '未知用户'
+  return `用户-${rawId.slice(0, 8)}`
+}
+
+function buyRequestRemainingLabel(br: BuyRequest, now: number | null) {
+  if (br.status !== 'OPEN') return buyRequestStatusLabelMap[br.status]
+  if (!br.expiresAt) return '无期限'
+  if (!now) return '无'
+  const expiresTs = new Date(br.expiresAt).getTime()
+  if (!Number.isFinite(expiresTs)) return '无'
+  const diffMs = expiresTs - now
+  if (diffMs <= 0) return '已到期'
+  const diffMin = Math.max(1, Math.ceil(diffMs / 60_000))
+  if (diffMin < 60) return `剩${diffMin}m`
+  const diffH = Math.ceil(diffMin / 60)
+  if (diffH < 48) return `剩${diffH}h`
+  const diffD = Math.ceil(diffH / 24)
+  return `剩${diffD}d`
+}
+
+function brFindOfferedOption(stackKey: string) {
+  return props.cardOptions.find((item) => item.stackKey === stackKey) ?? null
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- 折叠式发布求购表单 -->
+    <div>
+      <button
+        type="button"
+        class="trade-collapse-toggle"
+        @click="emit('update:showBuyRequestForm', !showBuyRequestForm)"
+      >
+        <span>{{ showBuyRequestForm ? '收起求购' : '发布求购' }}</span>
+        <span class="trade-collapse-toggle__icon" :class="{ 'trade-collapse-toggle__icon--open': showBuyRequestForm }">&#9662;</span>
+      </button>
+
+      <Transition name="trade-collapse">
+        <article v-if="showBuyRequestForm" class="mt-2 rounded-lg border border-cyan-200/60 bg-cyan-50/40 p-4 dark:border-cyan-800/50 dark:bg-cyan-950/30">
+          <p class="mt-1 text-[10px] text-neutral-500 dark:text-neutral-400">指定想要的卡片，可使用 Token 或自己的卡牌出价。</p>
+
+          <div class="mt-3 space-y-3">
+            <!-- Step 1: 搜索页面 -->
+            <div class="space-y-1.5">
+              <div class="flex items-center justify-between">
+                <span class="text-[11px] text-neutral-500 dark:text-neutral-400">想要的页面</span>
+                <button
+                  v-if="brSelectedPage"
+                  type="button"
+                  class="text-[10px] text-cyan-600 hover:text-cyan-800 dark:text-cyan-400 dark:hover:text-cyan-200"
+                  @click="emit('br-clear-selection')"
+                >重新选择</button>
+              </div>
+              <template v-if="!brSelectedPage">
+                <UiInput
+                  :model-value="brTargetSearch"
+                  type="search"
+                  placeholder="搜索页面名 / 标签 / 作者"
+                  class="w-full"
+                  @update:model-value="emit('update:brTargetSearch', String($event))"
+                />
+                <div class="max-h-[14rem] overflow-y-auto pr-1">
+                  <p v-if="!brFilteredCatalog.length" class="gacha-empty py-3 text-[11px]">未找到匹配的页面。</p>
+                  <div v-else class="gacha-card-grid--mini">
+                    <button
+                      v-for="entry in brFilteredCatalog.slice(0, 30)"
+                      :key="`br-page-${entry.pageId ?? entry.variants[0]?.id}`"
+                      type="button"
+                      class="trade-create-card"
+                      @click="emit('br-select-page', entry)"
+                    >
+                      <GachaCardMini
+                        :title="entry.title"
+                        :rarity="entry.rarity"
+                        :image-url="entry.variants[0]?.imageUrl || undefined"
+                        :retired="entry.isRetired"
+                        :hide-footer="true"
+                      />
+                    </button>
+                  </div>
+                </div>
+              </template>
+              <p v-else class="text-[11px] text-cyan-700 dark:text-cyan-200">
+                已选: {{ brSelectedPage.title }} · {{ rarityLabel(brSelectedPage.rarity) }}
+                <span v-if="brSelectedPage.variants.length > 1" class="text-neutral-400">（{{ brSelectedPage.variants.length }} 个画面）</span>
+              </p>
+            </div>
+
+            <!-- Step 2: 画面选择 -->
+            <div v-if="brSelectedPage && brSelectedPage.variants.length > 1" class="space-y-1.5">
+              <div class="flex items-center justify-between">
+                <span class="text-[11px] text-neutral-500 dark:text-neutral-400">选择画面（可多选）</span>
+                <span class="flex gap-2">
+                  <button
+                    v-if="brSelectedVariantIds.length > 0"
+                    type="button"
+                    class="text-[10px] text-cyan-600 hover:text-cyan-800 dark:text-cyan-400 dark:hover:text-cyan-200"
+                    @click="emit('br-clear-variants')"
+                  >任意画面</button>
+                  <button
+                    v-if="brSelectedVariantIds.length < brSelectedPage.variants.length"
+                    type="button"
+                    class="text-[10px] text-cyan-600 hover:text-cyan-800 dark:text-cyan-400 dark:hover:text-cyan-200"
+                    @click="emit('br-select-all-variants')"
+                  >全选</button>
+                </span>
+              </div>
+              <div class="gacha-card-grid--mini">
+                <button
+                  v-for="v in brSelectedPage.variants"
+                  :key="`br-variant-${v.id}`"
+                  type="button"
+                  class="trade-create-card"
+                  :class="{ 'trade-create-card--selected': brSelectedVariantIds.includes(v.id) }"
+                  @click="emit('br-toggle-variant', v.id)"
+                >
+                  <GachaCardMini
+                    :title="brSelectedPage.title"
+                    :rarity="brSelectedPage.rarity"
+                    :image-url="v.imageUrl || undefined"
+                    :retired="v.isRetired"
+                    :hide-footer="true"
+                  />
+                </button>
+              </div>
+              <p class="text-[10px] text-neutral-400 dark:text-neutral-500">
+                {{ brSelectedVariantIds.length === 0 ? '未选择 = 接受任意画面（PAGE 级匹配）' : `已选 ${brSelectedVariantIds.length} 个画面` }}
+              </p>
+            </div>
+
+            <!-- Step 3: 镀层选择 -->
+            <div v-if="brSelectedPage && brSelectedVariantIds.length > 0" class="space-y-1.5">
+              <span class="text-[11px] text-neutral-500 dark:text-neutral-400">镀层要求（可多选，不选 = 任意镀层）</span>
+              <div class="flex flex-wrap gap-1.5">
+                <button
+                  v-for="style in coatingOptions"
+                  :key="`br-coat-${style}`"
+                  type="button"
+                  class="br-match-btn"
+                  :class="{ 'br-match-btn--active': brSelectedCoatings.includes(style) }"
+                  @click="emit('br-toggle-coating', style)"
+                >
+                  {{ coatingStyleLabelMap[style] }}
+                </button>
+              </div>
+              <p v-if="brSelectedCoatings.length > 0" class="text-[10px] text-neutral-400 dark:text-neutral-500">
+                已选 {{ brSelectedCoatings.length }} 种镀层
+              </p>
+            </div>
+
+            <!-- 匹配级别提示 -->
+            <p v-if="brSelectedPage" class="rounded-lg bg-neutral-100/80 px-2.5 py-1.5 text-[10px] text-neutral-500 dark:bg-neutral-800/60 dark:text-neutral-400">
+              <template v-if="brDerivedPayloads.length === 1">
+                匹配级别: <span class="font-semibold text-cyan-700 dark:text-cyan-300">{{ buyRequestMatchLevelLabelMap[brDerivedPayloads[0]!.matchLevel] }}</span>
+                — {{ brDerivedMatchLevelLabel }}
+              </template>
+              <template v-else>
+                将创建 <span class="font-semibold text-cyan-700 dark:text-cyan-300">{{ brDerivedPayloads.length }}</span> 个求购（每个出价相同）
+                — {{ brDerivedMatchLevelLabel }}
+              </template>
+            </p>
+
+            <!-- Token 出价 -->
+            <label class="block space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
+              <span>Token 出价（可为 0）</span>
+              <UiInput :model-value="brTokenOffer" type="number" min="0" max="500000" step="1" @update:model-value="emit('update:brTokenOffer', Number($event))" />
+            </label>
+
+            <!-- 提供卡牌 -->
+            <div class="space-y-1.5">
+              <span class="text-[11px] text-neutral-500 dark:text-neutral-400">
+                提供的卡牌（可选，{{ brOfferedCards.length }} 张已选）
+              </span>
+              <UiInput
+                :model-value="brOfferedSearch"
+                type="search"
+                placeholder="搜索可提供的卡牌（标题 / 标签 / 作者）"
+                class="w-full"
+                @update:model-value="emit('update:brOfferedSearch', String($event))"
+              />
+              <div v-if="inventoryLoading && !cardOptions.length" class="text-[11px] text-neutral-500 dark:text-neutral-400">
+                正在加载库存...
+              </div>
+              <div v-else class="max-h-[12rem] overflow-y-auto pr-1">
+                <div v-if="brFilteredTradeCardOptions.length" class="gacha-card-grid--mini">
+                  <button
+                    v-for="item in brFilteredTradeCardOptions.slice(0, 30)"
+                    :key="`br-offer-${item.stackKey}`"
+                    type="button"
+                    class="trade-create-card"
+                    :class="{ 'trade-create-card--selected': brOfferedCards.some((c) => c.stackKey === item.stackKey) }"
+                    @click="emit('br-toggle-offered-card', item)"
+                  >
+                    <GachaCardMini
+                      :title="item.title"
+                      :rarity="item.rarity"
+                      :image-url="item.imageUrl || undefined"
+                      :retired="item.isRetired"
+                      :affix-visual-style="item.affixVisualStyle"
+                      :affix-label="item.affixLabel"
+                    >
+                      <template #meta>
+                        <span class="trade-remaining-chip">可选 {{ item.availableCount }}</span>
+                      </template>
+                    </GachaCardMini>
+                  </button>
+                </div>
+              </div>
+              <!-- 已选卡牌及数量设置 -->
+              <div v-if="brOfferedCards.length > 0" class="flex flex-wrap gap-2 pt-1">
+                <div
+                  v-for="oc in brOfferedCards"
+                  :key="`br-oc-${oc.stackKey}`"
+                  class="flex items-center gap-1 rounded-lg border border-cyan-200/60 bg-white/80 px-2 py-1 text-[10px] dark:border-cyan-700/50 dark:bg-neutral-900/60"
+                >
+                  <span class="max-w-[80px] truncate text-neutral-700 dark:text-neutral-200">
+                    {{ brFindOfferedOption(oc.stackKey)?.title ?? oc.cardId.slice(0, 8) }} · {{ oc.affixSignature || 'NONE' }}
+                  </span>
+                  <input
+                    type="number"
+                    :value="oc.quantity"
+                    min="1"
+                    :max="brFindOfferedOption(oc.stackKey)?.availableCount ?? 99"
+                    class="w-10 rounded border border-neutral-200 bg-transparent px-1 py-0 text-center text-[10px] dark:border-neutral-700"
+                    @input="emit('br-set-offered-quantity', oc.stackKey, Number(($event.target as HTMLInputElement).value || 1))"
+                  />
+                  <button type="button" class="text-neutral-400 hover:text-red-500" @click="emit('br-remove-offered-card', oc.stackKey)">x</button>
+                </div>
+              </div>
+            </div>
+
+            <!-- 有效期 -->
+            <label class="block space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
+              <span>有效期（小时）</span>
+              <UiInput :model-value="brExpiresHours" type="number" min="1" :max="24 * 30" step="1" @update:model-value="emit('update:brExpiresHours', Number($event))" />
+            </label>
+
+            <div class="flex flex-wrap gap-2">
+              <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="emit('update:brExpiresHours', 24)">24h</UiButton>
+              <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="emit('update:brExpiresHours', 72)">72h</UiButton>
+              <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="emit('update:brExpiresHours', 168)">168h</UiButton>
+            </div>
+
+            <UiButton class="w-full py-2.5 text-sm" :disabled="buyRequestSubmitting || !brCanSubmit" @click="emit('create-buy-request')">
+              {{ buyRequestSubmitting ? '提交中...' : '发布求购' }}
+            </UiButton>
+          </div>
+        </article>
+      </Transition>
+    </div>
+
+    <!-- 公共求购浏览 -->
+    <article class="rounded-lg border border-neutral-200/75 bg-neutral-50/75 p-4 dark:border-neutral-800/70 dark:bg-neutral-900/55">
+      <header class="flex flex-wrap items-center justify-between gap-2">
+        <h4 class="text-xs font-semibold text-neutral-700 dark:text-neutral-200">
+          公共求购
+        </h4>
+        <UiButton variant="outline" size="sm" :disabled="buyRequestLoading" @click="emit('refresh-buy-requests')">
+          {{ buyRequestLoading ? '刷新中...' : '刷新' }}
+        </UiButton>
+      </header>
+
+      <!-- 可接单筛选开关 -->
+      <div v-if="userId" class="mt-2">
+        <button
+          type="button"
+          class="br-fulfillable-toggle"
+          :class="{ 'br-fulfillable-toggle--active': brShowFulfillableOnly }"
+          @click="emit('toggle-fulfillable-only')"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="br-fulfillable-toggle__icon"><path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" /></svg>
+          仅显示我可接的求购
+        </button>
+      </div>
+
+      <div class="mt-2 grid gap-2 md:grid-cols-[minmax(0,1fr),minmax(160px,200px),auto]">
+        <UiInput :model-value="brSearchInput" type="search" placeholder="搜索卡片名 / 作者 / 买家" class="w-full" @update:model-value="emit('update:brSearchInput', String($event))" />
+        <UiSelectRoot :model-value="brSortMode" @update:model-value="emit('update:brSortMode', $event as any)">
+          <UiSelectTrigger placeholder="排序方式" />
+          <UiSelectContent>
+            <UiSelectItem value="LATEST">按发布时间</UiSelectItem>
+            <UiSelectItem value="RARITY_DESC">按稀有度</UiSelectItem>
+            <UiSelectItem value="TOKEN_DESC">按出价降序</UiSelectItem>
+            <UiSelectItem value="TOKEN_ASC">按出价升序</UiSelectItem>
+            <UiSelectItem value="EXPIRY_ASC">按到期时间</UiSelectItem>
+          </UiSelectContent>
+        </UiSelectRoot>
+        <UiButton variant="outline" class="h-9" @click="emit('br-reset-filters')">重置</UiButton>
+      </div>
+      <div class="mt-2">
+        <GachaRarityFilter :model-value="brRarityFilter" :options="tradeRarityFilterOptions" all-label="全部品质" @update:model-value="emit('update:brRarityFilter', $event as any)" />
+      </div>
+
+      <p class="mt-2 text-[11px] text-neutral-500 dark:text-neutral-400">
+        显示 {{ visibleBuyRequests.length }}{{ brShowFulfillableOnly ? ` (可接)` : '' }} / {{ buyRequestPublicTotal }} 条
+      </p>
+
+      <p v-if="!publicBuyRequests.length" class="gacha-empty mt-3">
+        {{ brShowFulfillableOnly ? '当前没有你可以接的求购。' : '当前没有公开求购。' }}
+      </p>
+      <div v-else class="mt-3 gacha-trade-item-grid">
+        <button
+          v-for="br in visibleBuyRequests"
+          :key="`public-br-${br.id}`"
+          type="button"
+          class="trade-item-row"
+          @click="emit('open-buy-request-detail', br)"
+        >
+          <div class="trade-item-row__card">
+            <GachaCardMini
+              :title="br.targetCard.title"
+              :rarity="br.targetCard.rarity"
+              :image-url="br.targetCard.imageUrl || undefined"
+              :retired="br.targetCard.isRetired"
+              :hide-footer="true"
+            />
+          </div>
+          <div class="trade-item-row__info">
+            <span class="trade-item-row__user">{{ formatAccountDisplayName(br.buyer, br.buyerId) }}</span>
+            <span class="trade-item-row__price">{{ br.tokenOffer > 0 ? `${formatTokens(br.tokenOffer)}T` : '' }}{{ br.tokenOffer > 0 && br.offeredCards.length > 0 ? ' + ' : '' }}{{ br.offeredCards.length > 0 ? `${br.offeredCards.length}卡` : '' }}</span>
+            <span class="flex items-center gap-1">
+              <span class="trade-item-row__time">{{ buyRequestRemainingLabel(br, clientNow) }}</span>
+              <span class="br-match-chip">{{ buyRequestMatchLevelShortMap[br.matchLevel] }}</span>
+            </span>
+          </div>
+        </button>
+      </div>
+
+      <div v-if="hasMoreBrLocal" class="mt-3 flex items-center justify-center">
+        <UiButton variant="outline" size="sm" @click="emit('br-load-more-local')">
+          显示更多已加载求购（剩余 {{ publicBuyRequests.length - visibleBuyRequests.length }} 条）
+        </UiButton>
+      </div>
+
+      <GachaPagination
+        :current="buyRequestPublicPage"
+        :total="buyRequestPublicTotal"
+        :page-size="brPageSize"
+        :loading="buyRequestPublicLoadingMore || buyRequestLoading"
+        @change="(p: number) => emit('buy-request-page-change', p)"
+      />
+    </article>
+  </div>
+</template>

--- a/frontend/components/gacha/trade/TradeBuyForm.vue
+++ b/frontend/components/gacha/trade/TradeBuyForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { AffixVisualStyle, Rarity, BuyRequest, PageCatalogEntry, BuyRequestMatchLevel } from '~/types/gacha'
-import { formatTokens } from '~/utils/gachaFormatters'
+import { formatTokens, formatDateCompact } from '~/utils/gachaFormatters'
 import { rarityLabel } from '~/utils/gachaRarity'
 import { buyRequestStatusLabelMap, buyRequestStatusChipClassMap, buyRequestMatchLevelLabelMap, buyRequestMatchLevelShortMap, coatingStyleLabelMap } from '~/utils/gachaConstants'
 import type { BuyRequestSortMode } from '~/utils/gachaConstants'

--- a/frontend/components/gacha/trade/TradeDetail.vue
+++ b/frontend/components/gacha/trade/TradeDetail.vue
@@ -1,0 +1,484 @@
+<script setup lang="ts">
+import type { AffixVisualStyle, Rarity, TradeListing, BuyRequest } from '~/types/gacha'
+import { formatTokens, formatDateCompact } from '~/utils/gachaFormatters'
+import { rarityLabel } from '~/utils/gachaRarity'
+import { resolveAffixParts } from '~/utils/gachaAffix'
+import { tradeStatusLabelMap, tradeStatusChipClassMap, buyRequestStatusLabelMap, buyRequestStatusChipClassMap, buyRequestMatchLevelLabelMap, buyRequestMatchLevelShortMap, coatingStyleLabelMap } from '~/utils/gachaConstants'
+import GachaAffixChip from '~/components/gacha/GachaAffixChip.vue'
+import GachaCard from '~/components/gacha/GachaCard.vue'
+import GachaCardMini from '~/components/gacha/GachaCardMini.vue'
+import { UiButton } from '~/components/ui/button'
+import {
+  UiDialogRoot,
+  UiDialogPortal,
+  UiDialogOverlay,
+  UiDialogContent,
+  UiDialogClose
+} from '~/components/ui/dialog'
+
+interface TradeCardOption {
+  stackKey: string
+  cardId: string
+  title: string
+  rarity: Rarity
+  imageUrl: string | null
+  isRetired?: boolean
+  availableCount: number
+  affixSignature?: string
+  affixVisualStyle?: AffixVisualStyle
+  affixLabel?: string
+}
+
+defineProps<{
+  // My listing dialog
+  selectedMyListing: TradeListing | null
+  cancellingId: string | null
+  // Public listing dialog
+  selectedPublicListing: TradeListing | null
+  buyingId: string | null
+  userId: string | null
+  // Buy request dialog
+  selectedBuyRequest: BuyRequest | null
+  buyRequestFulfillCandidates: TradeCardOption[]
+  selectedFulfillStackKey: string
+  buyRequestFulfillingId: string | null
+  buyRequestCancelId: string | null
+  inventoryLoading: boolean
+  cardOptionsLength: number
+}>()
+
+const emit = defineEmits<{
+  'close-my-listing': []
+  'close-public-listing': []
+  'close-buy-request': []
+  'cancel-listing': [id: string]
+  'buy-listing': [id: string]
+  'update:selectedFulfillStackKey': [val: string]
+  'fulfill-buy-request': []
+  'cancel-buy-request': [id: string]
+}>()
+
+function tradeStatusLabel(status: TradeListing['status']) {
+  return tradeStatusLabelMap[status] || status
+}
+
+function listingTotalPrice(listing: TradeListing) {
+  return Math.max(0, Number(listing.remaining || 0)) * Math.max(0, Number(listing.unitPrice || 0))
+}
+
+function formatAccountDisplayName(
+  account: { id: string; displayName: string | null; linkedWikidotId: number | null } | null | undefined,
+  fallbackId?: string | null
+) {
+  if (account?.displayName) return account.displayName
+  if (account?.linkedWikidotId) return `WID:${account.linkedWikidotId}`
+  const rawId = String(fallbackId || account?.id || '').trim()
+  if (!rawId) return '未知用户'
+  return `用户-${rawId.slice(0, 8)}`
+}
+</script>
+
+<template>
+  <!-- 我的挂牌详情弹窗 -->
+  <UiDialogRoot :open="!!selectedMyListing" @update:open="(v: boolean) => { if (!v) emit('close-my-listing') }">
+    <UiDialogPortal>
+      <UiDialogOverlay />
+      <UiDialogContent class="max-w-lg p-0">
+        <template v-if="selectedMyListing">
+          <header class="flex items-start justify-between gap-3 border-b border-neutral-200/60 px-5 py-4 dark:border-neutral-800/70">
+            <div class="min-w-0">
+              <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-cyan-700 dark:text-cyan-200">My Listing</p>
+              <h3 class="mt-1 truncate text-lg font-semibold text-neutral-900 dark:text-neutral-50">{{ selectedMyListing.card.title }}</h3>
+              <p class="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">
+                {{ rarityLabel(selectedMyListing.card.rarity) }} · {{ tradeStatusLabel(selectedMyListing.status) }}
+              </p>
+            </div>
+            <UiDialogClose as-child>
+              <UiButton variant="ghost" size="sm" class="h-9 w-9 rounded-full p-0" aria-label="关闭">X</UiButton>
+            </UiDialogClose>
+          </header>
+
+          <div class="max-h-[calc(100vh-7rem)] max-h-[calc(100dvh-7rem)] overflow-y-auto px-5 pb-5 pt-4">
+            <div class="grid gap-4 sm:grid-cols-[150px_minmax(0,1fr)] sm:items-start">
+              <div class="trade-detail-mini-card">
+                <GachaCard
+                  :title="selectedMyListing.card.title"
+                  :rarity="selectedMyListing.card.rarity"
+                  :tags="selectedMyListing.card.tags ?? []"
+                  :wikidot-id="selectedMyListing.card.wikidotId"
+                  :authors="selectedMyListing.card.authors"
+                  :image-url="selectedMyListing.card.imageUrl || undefined"
+                  :retired="selectedMyListing.card.isRetired"
+                  variant="mini"
+                  :hide-footer="true"
+                  :affix-visual-style="selectedMyListing.card.affixVisualStyle || selectedMyListing.affixBreakdown?.[0]?.affixVisualStyle"
+                  :affix-signature="selectedMyListing.card.affixSignature || selectedMyListing.affixBreakdown?.[0]?.affixSignature"
+                  :affix-styles="selectedMyListing.card.affixStyles || selectedMyListing.affixBreakdown?.[0]?.affixStyles"
+                  :affix-style-counts="selectedMyListing.card.affixStyleCounts || selectedMyListing.affixBreakdown?.[0]?.affixStyleCounts"
+                  :affix-label="selectedMyListing.card.affixLabel || selectedMyListing.affixBreakdown?.[0]?.affixLabel"
+                />
+              </div>
+
+              <div class="space-y-3">
+                <dl class="grid grid-cols-2 gap-2 text-xs">
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">单价</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatTokens(selectedMyListing.unitPrice) }} Token</dd>
+                  </div>
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">总价</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatTokens(listingTotalPrice(selectedMyListing)) }} Token</dd>
+                  </div>
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">剩余数量</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ selectedMyListing.remaining }} / {{ selectedMyListing.quantity }}</dd>
+                  </div>
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">到期时间</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatDateCompact(selectedMyListing.expiresAt) || '无' }}</dd>
+                  </div>
+                  <div
+                    v-if="selectedMyListing.status === 'SOLD'"
+                    class="rounded-xl border border-emerald-200/80 bg-emerald-50/80 px-2.5 py-2 dark:border-emerald-700/70 dark:bg-emerald-900/20"
+                  >
+                    <dt class="text-emerald-700 dark:text-emerald-300">成交买家</dt>
+                    <dd class="mt-0.5 font-semibold text-emerald-900 dark:text-emerald-100">
+                      {{ formatAccountDisplayName(selectedMyListing.buyer, selectedMyListing.buyerId) }}
+                    </dd>
+                  </div>
+                  <div
+                    v-if="selectedMyListing.status === 'SOLD'"
+                    class="rounded-xl border border-emerald-200/80 bg-emerald-50/80 px-2.5 py-2 dark:border-emerald-700/70 dark:bg-emerald-900/20"
+                  >
+                    <dt class="text-emerald-700 dark:text-emerald-300">成交时间</dt>
+                    <dd class="mt-0.5 font-semibold text-emerald-900 dark:text-emerald-100">
+                      {{ formatDateCompact(selectedMyListing.soldAt) || '未知' }}
+                    </dd>
+                  </div>
+                </dl>
+
+                <div v-if="selectedMyListing.affixBreakdown?.length" class="flex flex-wrap gap-1.5 text-[10px]">
+                  <template
+                    v-for="entry in selectedMyListing.affixBreakdown"
+                    :key="`my-detail-bd-${entry.affixSignature || entry.affixVisualStyle}`"
+                  >
+                    <GachaAffixChip
+                      v-for="part in resolveAffixParts(entry)"
+                      :key="`my-detail-bd-${entry.affixSignature || entry.affixVisualStyle}-${part.style}-${part.count}`"
+                      :style="part.style"
+                      :count="part.count"
+                      :show-glyph="true"
+                      :suffix="`x${entry.count}`"
+                    />
+                  </template>
+                </div>
+
+                <div class="flex items-center gap-2 pt-1">
+                  <span
+                    class="inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold"
+                    :class="tradeStatusChipClassMap[selectedMyListing.status]"
+                  >
+                    {{ tradeStatusLabel(selectedMyListing.status) }}
+                  </span>
+                  <span class="text-[11px] text-neutral-500 dark:text-neutral-400">
+                    上架 {{ formatDateCompact(selectedMyListing.createdAt) }}
+                  </span>
+                </div>
+
+                <UiButton
+                  v-if="selectedMyListing.status === 'OPEN' && selectedMyListing.remaining > 0"
+                  class="w-full"
+                  variant="outline"
+                  :disabled="cancellingId === selectedMyListing.id"
+                  @click="emit('cancel-listing', selectedMyListing.id); emit('close-my-listing')"
+                >
+                  {{ cancellingId === selectedMyListing.id ? '撤销中...' : '撤销挂牌' }}
+                </UiButton>
+              </div>
+            </div>
+          </div>
+        </template>
+      </UiDialogContent>
+    </UiDialogPortal>
+  </UiDialogRoot>
+
+  <!-- 公共挂牌详情弹窗 -->
+  <UiDialogRoot :open="!!selectedPublicListing" @update:open="(v: boolean) => { if (!v) emit('close-public-listing') }">
+    <UiDialogPortal>
+      <UiDialogOverlay />
+      <UiDialogContent class="max-w-lg p-0">
+        <template v-if="selectedPublicListing">
+          <header class="flex items-start justify-between gap-3 border-b border-neutral-200/60 px-5 py-4 dark:border-neutral-800/70">
+            <div class="min-w-0">
+              <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-cyan-700 dark:text-cyan-200">Trade Listing</p>
+              <h3 class="mt-1 truncate text-lg font-semibold text-neutral-900 dark:text-neutral-50">{{ selectedPublicListing.card.title }}</h3>
+              <p class="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">
+                {{ rarityLabel(selectedPublicListing.card.rarity) }} · 卖家 {{ formatAccountDisplayName(selectedPublicListing.seller, selectedPublicListing.sellerId) }}
+              </p>
+            </div>
+            <UiDialogClose as-child>
+              <UiButton variant="ghost" size="sm" class="h-9 w-9 rounded-full p-0" aria-label="关闭">X</UiButton>
+            </UiDialogClose>
+          </header>
+
+          <div class="max-h-[calc(100vh-7rem)] max-h-[calc(100dvh-7rem)] overflow-y-auto px-5 pb-5 pt-4">
+            <div class="grid gap-4 sm:grid-cols-[150px_minmax(0,1fr)] sm:items-start">
+              <div class="trade-detail-mini-card">
+                <GachaCard
+                  :title="selectedPublicListing.card.title"
+                  :rarity="selectedPublicListing.card.rarity"
+                  :tags="selectedPublicListing.card.tags ?? []"
+                  :wikidot-id="selectedPublicListing.card.wikidotId"
+                  :authors="selectedPublicListing.card.authors"
+                  :image-url="selectedPublicListing.card.imageUrl || undefined"
+                  :retired="selectedPublicListing.card.isRetired"
+                  variant="mini"
+                  :hide-footer="true"
+                  :affix-visual-style="selectedPublicListing.card.affixVisualStyle || selectedPublicListing.affixBreakdown?.[0]?.affixVisualStyle"
+                  :affix-signature="selectedPublicListing.card.affixSignature || selectedPublicListing.affixBreakdown?.[0]?.affixSignature"
+                  :affix-styles="selectedPublicListing.card.affixStyles || selectedPublicListing.affixBreakdown?.[0]?.affixStyles"
+                  :affix-style-counts="selectedPublicListing.card.affixStyleCounts || selectedPublicListing.affixBreakdown?.[0]?.affixStyleCounts"
+                  :affix-label="selectedPublicListing.card.affixLabel || selectedPublicListing.affixBreakdown?.[0]?.affixLabel"
+                />
+              </div>
+
+              <div class="space-y-3">
+                <dl class="grid grid-cols-2 gap-2 text-xs">
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">单价</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatTokens(selectedPublicListing.unitPrice) }} Token</dd>
+                  </div>
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">总价</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatTokens(listingTotalPrice(selectedPublicListing)) }} Token</dd>
+                  </div>
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">剩余数量</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ selectedPublicListing.remaining }} / {{ selectedPublicListing.quantity }}</dd>
+                  </div>
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">到期时间</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatDateCompact(selectedPublicListing.expiresAt) || '无' }}</dd>
+                  </div>
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">卖家</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">
+                      {{ formatAccountDisplayName(selectedPublicListing.seller, selectedPublicListing.sellerId) }}
+                    </dd>
+                  </div>
+                </dl>
+
+                <div v-if="selectedPublicListing.affixBreakdown?.length" class="flex flex-wrap gap-1.5 text-[10px]">
+                  <template
+                    v-for="entry in selectedPublicListing.affixBreakdown"
+                    :key="`detail-bd-${entry.affixSignature || entry.affixVisualStyle}`"
+                  >
+                    <GachaAffixChip
+                      v-for="part in resolveAffixParts(entry)"
+                      :key="`detail-bd-${entry.affixSignature || entry.affixVisualStyle}-${part.style}-${part.count}`"
+                      :style="part.style"
+                      :count="part.count"
+                      :show-glyph="true"
+                      :suffix="`x${entry.count}`"
+                    />
+                  </template>
+                </div>
+
+                <div class="flex items-center gap-2 pt-1">
+                  <span
+                    class="inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold"
+                    :class="tradeStatusChipClassMap[selectedPublicListing.status]"
+                  >
+                    {{ tradeStatusLabel(selectedPublicListing.status) }}
+                  </span>
+                  <span class="text-[11px] text-neutral-500 dark:text-neutral-400">
+                    上架 {{ formatDateCompact(selectedPublicListing.createdAt) }}
+                  </span>
+                </div>
+
+                <UiButton
+                  class="w-full"
+                  :disabled="buyingId === selectedPublicListing.id || selectedPublicListing.sellerId === userId || selectedPublicListing.status !== 'OPEN' || selectedPublicListing.remaining <= 0"
+                  @click="emit('buy-listing', selectedPublicListing.id); emit('close-public-listing')"
+                >
+                  <span v-if="buyingId === selectedPublicListing.id">购买中...</span>
+                  <span v-else-if="selectedPublicListing.sellerId === userId">这是我的挂牌</span>
+                  <span v-else>购买 · {{ formatTokens(selectedPublicListing.unitPrice) }} Token</span>
+                </UiButton>
+              </div>
+            </div>
+          </div>
+        </template>
+      </UiDialogContent>
+    </UiDialogPortal>
+  </UiDialogRoot>
+
+  <!-- 求购详情弹窗 -->
+  <UiDialogRoot :open="!!selectedBuyRequest" @update:open="(v: boolean) => { if (!v) emit('close-buy-request') }">
+    <UiDialogPortal>
+      <UiDialogOverlay />
+      <UiDialogContent class="max-w-xl p-0">
+        <template v-if="selectedBuyRequest">
+          <header class="flex items-start justify-between gap-3 border-b border-neutral-200/60 px-5 py-4 dark:border-neutral-800/70">
+            <div class="min-w-0">
+              <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-cyan-700 dark:text-cyan-200">Buy Request</p>
+              <h3 class="mt-1 truncate text-lg font-semibold text-neutral-900 dark:text-neutral-50">求购: {{ selectedBuyRequest.targetCard.title }}</h3>
+              <p class="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">
+                {{ rarityLabel(selectedBuyRequest.targetCard.rarity) }} · 买家 {{ formatAccountDisplayName(selectedBuyRequest.buyer, selectedBuyRequest.buyerId) }}
+              </p>
+            </div>
+            <UiDialogClose as-child>
+              <UiButton variant="ghost" size="sm" class="h-9 w-9 rounded-full p-0" aria-label="关闭">X</UiButton>
+            </UiDialogClose>
+          </header>
+
+          <div class="br-detail-body">
+            <div class="br-detail-layout">
+              <div class="br-detail-card">
+                <GachaCard
+                  :title="selectedBuyRequest.targetCard.title"
+                  :rarity="selectedBuyRequest.targetCard.rarity"
+                  :tags="selectedBuyRequest.targetCard.tags ?? []"
+                  :wikidot-id="selectedBuyRequest.targetCard.wikidotId"
+                  :authors="selectedBuyRequest.targetCard.authors"
+                  :image-url="selectedBuyRequest.targetCard.imageUrl || undefined"
+                  :retired="selectedBuyRequest.targetCard.isRetired"
+                  variant="mini"
+                  :hide-footer="true"
+                />
+              </div>
+
+              <div class="space-y-3">
+                <dl class="br-detail-stats">
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">Token 出价</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">
+                      {{ selectedBuyRequest.tokenOffer > 0 ? `${formatTokens(selectedBuyRequest.tokenOffer)} Token` : '无' }}
+                    </dd>
+                  </div>
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">提供卡牌</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">
+                      {{ selectedBuyRequest.offeredCards.length > 0 ? `${selectedBuyRequest.offeredCards.length} 种` : '无' }}
+                    </dd>
+                  </div>
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">到期时间</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">{{ formatDateCompact(selectedBuyRequest.expiresAt) || '无' }}</dd>
+                  </div>
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">状态</dt>
+                    <dd class="mt-0.5">
+                      <span class="inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold" :class="buyRequestStatusChipClassMap[selectedBuyRequest.status]">
+                        {{ buyRequestStatusLabelMap[selectedBuyRequest.status] }}
+                      </span>
+                    </dd>
+                  </div>
+                  <div class="rounded-xl border border-neutral-200/70 bg-neutral-50/90 px-2.5 py-2 dark:border-neutral-700/70 dark:bg-neutral-800/70">
+                    <dt class="text-neutral-500 dark:text-neutral-400">匹配要求</dt>
+                    <dd class="mt-0.5 font-semibold text-neutral-800 dark:text-neutral-100">
+                      {{ buyRequestMatchLevelLabelMap[selectedBuyRequest.matchLevel] }}
+                      <span v-if="selectedBuyRequest.matchLevel === 'COATING' && selectedBuyRequest.requiredCoating" class="text-[10px] font-normal text-neutral-500 dark:text-neutral-400">
+                        · {{ coatingStyleLabelMap[selectedBuyRequest.requiredCoating] }}
+                      </span>
+                    </dd>
+                  </div>
+                </dl>
+
+                <div v-if="selectedBuyRequest.offeredCards.length > 0" class="space-y-1.5">
+                  <span class="text-[10px] font-semibold text-neutral-500 dark:text-neutral-400">提供的卡牌</span>
+                  <div class="flex flex-wrap gap-2">
+                    <div
+                      v-for="oc in selectedBuyRequest.offeredCards"
+                      :key="`br-detail-oc-${oc.id}`"
+                      class="flex items-center gap-1.5 rounded-lg border border-neutral-200/60 bg-white/70 px-2 py-1 dark:border-neutral-700/60 dark:bg-neutral-800/60"
+                    >
+                      <img v-if="oc.card.imageUrl" :src="oc.card.imageUrl" class="h-6 w-6 rounded object-cover" loading="lazy" />
+                      <span class="max-w-[100px] truncate text-[10px] font-medium text-neutral-700 dark:text-neutral-200">{{ oc.card.title }}</span>
+                      <span class="text-[9px] text-neutral-500 dark:text-neutral-400">x{{ oc.quantity }}</span>
+                    </div>
+                  </div>
+                </div>
+
+                <div
+                  v-if="selectedBuyRequest.status === 'OPEN' && selectedBuyRequest.buyerId !== userId"
+                  class="space-y-1.5"
+                >
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold text-neutral-500 dark:text-neutral-400">选择要提供的卡牌</span>
+                    <span v-if="buyRequestFulfillCandidates.length > 1" class="text-[10px] text-neutral-500 dark:text-neutral-400">
+                      可选 {{ buyRequestFulfillCandidates.length }} 种
+                    </span>
+                  </div>
+                  <p
+                    v-if="inventoryLoading && !cardOptionsLength"
+                    class="text-[11px] text-neutral-500 dark:text-neutral-400"
+                  >
+                    正在加载你的可交付库存...
+                  </p>
+                  <div v-else-if="buyRequestFulfillCandidates.length > 0" class="br-fulfill-grid">
+                    <button
+                      v-for="item in buyRequestFulfillCandidates"
+                      :key="`br-fulfill-candidate-${item.stackKey}`"
+                      type="button"
+                      class="trade-create-card"
+                      :class="{ 'trade-create-card--selected': selectedFulfillStackKey === item.stackKey }"
+                      @click="emit('update:selectedFulfillStackKey', item.stackKey)"
+                    >
+                      <GachaCardMini
+                        :title="item.title"
+                        :rarity="item.rarity"
+                        :image-url="item.imageUrl || undefined"
+                        :retired="item.isRetired"
+                        :affix-visual-style="item.affixVisualStyle"
+                        :affix-label="item.affixLabel"
+                      >
+                        <template #meta>
+                          <span class="trade-remaining-chip">可交付 {{ item.availableCount }}</span>
+                        </template>
+                      </GachaCardMini>
+                    </button>
+                  </div>
+                  <p v-else class="text-[11px] text-neutral-500 dark:text-neutral-400">
+                    暂无可直接交付库存，将由系统自动尝试释放符合条件的卡牌。
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <!-- Sticky action buttons -->
+            <div
+              v-if="selectedBuyRequest.status === 'OPEN'"
+              class="br-detail-actions"
+            >
+              <UiButton
+                v-if="selectedBuyRequest.buyerId !== userId"
+                class="w-full"
+                :disabled="buyRequestFulfillingId === selectedBuyRequest.id"
+                @click="emit('fulfill-buy-request')"
+              >
+                {{
+                  buyRequestFulfillingId === selectedBuyRequest.id
+                    ? '接受中...'
+                    : buyRequestFulfillCandidates.length > 1
+                      ? '选择并接受求购'
+                      : '接受求购（出售目标卡）'
+                }}
+              </UiButton>
+
+              <UiButton
+                v-if="selectedBuyRequest.buyerId === userId"
+                class="w-full"
+                variant="outline"
+                :disabled="buyRequestCancelId === selectedBuyRequest.id"
+                @click="emit('cancel-buy-request', selectedBuyRequest.id); emit('close-buy-request')"
+              >
+                {{ buyRequestCancelId === selectedBuyRequest.id ? '取消中...' : '取消求购' }}
+              </UiButton>
+            </div>
+          </div>
+        </template>
+      </UiDialogContent>
+    </UiDialogPortal>
+  </UiDialogRoot>
+</template>

--- a/frontend/components/gacha/trade/TradeDetail.vue
+++ b/frontend/components/gacha/trade/TradeDetail.vue
@@ -482,3 +482,33 @@ function formatAccountDisplayName(
     </UiDialogPortal>
   </UiDialogRoot>
 </template>
+
+<style>
+/* These styles are NOT scoped and NOT namespaced under .trade-bazaar because
+   UiDialogPortal teleports content to <body>, outside the .trade-bazaar ancestor. */
+.trade-detail-mini-card { width: 100%; max-width: 150px; margin-inline: auto; }
+.trade-detail-mini-card > * { width: 100%; }
+
+.trade-create-card { position: relative; display: block; width: 100%; min-width: 0; border-radius: 0.9rem; border: 1px solid rgba(148, 163, 184, 0.24); background: rgba(255, 255, 255, 0.72); padding: 0.22rem; text-align: left; cursor: pointer; transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease; }
+.trade-create-card:hover { border-color: rgba(14, 116, 144, 0.35); box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08); transform: translateY(-1px); }
+.trade-create-card--selected { border-color: rgba(14, 116, 144, 0.55); box-shadow: 0 0 0 4px rgba(14, 116, 144, 0.22), 0 0 0 1px rgba(14, 116, 144, 0.12), 0 8px 20px rgba(8, 145, 178, 0.16); }
+html.dark .trade-create-card { border-color: rgba(100, 116, 139, 0.45); background: rgba(15, 23, 42, 0.62); }
+html.dark .trade-create-card:hover { border-color: rgba(34, 211, 238, 0.45); box-shadow: 0 4px 14px rgba(0, 0, 0, 0.28); }
+html.dark .trade-create-card--selected { border-color: rgba(34, 211, 238, 0.62); box-shadow: 0 0 0 4px rgba(34, 211, 238, 0.22), 0 0 0 1px rgba(34, 211, 238, 0.2), 0 10px 22px rgba(6, 182, 212, 0.18); }
+
+.trade-remaining-chip { display: inline-flex; align-items: center; border-radius: 999px; border: 1px solid rgba(148, 163, 184, 0.35); background: rgba(248, 250, 252, 0.8); color: rgb(100 116 139); font-size: 9px; font-weight: 600; padding: 1px 5px; white-space: nowrap; }
+html.dark .trade-remaining-chip { border-color: rgba(100, 116, 139, 0.45); background: rgba(15, 23, 42, 0.7); color: rgb(148 163 184); }
+
+.br-detail-body { max-height: calc(100vh - 7rem); max-height: calc(100dvh - 7rem); overflow-y: auto; padding: 1rem 1.25rem 1.25rem; }
+.br-detail-layout { display: grid; gap: 12px; align-items: start; }
+.br-detail-card { width: 100%; max-width: 140px; margin-inline: auto; }
+.br-detail-card > * { width: 100%; }
+@media (min-width: 640px) { .br-detail-layout { gap: 16px; grid-template-columns: 160px minmax(0, 1fr); } .br-detail-card { max-width: none; margin-inline: 0; } }
+.br-detail-stats { display: grid; gap: 6px; grid-template-columns: 1fr; font-size: 12px; }
+@media (min-width: 640px) { .br-detail-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; } }
+.br-detail-actions { position: sticky; bottom: 0; padding-top: 12px; background: linear-gradient(to bottom, transparent, var(--g-surface-card) 6px); }
+.br-fulfill-grid { display: grid; gap: 8px; grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: stretch; }
+.br-fulfill-grid > * { display: flex; height: 100%; width: 100%; min-width: 0; }
+.br-fulfill-grid > * > * { width: 100%; height: 100%; }
+@media (min-width: 640px) { .br-fulfill-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+</style>

--- a/frontend/components/gacha/trade/TradeListings.vue
+++ b/frontend/components/gacha/trade/TradeListings.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import type { Rarity, TradeListing } from '~/types/gacha'
+import { formatTokens, formatDateCompact } from '~/utils/gachaFormatters'
+import { rarityLabel } from '~/utils/gachaRarity'
+import { tradeStatusLabelMap, tradeStatusChipClassMap } from '~/utils/gachaConstants'
+import GachaCardMini from '~/components/gacha/GachaCardMini.vue'
+import GachaRarityFilter from '~/components/gacha/GachaRarityFilter.vue'
+import GachaPagination from '~/components/gacha/GachaPagination.vue'
+import { UiButton } from '~/components/ui/button'
+import { UiInput } from '~/components/ui/input'
+import { UiSelectRoot, UiSelectTrigger, UiSelectContent, UiSelectItem } from '~/components/ui/select'
+
+type TradeSortMode = 'LATEST' | 'PRICE_ASC' | 'PRICE_DESC' | 'TOTAL_ASC' | 'TOTAL_DESC' | 'RARITY_DESC'
+
+defineProps<{
+  publicListings: TradeListing[]
+  publicTotal: number
+  loading: boolean
+  publicLoadingMore: boolean
+  tradeSearch: string
+  tradeSearchMode: 'ALL' | 'CARD' | 'SELLER'
+  tradeSortMode: TradeSortMode
+  tradeRarityFilter: Rarity | 'ALL'
+  tradeRarityFilterOptions: Array<Rarity | 'ALL'>
+  tradePublicPage: number
+  pageSize: number
+  clientNow: number | null
+  userId: string | null
+}>()
+
+const emit = defineEmits<{
+  'update:tradeSearch': [val: string]
+  'update:tradeSearchMode': [val: 'ALL' | 'CARD' | 'SELLER']
+  'update:tradeSortMode': [val: TradeSortMode]
+  'update:tradeRarityFilter': [val: Rarity | 'ALL']
+  'reset-filters': []
+  'open-listing-detail': [listing: TradeListing]
+  'trade-page-change': [page: number]
+}>()
+
+function formatAccountDisplayName(
+  account: { id: string; displayName: string | null; linkedWikidotId: number | null } | null | undefined,
+  fallbackId?: string | null
+) {
+  if (account?.displayName) return account.displayName
+  if (account?.linkedWikidotId) return `WID:${account.linkedWikidotId}`
+  const rawId = String(fallbackId || account?.id || '').trim()
+  if (!rawId) return '未知用户'
+  return `用户-${rawId.slice(0, 8)}`
+}
+
+function listingRemainingLabel(listing: TradeListing, now: number | null) {
+  if (listing.status !== 'OPEN' || listing.remaining <= 0) return tradeStatusLabelMap[listing.status] || listing.status
+  if (!listing.expiresAt) return '无期限'
+  if (!now) return formatDateCompact(listing.expiresAt) || '无'
+  const expiresTs = new Date(listing.expiresAt).getTime()
+  if (!Number.isFinite(expiresTs)) return formatDateCompact(listing.expiresAt) || '无'
+  const diffMs = expiresTs - now
+  if (diffMs <= 0) return '已到期'
+  const diffMin = Math.max(1, Math.ceil(diffMs / 60_000))
+  if (diffMin < 60) return `剩${diffMin}m`
+  const diffH = Math.ceil(diffMin / 60)
+  if (diffH < 48) return `剩${diffH}h`
+  const diffD = Math.ceil(diffH / 24)
+  return `剩${diffD}d`
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- 搜索 / 排序 -->
+    <div class="grid gap-2 md:grid-cols-[minmax(0,1fr),minmax(160px,200px),minmax(180px,230px),auto]">
+      <UiInput
+        :model-value="tradeSearch"
+        type="search"
+        placeholder="搜索卡片名 / 标签 / 作者 / 卖家"
+        class="w-full"
+        @update:model-value="emit('update:tradeSearch', String($event))"
+      />
+      <UiSelectRoot :model-value="tradeSearchMode" @update:model-value="emit('update:tradeSearchMode', $event as any)">
+        <UiSelectTrigger placeholder="搜索模式" />
+        <UiSelectContent>
+          <UiSelectItem value="ALL">全字段搜索</UiSelectItem>
+          <UiSelectItem value="CARD">仅卡片</UiSelectItem>
+          <UiSelectItem value="SELLER">仅卖家</UiSelectItem>
+        </UiSelectContent>
+      </UiSelectRoot>
+      <UiSelectRoot :model-value="tradeSortMode" @update:model-value="emit('update:tradeSortMode', $event as any)">
+        <UiSelectTrigger placeholder="排序方式" />
+        <UiSelectContent>
+          <UiSelectItem value="LATEST">按上架时间（新到旧）</UiSelectItem>
+          <UiSelectItem value="RARITY_DESC">按稀有度（高到低）</UiSelectItem>
+          <UiSelectItem value="PRICE_ASC">按单价（低到高）</UiSelectItem>
+          <UiSelectItem value="PRICE_DESC">按单价（高到低）</UiSelectItem>
+          <UiSelectItem value="TOTAL_ASC">按总价（低到高）</UiSelectItem>
+          <UiSelectItem value="TOTAL_DESC">按总价（高到低）</UiSelectItem>
+        </UiSelectContent>
+      </UiSelectRoot>
+      <UiButton variant="outline" class="h-9" @click="emit('reset-filters')">重置</UiButton>
+    </div>
+
+    <div class="mt-2">
+      <GachaRarityFilter
+        :model-value="tradeRarityFilter"
+        :options="tradeRarityFilterOptions"
+        all-label="全部品质"
+        @update:model-value="emit('update:tradeRarityFilter', $event as any)"
+      />
+    </div>
+
+    <p class="mt-2 text-[11px] text-neutral-500 dark:text-neutral-400">
+      显示 {{ publicListings.length }} / {{ publicTotal }} 条
+    </p>
+
+    <p v-if="!publicListings.length" class="gacha-empty mt-3">当前筛选条件下没有可购买挂牌。</p>
+    <div v-else class="mt-3">
+      <div class="gacha-trade-item-grid">
+        <button
+          v-for="listing in publicListings"
+          :key="`public-trade-${listing.id}`"
+          type="button"
+          class="trade-item-row"
+          @click="emit('open-listing-detail', listing)"
+        >
+          <div class="trade-item-row__card">
+            <GachaCardMini
+              :title="listing.card.title"
+              :rarity="listing.card.rarity"
+              :image-url="listing.card.imageUrl || undefined"
+              :retired="listing.card.isRetired"
+              :affix-visual-style="listing.card.affixVisualStyle || listing.affixBreakdown?.[0]?.affixVisualStyle"
+              :affix-label="listing.card.affixLabel || listing.affixBreakdown?.[0]?.affixLabel"
+              :hide-footer="true"
+            />
+          </div>
+          <div class="trade-item-row__info">
+            <span class="trade-item-row__user">{{ formatAccountDisplayName(listing.seller, listing.sellerId) }}</span>
+            <span class="trade-item-row__price">{{ formatTokens(listing.unitPrice) }}T <span class="trade-item-row__qty">× {{ listing.remaining }}张</span></span>
+            <span class="trade-item-row__time">{{ listingRemainingLabel(listing, clientNow) }}</span>
+          </div>
+        </button>
+      </div>
+    </div>
+
+    <GachaPagination
+      :current="tradePublicPage"
+      :total="publicTotal"
+      :page-size="pageSize"
+      :loading="loading || publicLoadingMore"
+      @change="(p: number) => emit('trade-page-change', p)"
+    />
+  </div>
+</template>

--- a/frontend/components/gacha/trade/TradeSellForm.vue
+++ b/frontend/components/gacha/trade/TradeSellForm.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import type { AffixVisualStyle, Rarity } from '~/types/gacha'
+import { formatTokens } from '~/utils/gachaFormatters'
+import { rarityLabel } from '~/utils/gachaRarity'
+import GachaCardMini from '~/components/gacha/GachaCardMini.vue'
+import { UiButton } from '~/components/ui/button'
+import { UiInput } from '~/components/ui/input'
+
+interface TradeCardOption {
+  stackKey: string
+  cardId: string
+  title: string
+  rarity: Rarity
+  imageUrl: string | null
+  isRetired?: boolean
+  wikidotId?: number | null
+  pageId?: number | null
+  tags?: string[]
+  authors?: Array<{ name: string; wikidotId: number | null }> | null
+  availableCount: number
+  affixSignature?: string
+  affixStyles?: AffixVisualStyle[]
+  affixStyleCounts?: Partial<Record<AffixVisualStyle, number>>
+  affixVisualStyle?: AffixVisualStyle
+  affixLabel?: string
+}
+
+type RarityGroup = { rarity: Rarity; startIndex: number; count: number }
+
+const props = defineProps<{
+  inventoryLoading: boolean
+  cardOptions: TradeCardOption[]
+  filteredTradeCardOptions: TradeCardOption[]
+  visibleTradeCardOptions: TradeCardOption[]
+  rarityGroups: RarityGroup[]
+  normalizedCreateSearch: string
+  tradeSelectionKey: string
+  selectedTradeCardOption: TradeCardOption | null
+  tradeQuantity: number
+  tradeQuantityMax: number
+  tradeUnitPrice: number
+  tradeExpiresHours: number
+  submitting: boolean
+  pickerHasMore: boolean
+  pickerRemainingCount: number
+  showCreateForm: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:showCreateForm': [val: boolean]
+  'update:tradeCreateSearch': [val: string]
+  'update:tradeSelectionKey': [val: string]
+  'update:tradeQuantity': [val: number]
+  'update:tradeUnitPrice': [val: number]
+  'update:tradeExpiresHours': [val: number]
+  create: []
+  'picker-load-more': []
+  'picker-next-group-label': []
+}>()
+
+function pickerNextGroupLabel(): string {
+  const nextIdx = props.visibleTradeCardOptions.length
+  for (const g of props.rarityGroups) {
+    if (nextIdx >= g.startIndex && nextIdx < g.startIndex + g.count) {
+      return rarityLabel(g.rarity)
+    }
+  }
+  return ''
+}
+</script>
+
+<template>
+  <div>
+    <button
+      type="button"
+      class="trade-collapse-toggle"
+      @click="emit('update:showCreateForm', !showCreateForm)"
+    >
+      <span>{{ showCreateForm ? '收起发布' : '发布挂牌' }}</span>
+      <span class="trade-collapse-toggle__icon" :class="{ 'trade-collapse-toggle__icon--open': showCreateForm }">&#9662;</span>
+    </button>
+
+    <Transition name="trade-collapse">
+      <article v-if="showCreateForm" class="mt-2 rounded-lg border border-neutral-200/75 bg-neutral-50/75 p-4 dark:border-neutral-800/70 dark:bg-neutral-900/55">
+        <p class="text-[11px] text-neutral-500 dark:text-neutral-400">仅可上架未放置、且当前可用的库存数量。</p>
+
+        <div v-if="inventoryLoading && !cardOptions.length" class="gacha-empty mt-3">
+          正在加载可上架卡片...
+        </div>
+
+        <div v-else-if="!cardOptions.length" class="gacha-empty mt-3">
+          当前无可上架卡片。你可以先抽卡或从放置槽中撤下卡片。
+        </div>
+
+        <form v-else class="mt-3 space-y-3" @submit.prevent="emit('create')">
+          <div class="space-y-2">
+            <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-neutral-500 dark:text-neutral-400">
+              <span>选择卡片</span>
+              <span>当前可选 {{ filteredTradeCardOptions.length }} 种</span>
+            </div>
+            <!-- Rarity group summary -->
+            <div v-if="rarityGroups.length > 1 && !normalizedCreateSearch" class="flex flex-wrap gap-1">
+              <span
+                v-for="g in rarityGroups"
+                :key="`rg-${g.rarity}`"
+                class="picker-rarity-tag"
+                :class="`picker-rarity-tag--${g.rarity.toLowerCase()}`"
+              >{{ rarityLabel(g.rarity) }} {{ g.count }}</span>
+            </div>
+            <p v-if="inventoryLoading" class="text-[11px] text-neutral-500 dark:text-neutral-400">
+              正在后台同步可上架库存...
+            </p>
+            <UiInput
+              :model-value="normalizedCreateSearch"
+              type="search"
+              placeholder="搜索可上架卡片（标题 / 标签 / 作者 / ID）"
+              class="w-full"
+              @update:model-value="emit('update:tradeCreateSearch', String($event))"
+            />
+            <div class="picker-scroll-area">
+              <p v-if="!filteredTradeCardOptions.length" class="gacha-empty py-4">
+                当前筛选条件下没有可上架卡片。
+              </p>
+              <div v-else class="trade-create-grid gacha-card-grid--mini">
+                <button
+                  v-for="item in visibleTradeCardOptions"
+                  :key="`trade-card-${item.stackKey}`"
+                  type="button"
+                  class="trade-create-card"
+                  :class="{ 'trade-create-card--selected': tradeSelectionKey === item.stackKey }"
+                  :aria-pressed="tradeSelectionKey === item.stackKey"
+                  @click="emit('update:tradeSelectionKey', item.stackKey)"
+                >
+                  <GachaCardMini
+                    :title="item.title"
+                    :rarity="item.rarity"
+                    :image-url="item.imageUrl || undefined"
+                    :retired="item.isRetired"
+                    :affix-visual-style="item.affixVisualStyle"
+                    :affix-label="item.affixLabel"
+                  >
+                    <template #meta>
+                      <span class="trade-remaining-chip">可上架 {{ item.availableCount }}</span>
+                    </template>
+                  </GachaCardMini>
+                </button>
+              </div>
+              <button
+                v-if="pickerHasMore"
+                type="button"
+                class="picker-load-more-btn"
+                @click="emit('picker-load-more')"
+              >
+                加载更多（剩余 {{ pickerRemainingCount }}{{ pickerNextGroupLabel() ? `，下批为 ${pickerNextGroupLabel()}` : '' }}）
+              </button>
+            </div>
+          </div>
+
+          <p v-if="selectedTradeCardOption" class="text-[11px] text-neutral-500 dark:text-neutral-400">
+            已选 {{ selectedTradeCardOption.title }} · {{ rarityLabel(selectedTradeCardOption.rarity) }} · 词条 {{ selectedTradeCardOption.affixSignature || 'NONE' }} · 可上架 {{ selectedTradeCardOption.availableCount }}
+          </p>
+
+          <div class="grid gap-2 sm:grid-cols-3">
+            <label class="space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
+              <span>数量</span>
+              <UiInput :model-value="tradeQuantity" type="number" min="1" :max="tradeQuantityMax" step="1" @update:model-value="emit('update:tradeQuantity', Number($event))" />
+            </label>
+            <label class="space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
+              <span>单价 Token</span>
+              <UiInput :model-value="tradeUnitPrice" type="number" min="1" max="1000000" step="1" @update:model-value="emit('update:tradeUnitPrice', Number($event))" />
+            </label>
+            <label class="space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
+              <span>有效期（小时）</span>
+              <UiInput :model-value="tradeExpiresHours" type="number" min="1" :max="24 * 30" step="1" @update:model-value="emit('update:tradeExpiresHours', Number($event))" />
+            </label>
+          </div>
+
+          <p class="text-[11px] text-neutral-500 dark:text-neutral-400">
+            挂牌总价 {{ formatTokens(Math.max(1, Number(tradeQuantity || 1)) * Math.max(1, Number(tradeUnitPrice || 1))) }} Token · 预计到期 {{ tradeExpiresHours }} 小时后
+          </p>
+
+          <div class="flex flex-wrap gap-2">
+            <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="emit('update:tradeExpiresHours', 24)">24h</UiButton>
+            <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="emit('update:tradeExpiresHours', 72)">72h</UiButton>
+            <UiButton type="button" variant="ghost" size="sm" class="rounded-full border border-neutral-200 bg-white px-2.5 py-1 text-[11px] dark:border-neutral-700 dark:bg-neutral-800" @click="emit('update:tradeExpiresHours', 168)">168h</UiButton>
+          </div>
+
+          <UiButton type="submit" class="w-full py-2.5 text-sm" :disabled="submitting || !selectedTradeCardOption">
+            {{ submitting ? '上架中...' : '提交并确认' }}
+          </UiButton>
+        </form>
+      </article>
+    </Transition>
+  </div>
+</template>

--- a/frontend/components/gacha/trade/TradeSellForm.vue
+++ b/frontend/components/gacha/trade/TradeSellForm.vue
@@ -33,6 +33,7 @@ const props = defineProps<{
   filteredTradeCardOptions: TradeCardOption[]
   visibleTradeCardOptions: TradeCardOption[]
   rarityGroups: RarityGroup[]
+  tradeCreateSearch: string
   normalizedCreateSearch: string
   tradeSelectionKey: string
   selectedTradeCardOption: TradeCardOption | null
@@ -111,7 +112,7 @@ function pickerNextGroupLabel(): string {
               正在后台同步可上架库存...
             </p>
             <UiInput
-              :model-value="normalizedCreateSearch"
+              :model-value="tradeCreateSearch"
               type="search"
               placeholder="搜索可上架卡片（标题 / 标签 / 作者 / ID）"
               class="w-full"

--- a/frontend/components/user/UserHeader.vue
+++ b/frontend/components/user/UserHeader.vue
@@ -1,0 +1,383 @@
+<template>
+  <div class="space-y-6">
+    <!-- Header -->
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between border-b-2 border-[var(--g-accent-medium)] dark:border-[var(--g-accent-strong)] pb-3 mb-4">
+      <div class="flex items-center gap-3">
+        <div class="h-8 w-1 bg-[var(--g-accent)] rounded" />
+        <h2 class="text-lg font-bold text-neutral-800 dark:text-neutral-100">用户详情</h2>
+      </div>
+      <div class="flex items-center gap-3 w-full sm:w-auto sm:justify-end">
+        <button
+          v-if="canFollow"
+          type="button"
+          :aria-label="isFollowingThis ? '取消收藏作者' : '收藏作者'"
+          :title="isFollowingThis ? '取消收藏作者' : '收藏作者'"
+          class="inline-flex items-center justify-center h-9 w-9 rounded-full border transition shadow-sm"
+          :class="isFollowingThis
+            ? 'border-[rgba(var(--accent),0.45)] bg-[var(--g-accent-soft)] text-[var(--g-accent)] dark:border-[rgba(var(--accent),0.45)]'
+            : 'border-neutral-200 bg-white/80 text-neutral-600 hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:bg-neutral-800/80 dark:text-neutral-300'"
+          @click="$emit('toggle-follow')"
+        >
+          <!-- Use the same star geometry for both states to ensure equal visual size -->
+          <LucideIcon v-if="isFollowingThis" name="Star" class="w-5 h-5" stroke-width="1.8" fill="currentColor" />
+          <LucideIcon v-else name="Star" class="w-5 h-5" stroke-width="1.8" />
+        </button>
+      </div>
+    </div>
+
+    <!-- User Info and Overall Stats -->
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <!-- User Basic Info -->
+      <div class="lg:col-span-2 border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div class="flex items-start gap-3 min-w-0 flex-1">
+            <UserAvatar :wikidot-id="wikidotId" :name="user?.displayName || 'Unknown User'" :size="56" class="shrink-0 ring-1 ring-neutral-200 dark:ring-neutral-800" />
+            <div class="min-w-0 flex-1">
+              <h1 class="text-xl sm:text-2xl font-bold text-neutral-900 dark:text-neutral-100 truncate">{{ user?.displayName || 'Unknown User' }}</h1>
+              <div class="mt-1 text-xs text-neutral-600 dark:text-neutral-400 flex items-center gap-2">
+                <span>ID：{{ wikidotId }}</span>
+                <span v-if="user?.isGuest" class="inline-flex items-center px-2 py-0.5 rounded bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400">访客</span>
+              </div>
+            </div>
+          </div>
+          <div v-if="statsPending" class="text-right shrink-0">
+            <div class="w-16 h-7 rounded bg-neutral-100 animate-pulse dark:bg-neutral-700/60 mb-1"></div>
+            <div class="w-20 h-3 rounded bg-neutral-100 animate-pulse dark:bg-neutral-700/60 ml-auto"></div>
+          </div>
+          <div v-else-if="stats?.rank" class="text-right shrink-0">
+            <div class="text-2xl sm:text-3xl font-bold text-[var(--g-accent)] whitespace-nowrap overflow-hidden">#{{ stats.rank }}</div>
+            <div class="text-xs text-neutral-600 dark:text-neutral-400">综合排名</div>
+          </div>
+        </div>
+
+        <!-- Activity Timeline -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+          <div v-if="user?.firstActivityAt" class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3">
+            <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">首次活动</div>
+            <div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">{{ formatDate(user.firstActivityAt) }}</div>
+            <div v-if="user?.firstActivityType && !isForumPostActivity(user?.firstActivityType)" class="text-xs text-neutral-500 dark:text-neutral-500 mt-1">
+              {{ formatActivityType(user.firstActivityType) }}
+            </div>
+            <div v-if="user?.firstActivityPageWikidotId || user?.firstActivityPageTitle" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden">
+              <div class="flex flex-wrap items-start gap-1">
+                <NuxtLink :to="`/page/${user.firstActivityPageWikidotId}`" class="hover:text-[var(--g-accent)] truncate max-w-full block">
+                  {{ user.firstActivityPageTitle || '未知页面' }}
+                </NuxtLink>
+                <span v-if="user?.firstActivityType === 'VOTE'" :class="[
+                  'font-bold shrink-0',
+                  Number(user?.firstActivityDirection || 0) > 0 ? 'text-green-600 dark:text-green-400' : Number(user?.firstActivityDirection || 0) < 0 ? 'text-red-600 dark:text-red-400' : 'text-neutral-500 dark:text-neutral-500'
+                ]">
+                  {{ Number(user?.firstActivityDirection || 0) > 0 ? '+1' : Number(user?.firstActivityDirection || 0) < 0 ? '-1' : '0' }}
+                </span>
+                <span v-else-if="user?.firstActivityType === 'REVISION' && user?.firstActivityRevisionType" class="text-neutral-500 dark:text-neutral-500 shrink-0">— {{ formatRevisionType(user.firstActivityRevisionType) }}</span>
+              </div>
+              <div v-if="user?.firstActivityComment" class="text-neutral-500 dark:text-neutral-500 mt-1 text-xs break-words overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;">
+                — {{ user.firstActivityComment }}
+              </div>
+            </div>
+            <div v-else-if="isForumPostActivity(user?.firstActivityType)" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden">
+              <NuxtLink
+                :to="forumPostLink(user?.firstActivityForumThreadId, user?.firstActivityForumPostId)"
+                class="block text-xs font-medium text-neutral-700 dark:text-neutral-300 hover:text-[var(--g-accent)] break-words overflow-hidden"
+                style="display: -webkit-box; -webkit-line-clamp: 1; line-clamp: 1; -webkit-box-orient: vertical;"
+              >
+                发帖 - {{ user?.firstActivityForumThreadTitle || '论坛主题' }} - {{ user?.firstActivityForumPostTitle || '无标题' }}
+              </NuxtLink>
+              <div
+                v-if="user?.firstActivityForumExcerpt"
+                class="text-neutral-500 dark:text-neutral-500 mt-1 text-xs break-words overflow-hidden"
+                style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;"
+              >
+                {{ user.firstActivityForumExcerpt }}
+              </div>
+            </div>
+          </div>
+          <div v-if="user?.lastActivityAt" class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3">
+            <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">最近活动</div>
+            <div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">{{ formatDate(user.lastActivityAt) }}</div>
+            <div v-if="user?.lastActivityType && !isForumPostActivity(user?.lastActivityType)" class="text-xs text-neutral-500 dark:text-neutral-500 mt-1">
+              {{ formatActivityType(user.lastActivityType) }}
+            </div>
+            <div v-if="user?.lastActivityType === 'VOTE' && (user?.lastActivityPageWikidotId || user?.lastActivityPageTitle)" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden">
+              <div class="flex flex-wrap items-start gap-1">
+                <span class="shrink-0">投票 ·</span>
+                <NuxtLink :to="`/page/${user.lastActivityPageWikidotId}`" class="hover:text-[var(--g-accent)] truncate max-w-full block">
+                  {{ user.lastActivityPageTitle || '未知页面' }}
+                </NuxtLink>
+                <span :class="[
+                  'font-bold shrink-0',
+                  Number(user?.lastActivityDirection || 0) > 0 ? 'text-green-600 dark:text-green-400' : Number(user?.lastActivityDirection || 0) < 0 ? 'text-red-600 dark:text-red-400' : 'text-neutral-500 dark:text-neutral-500'
+                ]">
+                  {{ Number(user?.lastActivityDirection || 0) > 0 ? '+1' : Number(user?.lastActivityDirection || 0) < 0 ? '-1' : '0' }}
+                </span>
+              </div>
+            </div>
+            <div v-else-if="user?.lastActivityType === 'REVISION' && (user?.lastActivityPageWikidotId || user?.lastActivityPageTitle)" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden">
+              <div class="flex flex-wrap items-start gap-1">
+                <span class="shrink-0">{{ formatRevisionType(user?.lastActivityRevisionType || '') }} ·</span>
+                <NuxtLink :to="`/page/${user.lastActivityPageWikidotId}`" class="hover:text-[var(--g-accent)] truncate max-w-full block">
+                  {{ user.lastActivityPageTitle || '未知页面' }}
+                </NuxtLink>
+              </div>
+              <div v-if="user?.lastActivityComment" class="text-neutral-500 dark:text-neutral-500 mt-1 text-xs break-words overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;">
+                — {{ user.lastActivityComment }}
+              </div>
+            </div>
+            <div v-else-if="isForumPostActivity(user?.lastActivityType)" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden">
+              <NuxtLink
+                :to="forumPostLink(user?.lastActivityForumThreadId, user?.lastActivityForumPostId)"
+                class="block text-xs font-medium text-neutral-700 dark:text-neutral-300 hover:text-[var(--g-accent)] break-words overflow-hidden"
+                style="display: -webkit-box; -webkit-line-clamp: 1; line-clamp: 1; -webkit-box-orient: vertical;"
+              >
+                发帖 - {{ user?.lastActivityForumThreadTitle || '论坛主题' }} - {{ user?.lastActivityForumPostTitle || '无标题' }}
+              </NuxtLink>
+              <div
+                v-if="user?.lastActivityForumExcerpt"
+                class="text-neutral-500 dark:text-neutral-500 mt-1 text-xs break-words overflow-hidden"
+                style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;"
+              >
+                {{ user.lastActivityForumExcerpt }}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Overall Stats Grid -->
+        <div v-if="statsPending" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mt-6">
+          <div v-for="n in 4" :key="`stats-skeleton-${n}`" class="bg-neutral-100 dark:bg-neutral-800 rounded-lg p-3 animate-pulse">
+            <div class="h-3 w-20 bg-neutral-300/70 dark:bg-neutral-700/70 rounded mb-3"></div>
+            <div class="h-8 bg-neutral-300/80 dark:bg-neutral-700/80 rounded"></div>
+          </div>
+        </div>
+        <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mt-6">
+          <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3 text-center">
+            <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">总评分</div>
+            <div class="text-2xl font-bold text-neutral-900 dark:text-neutral-100">{{ stats?.totalRating ?? '0' }}</div>
+          </div>
+          <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3 text-center">
+            <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">平均评分</div>
+            <div class="text-2xl font-bold text-neutral-900 dark:text-neutral-100">{{ stats?.meanRating ? Number(stats.meanRating).toFixed(1) : '0.0' }}</div>
+          </div>
+          <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3 text-center">
+            <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">作品数</div>
+            <div class="text-2xl font-bold text-neutral-900 dark:text-neutral-100">{{ stats?.pageCount ?? '0' }}</div>
+          </div>
+          <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3 text-center">
+            <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">投票</div>
+            <div class="flex items-center justify-center gap-4">
+              <span class="text-2xl font-bold text-green-600 dark:text-green-400">{{ stats?.votesUp ?? '0' }}</span>
+              <span class="text-neutral-400">/</span>
+              <span class="text-2xl font-bold text-red-600 dark:text-red-400">{{ stats?.votesDown ?? '0' }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Category Rankings / Radar -->
+      <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
+          <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">分类表现</h3>
+          <div class="inline-flex w-full sm:w-auto rounded-md overflow-hidden border border-neutral-200 dark:border-neutral-800 justify-center sm:justify-start">
+            <button type="button" class="px-2 py-1 text-xs"
+              :class="categoryView==='list' ? 'bg-[var(--g-accent)] text-white' : 'bg-transparent text-neutral-600 dark:text-neutral-300'"
+              @click="categoryView='list'">列表</button>
+            <button type="button" class="px-2 py-1 text-xs"
+              :class="categoryView==='radar' ? 'bg-[var(--g-accent)] text-white' : 'bg-transparent text-neutral-600 dark:text-neutral-300'"
+              @click="categoryView='radar'">雷达</button>
+          </div>
+        </div>
+        <div v-if="statsPending">
+          <div class="space-y-3">
+            <div v-for="n in 6" :key="`category-skeleton-${n}`" class="h-10 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-800" />
+          </div>
+        </div>
+        <div v-else-if="stats">
+          <div v-if="categoryView==='list'" class="space-y-3">
+            <CategoryRank label="SCP" :rank="stats.scpRank ?? '-'" :rating="stats.scpRating ?? 0" :count="stats.pageCountScp ?? 0" />
+            <CategoryRank label="故事" :rank="stats.storyRank ?? '-'" :rating="stats.storyRating ?? 0" :count="stats.pageCountTale ?? 0" />
+            <CategoryRank label="GoI格式" :rank="stats.goiRank ?? '-'" :rating="stats.goiRating ?? 0" :count="stats.pageCountGoiFormat ?? 0" />
+            <CategoryRank label="翻译" :rank="stats.translationRank ?? '-'" :rating="stats.translationRating ?? 0" :count="stats.translationPageCount ?? 0" />
+            <CategoryRank label="被放逐者的图书馆" :rank="stats.wanderersRank ?? '-'" :rating="stats.wanderersRating ?? 0" :count="stats.wanderersPageCount ?? 0" />
+            <CategoryRank label="艺术作品" :rank="stats.artRank ?? '-'" :rating="stats.artRating ?? 0" :count="stats.pageCountArtwork ?? 0" />
+          </div>
+          <div v-else>
+            <ClientOnly>
+              <UserCategoryRadarChart :user-stats="stats" />
+              <template #fallback>
+                <div class="h-72 flex items-center justify-center text-neutral-500 dark:text-neutral-400">加载雷达图中...</div>
+              </template>
+            </ClientOnly>
+          </div>
+        </div>
+        <div v-if="stats?.favTag" class="mt-4 pt-4 border-t border-neutral-200 dark:border-neutral-700">
+          <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">最爱标签</div>
+          <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400">
+            #{{ stats.favTag }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Public Collections -->
+    <section
+      v-if="publicCollectionsLoading || publicCollections.length > 0"
+      class="relative overflow-hidden rounded-lg border border-neutral-200/80 bg-white p-6 shadow-sm dark:border-neutral-800/70 dark:bg-neutral-950"
+    >
+      <div class="space-y-6">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <h3 class="flex items-center gap-2 text-base font-semibold text-neutral-800 dark:text-neutral-100">
+            <LucideIcon name="BookmarkPlus" class="h-5 w-5 text-[var(--g-accent)]" />
+            公开收藏夹
+          </h3>
+          <span v-if="!publicCollectionsLoading && publicCollections.length > 0" class="text-xs text-neutral-500 dark:text-neutral-400">
+            共 {{ publicCollections.length }} 个
+          </span>
+        </div>
+        <div v-if="publicCollectionsLoading" class="grid gap-4 md:grid-cols-2">
+          <div v-for="n in 3" :key="`collection-skeleton-${n}`" class="h-40 rounded-lg bg-neutral-100/80 animate-pulse dark:bg-neutral-800/60" />
+        </div>
+        <div v-else class="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+          <NuxtLink
+            v-for="collection in publicCollections"
+            :key="collection.id"
+            :to="`/user/${wikidotId}/collections/${collection.slug}`"
+            class="block rounded-lg focus:outline-none focus:ring-2 focus:ring-[var(--g-accent-border)]"
+          >
+            <CollectionCard :collection="collection" :show-visibility="false" :clickable="false">
+              <template #footer>
+                <span class="inline-flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
+                  <LucideIcon name="ArrowUpRight" class="h-3 w-3" />
+                  查看详情
+                </span>
+              </template>
+            </CollectionCard>
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+
+    <!-- Rating History Chart -->
+    <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
+      <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-4">评分历史趋势</h3>
+      <div v-if="ratingHistoryPending" class="h-64 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-800/70"></div>
+      <ClientOnly v-else-if="ratingHistory && ratingHistory.length > 0">
+        <RatingHistoryChart
+          :data="ratingHistory"
+          :first-activity-date="user?.firstActivityAt || '2022-06-15'"
+          :compact="true"
+          :allow-page-markers="true"
+          :target-total="stats?.totalRating || undefined"
+        />
+        <template #fallback>
+          <div class="h-64 flex items-center justify-center text-neutral-500 dark:text-neutral-400">
+            加载图表中...
+          </div>
+        </template>
+      </ClientOnly>
+      <div v-else class="text-sm text-neutral-500 dark:text-neutral-400">暂无评分历史数据</div>
+    </div>
+
+    <!-- Activity Heatmap -->
+    <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
+      <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between mb-4">
+        <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">过去一年活跃热力图</h3>
+        <span class="text-xs text-neutral-500 dark:text-neutral-400">绿色越深代表当天的投票与创作更多</span>
+      </div>
+      <UserActivityHeatmap
+        :records="activityHeatmapRecords"
+        :requested-range="activityHeatmapRange"
+        :pending="userDailyStatsPending"
+        :error="userDailyStatsError"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import CollectionCard from '~/components/collections/CollectionCard.vue'
+import type { CollectionSummary } from '~/composables/useCollections'
+import { formatDateUtc8 } from '~/utils/timezone'
+
+defineProps<{
+  wikidotId: string
+  user: any
+  stats: any
+  statsPending: boolean
+  // Collections
+  publicCollections: CollectionSummary[]
+  publicCollectionsLoading: boolean
+  // Rating history
+  ratingHistory: any
+  ratingHistoryPending: boolean
+  // Heatmap
+  activityHeatmapRecords: any[]
+  activityHeatmapRange: { startIso: string; endIso: string }
+  userDailyStatsPending: boolean
+  userDailyStatsError: any
+  // Follow
+  canFollow: boolean
+  isFollowingThis: boolean
+}>()
+
+defineEmits<{
+  'toggle-follow': []
+}>()
+
+const categoryView = ref<'list' | 'radar'>('list')
+
+function formatDate(dateStr: string) {
+  if (!dateStr) return 'N/A'
+  return formatDateUtc8(dateStr, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  }) || 'N/A'
+}
+
+function formatActivityType(type: string) {
+  const typeMap: Record<string, string> = {
+    'PAGE_CREATED': '创建页面',
+    'PAGE_EDITED': '编辑页面',
+    'PAGE_TRANSLATED': '翻译页面',
+    'VOTE_CAST': '投票',
+    'COMMENT_POSTED': '发表评论',
+    'VOTE': '投票',
+    'REVISION': '修订',
+    'FORUM_POST': '论坛发帖',
+    'forum_post': '论坛发帖',
+    'attribution': '页面归属',
+    'revision': '修订',
+    'vote': '投票',
+  }
+  return typeMap[type] || type
+}
+
+function isForumPostActivity(type: string | null | undefined) {
+  return String(type || '').toUpperCase() === 'FORUM_POST'
+}
+
+function forumPostLink(threadId: number | string | null | undefined, postId: number | string | null | undefined) {
+  const tid = Number(threadId)
+  if (!Number.isFinite(tid) || tid <= 0) return '/forums'
+  const pid = Number(postId)
+  if (Number.isFinite(pid) && pid > 0) {
+    return `/forums/t/${tid}?postId=${pid}`
+  }
+  return `/forums/t/${tid}`
+}
+
+function formatRevisionType(type: string) {
+  const typeMap: Record<string, string> = {
+    'PAGE_CREATED': '创建页面',
+    'PAGE_EDITED': '编辑内容',
+    'PAGE_RENAMED': '重命名',
+    'PAGE_DELETED': '删除',
+    'PAGE_RESTORED': '恢复',
+    'METADATA_CHANGED': '修改元数据',
+    'TAGS_CHANGED': '修改标签',
+    'SOURCE_CHANGED': '编辑内容',
+  }
+  return typeMap[type] || type
+}
+</script>

--- a/frontend/components/user/UserPreferences.vue
+++ b/frontend/components/user/UserPreferences.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
+    <div class="flex items-center justify-between mb-4">
+      <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">偏好一览</h3>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <!-- Favorite Authors with avatar -->
+      <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-4">
+        <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-2">最喜欢的作者</div>
+        <div v-if="likerAuthorsPending" class="space-y-2">
+          <div v-for="n in 3" :key="`fav-author-skeleton-${n}`" class="h-10 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-700/60" />
+        </div>
+        <div v-else-if="favAuthors && favAuthors.length > 0" class="space-y-2">
+          <div v-for="a in favAuthors" :key="`fa-${a.userId}`" class="flex items-center justify-between gap-3">
+            <div class="flex items-center gap-2 min-w-0">
+              <UserAvatar :wikidot-id="a.wikidotId" :name="a.displayName || String(a.wikidotId || a.userId)" :size="24" class="ring-1 ring-neutral-200 dark:ring-neutral-800" />
+              <NuxtLink :to="`/user/${a.wikidotId}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] truncate">
+                {{ a.displayName || a.wikidotId || a.userId }}
+              </NuxtLink>
+            </div>
+            <div class="text-xs shrink-0 inline-flex items-center gap-1">
+              <span class="px-2 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">+{{ a.uv }}</span>
+              <span class="px-2 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">-{{ a.dv }}</span>
+            </div>
+          </div>
+        </div>
+        <div v-else class="text-xs text-neutral-500 dark:text-neutral-400">暂无数据</div>
+        <div class="flex items-center justify-end gap-2 mt-3">
+          <button @click="$emit('prev-fav-authors')" :disabled="prefAuthorsOffset===0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
+          <button @click="$emit('next-fav-authors')" :disabled="!hasMoreFavAuthors" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
+        </div>
+      </div>
+
+      <!-- Fans -->
+      <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-4">
+        <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-2">我的粉丝</div>
+        <div v-if="fanAuthorsPending" class="space-y-2">
+          <div v-for="n in 3" :key="`fan-author-skeleton-${n}`" class="h-10 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-700/60" />
+        </div>
+        <div v-else-if="fanAuthors && fanAuthors.length > 0" class="space-y-2">
+          <div v-for="fan in fanAuthors" :key="`fan-${fan.userId}`" class="flex items-center justify-between gap-3">
+            <div class="flex items-center gap-2 min-w-0">
+              <UserAvatar :wikidot-id="fan.wikidotId" :name="fan.displayName || String(fan.wikidotId || fan.userId)" :size="24" class="ring-1 ring-neutral-200 dark:ring-neutral-800" />
+              <NuxtLink :to="`/user/${fan.wikidotId}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] truncate">
+                {{ fan.displayName || fan.wikidotId || fan.userId }}
+              </NuxtLink>
+            </div>
+            <div class="text-xs shrink-0 inline-flex items-center gap-1">
+              <span class="px-2 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">+{{ fan.uv }}</span>
+              <span class="px-2 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">-{{ fan.dv }}</span>
+            </div>
+          </div>
+        </div>
+        <div v-else class="text-xs text-neutral-500 dark:text-neutral-400">暂无数据</div>
+        <div class="flex items-center justify-end gap-2 mt-3">
+          <button @click="$emit('prev-fan-authors')" :disabled="prefFansOffset===0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
+          <button @click="$emit('next-fan-authors')" :disabled="!hasMoreFanAuthors" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
+        </div>
+      </div>
+
+      <!-- Favorite Tags -->
+      <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-4">
+        <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-2">最喜欢的标签</div>
+        <div v-if="likerTagsPending" class="space-y-2">
+          <div v-for="n in 4" :key="`fav-tag-skeleton-${n}`" class="h-8 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-700/60" />
+        </div>
+        <div v-else-if="favTags && favTags.length > 0" class="space-y-2">
+          <div v-for="t in favTags" :key="`ft-${t.tag}`" class="flex items-center justify-between">
+            <NuxtLink :to="`/search?tags=${encodeURIComponent(t.tag)}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] truncate">
+              #{{ t.tag }}
+            </NuxtLink>
+            <div class="text-xs shrink-0 inline-flex items-center gap-1">
+              <span class="px-2 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">+{{ t.uv }}</span>
+              <span class="px-2 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">-{{ t.dv }}</span>
+            </div>
+          </div>
+        </div>
+        <div v-else class="text-xs text-neutral-500 dark:text-neutral-400">暂无数据</div>
+        <div class="flex items-center justify-end gap-2 mt-3">
+          <button @click="$emit('prev-fav-tags')" :disabled="prefFavTagsOffset===0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
+          <button @click="$emit('next-fav-tags')" :disabled="!hasMoreFavTags" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
+        </div>
+      </div>
+
+      <!-- Most Hated Tags -->
+      <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-4">
+        <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-2">最讨厌的标签</div>
+        <div v-if="haterTagsPending" class="space-y-2">
+          <div v-for="n in 4" :key="`hate-tag-skeleton-${n}`" class="h-8 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-700/60" />
+        </div>
+        <div v-else-if="hateTags && hateTags.length > 0" class="space-y-2">
+          <div v-for="t in hateTags" :key="`ht-${t.tag}`" class="flex items-center justify-between">
+            <NuxtLink :to="`/search?excludeTags=${encodeURIComponent(t.tag)}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] truncate">
+              #{{ t.tag }}
+            </NuxtLink>
+            <div class="text-xs shrink-0 inline-flex items-center gap-1">
+              <span class="px-2 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">-{{ t.dv }}</span>
+              <span class="px-2 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">+{{ t.uv }}</span>
+            </div>
+          </div>
+        </div>
+        <div v-else class="text-xs text-neutral-500 dark:text-neutral-400">暂无数据</div>
+        <div class="flex items-center justify-end gap-2 mt-3">
+          <button @click="$emit('prev-hate-tags')" :disabled="prefHateTagsOffset===0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
+          <button @click="$emit('next-hate-tags')" :disabled="!hasMoreHateTags" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  // Authors
+  favAuthors: any[]
+  fanAuthors: any[]
+  likerAuthorsPending: boolean
+  fanAuthorsPending: boolean
+  hasMoreFavAuthors: boolean
+  hasMoreFanAuthors: boolean
+  prefAuthorsOffset: number
+  prefFansOffset: number
+  // Tags
+  favTags: Array<{ tag: string; uv: number; dv: number }>
+  hateTags: Array<{ tag: string; uv: number; dv: number }>
+  likerTagsPending: boolean
+  haterTagsPending: boolean
+  hasMoreFavTags: boolean
+  hasMoreHateTags: boolean
+  prefFavTagsOffset: number
+  prefHateTagsOffset: number
+}>()
+
+defineEmits<{
+  'prev-fav-authors': []
+  'next-fav-authors': []
+  'prev-fan-authors': []
+  'next-fan-authors': []
+  'prev-fav-tags': []
+  'next-fav-tags': []
+  'prev-hate-tags': []
+  'next-hate-tags': []
+}>()
+</script>

--- a/frontend/components/user/UserRevisions.vue
+++ b/frontend/components/user/UserRevisions.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="space-y-6">
+    <!-- Recent Revisions -->
+    <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
+      <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-4">最近编辑</h3>
+      <div v-if="revisionsPending" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+        <div v-for="n in 6" :key="`revision-skeleton-${n}`" class="h-20 rounded bg-neutral-100 animate-pulse dark:bg-neutral-800/70" />
+      </div>
+      <div v-else-if="revisions && revisions.length > 0" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+        <div v-for="revision in revisions" :key="`${revision.timestamp}-${revision.pageWikidotId}`"
+             class="p-2 rounded border border-neutral-200 dark:border-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-800">
+          <div class="flex items-center justify-between gap-2">
+            <span :class="['inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium shrink-0 w-[120px] justify-center', revisionTypeClass(revision.type)]">
+              {{ formatRevisionType(revision.type) }}
+            </span>
+            <div class="text-xs text-neutral-500 dark:text-neutral-400 whitespace-nowrap shrink-0">{{ formatRelativeTime(revision.timestamp) }}</div>
+          </div>
+          <NuxtLink :to="`/page/${revision.pageWikidotId}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] mt-1 block truncate">
+            {{ composeTitle(revision.pageTitle, revision.pageAlternateTitle) || 'Untitled' }}
+          </NuxtLink>
+          <div v-if="revision.comment" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;">{{ revision.comment }}</div>
+        </div>
+      </div>
+      <div v-else class="text-sm text-neutral-500 dark:text-neutral-400">暂无数据</div>
+      <div v-if="!revisionsPending && revisions && revisions.length > 0" class="flex items-center justify-between mt-3">
+        <button @click="$emit('prev-rev-page')" :disabled="revOffset === 0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
+        <div class="text-xs text-neutral-500 dark:text-neutral-400">第 {{ revPageIndex + 1 }} / {{ revTotalPages }} 页</div>
+        <button @click="$emit('next-rev-page')" :disabled="!revHasMore" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
+      </div>
+    </div>
+
+    <!-- Recent Forum Posts -->
+    <ClientOnly>
+      <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
+        <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-4">最近论坛发帖</h3>
+        <div v-if="forumPostsPending" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+          <div v-for="n in 6" :key="`forum-skeleton-${n}`" class="h-20 rounded bg-neutral-100 animate-pulse dark:bg-neutral-800/70" />
+        </div>
+        <div v-else-if="forumPosts && forumPosts.length > 0" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+          <NuxtLink
+            v-for="post in forumPosts"
+            :key="post.id"
+            :to="`/forums/t/${post.threadId}`"
+            class="p-2 rounded border border-neutral-200 dark:border-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-800 block"
+          >
+            <div class="flex items-center justify-between gap-2">
+              <span v-if="post.categoryTitle" class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium shrink-0 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 max-w-[120px] truncate">{{ post.categoryTitle }}</span>
+              <div class="text-xs text-neutral-500 dark:text-neutral-400 whitespace-nowrap shrink-0">{{ formatRelativeTime(String(post.createdAt ?? '')) }}</div>
+            </div>
+            <div class="text-sm font-medium text-neutral-900 dark:text-neutral-100 mt-1 truncate">{{ post.threadTitle || post.title || '无标题' }}</div>
+            <div v-if="post.textHtml" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;" v-html="stripHtml(post.textHtml)"></div>
+          </NuxtLink>
+        </div>
+        <div v-else class="text-sm text-neutral-500 dark:text-neutral-400">暂无论坛发帖</div>
+        <div v-if="!forumPostsPending && forumPosts && forumPosts.length > 0" class="flex items-center justify-between mt-3">
+          <button @click="$emit('prev-forum-page')" :disabled="forumPostPage === 1" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
+          <div class="text-xs text-neutral-500 dark:text-neutral-400">第 {{ forumPostPage }} / {{ forumTotalPages }} 页</div>
+          <button @click="$emit('next-forum-page')" :disabled="forumPostPage >= forumTotalPages" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
+        </div>
+      </div>
+    </ClientOnly>
+  </div>
+</template>
+
+<script setup lang="ts">
+type ForumPostItem = {
+  id: number
+  title?: string
+  textHtml?: string
+  createdAt?: string
+  threadId: number
+  threadTitle?: string
+  categoryId?: number
+  categoryTitle?: string
+  createdByName?: string
+}
+
+defineProps<{
+  // Revisions
+  revisions: any[]
+  revisionsPending: boolean
+  revOffset: number
+  revPageIndex: number
+  revTotalPages: number
+  revHasMore: boolean
+  // Forum Posts
+  forumPosts: ForumPostItem[]
+  forumPostsPending: boolean
+  forumPostPage: number
+  forumTotalPages: number
+}>()
+
+defineEmits<{
+  'prev-rev-page': []
+  'next-rev-page': []
+  'prev-forum-page': []
+  'next-forum-page': []
+}>()
+
+function revisionTypeClass(type: string) {
+  const t = String(type || '')
+  if (t === 'PAGE_CREATED' || t === 'PAGE_RESTORED') {
+    return 'bg-[var(--g-accent-soft)] dark:bg-[var(--g-accent-strong)] text-[var(--g-accent)]'
+  }
+  if (t === 'PAGE_EDITED') {
+    return 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+  }
+  if (t === 'PAGE_RENAMED') {
+    return 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400'
+  }
+  if (t === 'PAGE_DELETED') {
+    return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400'
+  }
+  if (t === 'METADATA_CHANGED') {
+    return 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
+  }
+  if (t === 'TAGS_CHANGED') {
+    return 'bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400'
+  }
+  if (t === 'SOURCE_CHANGED') {
+    return 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400'
+  }
+  return 'bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300'
+}
+
+function formatRevisionType(type: string) {
+  const typeMap: Record<string, string> = {
+    'PAGE_CREATED': '创建页面',
+    'PAGE_EDITED': '编辑内容',
+    'PAGE_RENAMED': '重命名',
+    'PAGE_DELETED': '删除',
+    'PAGE_RESTORED': '恢复',
+    'METADATA_CHANGED': '修改元数据',
+    'TAGS_CHANGED': '修改标签',
+    'SOURCE_CHANGED': '编辑内容',
+  }
+  return typeMap[type] || type
+}
+
+function composeTitle(title?: string | null, alternateTitle?: string | null) {
+  const base = typeof title === 'string' ? title.trim() : ''
+  const alt = typeof alternateTitle === 'string' ? alternateTitle.trim() : ''
+  if (alt) return base ? `${base} - ${alt}` : alt
+  return base
+}
+
+function formatRelativeTime(dateStr: string) {
+  if (!dateStr) return ''
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMin = Math.floor(diffMs / 60000)
+  if (diffMin < 60) return `${diffMin} 分钟前`
+  const diffH = Math.floor(diffMin / 60)
+  if (diffH < 24) return `${diffH} 小时前`
+  const diffD = Math.floor(diffH / 24)
+  if (diffD < 30) return `${diffD} 天前`
+  const diffM = Math.floor(diffD / 30)
+  if (diffM < 12) return `${diffM} 个月前`
+  return `${Math.floor(diffM / 12)} 年前`
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, '').trim().slice(0, 200)
+}
+</script>

--- a/frontend/components/user/UserVotes.vue
+++ b/frontend/components/user/UserVotes.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
+    <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-4">最近投票</h3>
+    <div v-if="pending" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+      <div v-for="n in 6" :key="`vote-skeleton-${n}`" class="h-16 rounded bg-neutral-100 animate-pulse dark:bg-neutral-800/70" />
+    </div>
+    <div v-else-if="votes && votes.length > 0" class="space-y-2">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+        <div v-for="vote in votes" :key="`${vote.timestamp}-${vote.pageWikidotId}`"
+             :class="[
+               'flex items-center justify-between p-2 rounded',
+               vote.direction > 0 ? 'bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800/40' :
+               vote.direction < 0 ? 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/40' :
+               'bg-neutral-50 dark:bg-neutral-800'
+             ]">
+          <div class="flex-1 min-w-0">
+            <NuxtLink :to="`/page/${vote.pageWikidotId}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] truncate block">
+              {{ composeTitle(vote.pageTitle, vote.pageAlternateTitle) || 'Untitled' }}
+            </NuxtLink>
+            <div class="text-xs text-neutral-600 dark:text-neutral-400">{{ formatRelativeTime(vote.timestamp) }}</div>
+          </div>
+          <div :class="[
+            'text-lg font-bold ml-2',
+            vote.direction > 0 ? 'text-green-600 dark:text-green-400' :
+            vote.direction < 0 ? 'text-red-600 dark:text-red-400' :
+            'text-neutral-600 dark:text-neutral-400'
+          ]">
+            {{ vote.direction > 0 ? '+1' : vote.direction < 0 ? '-1' : '0' }}
+          </div>
+        </div>
+      </div>
+      <div class="flex items-center justify-between mt-3">
+        <button @click="$emit('prev-page')" :disabled="offset === 0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
+        <div class="text-xs text-neutral-500 dark:text-neutral-400">第 {{ pageIndex + 1 }} / {{ totalPages }} 页</div>
+        <button @click="$emit('next-page')" :disabled="!hasMore" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
+      </div>
+    </div>
+    <div v-else class="text-sm text-neutral-500 dark:text-neutral-400">暂无数据</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  votes: any[]
+  pending: boolean
+  offset: number
+  pageIndex: number
+  totalPages: number
+  hasMore: boolean
+}>()
+
+defineEmits<{
+  'prev-page': []
+  'next-page': []
+}>()
+
+function composeTitle(title?: string | null, alternateTitle?: string | null) {
+  const base = typeof title === 'string' ? title.trim() : ''
+  const alt = typeof alternateTitle === 'string' ? alternateTitle.trim() : ''
+  if (alt) return base ? `${base} - ${alt}` : alt
+  return base
+}
+
+function formatRelativeTime(dateStr: string) {
+  if (!dateStr) return ''
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMin = Math.floor(diffMs / 60000)
+  if (diffMin < 60) return `${diffMin} 分钟前`
+  const diffH = Math.floor(diffMin / 60)
+  if (diffH < 24) return `${diffH} 小时前`
+  const diffD = Math.floor(diffH / 24)
+  if (diffD < 30) return `${diffD} 天前`
+  const diffM = Math.floor(diffD / 30)
+  if (diffM < 12) return `${diffM} 个月前`
+  return `${Math.floor(diffM / 12)} 年前`
+}
+</script>

--- a/frontend/components/user/UserWorks.vue
+++ b/frontend/components/user/UserWorks.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg bg-white dark:bg-neutral-900 shadow-sm">
+    <div class="border-b border-neutral-200 dark:border-neutral-800">
+      <nav class="flex items-center justify-between px-6" aria-label="Tabs">
+        <button
+          v-for="tab in workTabs"
+          :key="tab.key"
+          @click="$emit('update:activeTab', tab.key)"
+          :class="[
+            'py-3 px-1 border-b-2 font-medium text-sm transition-colors',
+            activeTab === tab.key
+              ? 'border-[var(--g-accent)] text-[var(--g-accent)]'
+              : 'border-transparent text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300'
+          ]"
+        >
+          {{ tab.label }}
+          <span v-if="tab.count !== null && tab.count !== undefined" class="ml-2 text-xs text-neutral-400">({{ tab.count }})</span>
+        </button>
+        <div class="flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400">
+          <label class="sr-only">排序</label>
+          <select :value="sortField" @change="$emit('update:sortField', ($event.target as HTMLSelectElement).value)" class="px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">
+            <option value="date">按时间</option>
+            <option value="rating">按Rating</option>
+          </select>
+          <select :value="sortOrder" @change="$emit('update:sortOrder', ($event.target as HTMLSelectElement).value)" class="px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">
+            <option value="desc">降序</option>
+            <option value="asc">升序</option>
+          </select>
+        </div>
+      </nav>
+    </div>
+
+    <!-- Works List -->
+    <div class="p-6">
+      <div v-if="worksPending" class="text-center py-8">
+        <LucideIcon name="Loader2" class="w-5 h-5 animate-spin text-[var(--g-accent)] mx-auto" stroke-width="2" />
+      </div>
+      <div v-else-if="!works || works.length === 0" class="text-center py-8 text-neutral-500 dark:text-neutral-400">
+        暂无{{ currentTabLabel }}作品
+      </div>
+      <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        <PageCard
+          v-for="work in displayedWorks"
+          :key="work.wikidotId"
+          size="md"
+          :p="work"
+          :authors="authors"
+        />
+      </div>
+
+      <!-- Pagination with selector -->
+      <div v-if="totalPages > 1" class="flex flex-wrap items-center justify-center gap-2 mt-6">
+        <button
+          @click="$emit('update:currentPage', Math.max(1, currentPage - 1))"
+          :disabled="currentPage === 1"
+          class="px-3 py-1 rounded text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700"
+        >上一页</button>
+        <div class="inline-flex items-center gap-1 text-sm text-neutral-600 dark:text-neutral-400">
+          第
+          <select :value="currentPage" @change="$emit('update:currentPage', Number(($event.target as HTMLSelectElement).value))" class="px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">
+            <option v-for="n in totalPages" :key="`wp-${n}`" :value="n">{{ n }}</option>
+          </select>
+          / {{ totalPages }} 页
+        </div>
+        <button
+          @click="$emit('update:currentPage', Math.min(totalPages, currentPage + 1))"
+          :disabled="currentPage === totalPages"
+          class="px-3 py-1 rounded text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700"
+        >下一页</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  workTabs: Array<{ key: string; label: string; count: number }>
+  activeTab: string
+  sortField: string
+  sortOrder: string
+  worksPending: boolean
+  works: any[] | null
+  displayedWorks: any[]
+  currentTabLabel: string
+  currentPage: number
+  totalPages: number
+  authors: Array<{ name: string; url: string }>
+}>()
+
+defineEmits<{
+  'update:activeTab': [key: string]
+  'update:sortField': [field: string]
+  'update:sortOrder': [order: string]
+  'update:currentPage': [page: number]
+}>()
+</script>

--- a/frontend/pages/user/[wikidotId].vue
+++ b/frontend/pages/user/[wikidotId].vue
@@ -12,586 +12,97 @@
         加载失败: {{ userError.message }}
       </div>
       <div v-else class="space-y-6">
-      <!-- Header -->
-      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between border-b-2 border-[var(--g-accent-medium)] dark:border-[var(--g-accent-strong)] pb-3 mb-4">
-        <div class="flex items-center gap-3">
-          <div class="h-8 w-1 bg-[var(--g-accent)] rounded" />
-          <h2 class="text-lg font-bold text-neutral-800 dark:text-neutral-100">用户详情</h2>
-        </div>
-        <div class="flex items-center gap-3 w-full sm:w-auto sm:justify-end">
-          <button
-            v-if="canFollow"
-            type="button"
-            :aria-label="isFollowingThis ? '取消收藏作者' : '收藏作者'"
-            :title="isFollowingThis ? '取消收藏作者' : '收藏作者'"
-            class="inline-flex items-center justify-center h-9 w-9 rounded-full border transition shadow-sm"
-            :class="isFollowingThis
-              ? 'border-[rgba(var(--accent),0.45)] bg-[var(--g-accent-soft)] text-[var(--g-accent)] dark:border-[rgba(var(--accent),0.45)]'
-              : 'border-neutral-200 bg-white/80 text-neutral-600 hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:bg-neutral-800/80 dark:text-neutral-300'"
-            @click="toggleFollow"
-          >
-            <!-- Use the same star geometry for both states to ensure equal visual size -->
-            <LucideIcon v-if="isFollowingThis" name="Star" class="w-5 h-5" stroke-width="1.8" fill="currentColor" />
-            <LucideIcon v-else name="Star" class="w-5 h-5" stroke-width="1.8" />
-          </button>
-        </div>
-      </div>
 
-      
+      <UserHeader
+        :wikidot-id="wikidotId"
+        :user="user"
+        :stats="stats"
+        :stats-pending="statsPending"
+        :public-collections="publicCollections"
+        :public-collections-loading="publicCollectionsLoading"
+        :rating-history="ratingHistory"
+        :rating-history-pending="ratingHistoryPending"
+        :activity-heatmap-records="activityHeatmapRecords"
+        :activity-heatmap-range="activityHeatmapRange"
+        :user-daily-stats-pending="userDailyStatsPending"
+        :user-daily-stats-error="userDailyStatsError"
+        :can-follow="canFollow"
+        :is-following-this="isFollowingThis"
+        @toggle-follow="toggleFollow"
+      />
 
-      <!-- User Info and Overall Stats -->
-      <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <!-- User Basic Info -->
-        <div class="lg:col-span-2 border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
-          <div class="flex flex-wrap items-start justify-between gap-4">
-            <div class="flex items-start gap-3 min-w-0 flex-1">
-              <UserAvatar :wikidot-id="wikidotId" :name="user?.displayName || 'Unknown User'" :size="56" class="shrink-0 ring-1 ring-neutral-200 dark:ring-neutral-800" />
-              <div class="min-w-0 flex-1">
-                <h1 class="text-xl sm:text-2xl font-bold text-neutral-900 dark:text-neutral-100 truncate">{{ user?.displayName || 'Unknown User' }}</h1>
-                <div class="mt-1 text-xs text-neutral-600 dark:text-neutral-400 flex items-center gap-2">
-                  <span>ID：{{ wikidotId }}</span>
-                  <span v-if="user?.isGuest" class="inline-flex items-center px-2 py-0.5 rounded bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400">访客</span>
-                </div>
-              </div>
-            </div>
-            <div v-if="statsPending" class="text-right shrink-0">
-              <div class="w-16 h-7 rounded bg-neutral-100 animate-pulse dark:bg-neutral-700/60 mb-1"></div>
-              <div class="w-20 h-3 rounded bg-neutral-100 animate-pulse dark:bg-neutral-700/60 ml-auto"></div>
-            </div>
-            <div v-else-if="stats?.rank" class="text-right shrink-0">
-              <div class="text-2xl sm:text-3xl font-bold text-[var(--g-accent)] whitespace-nowrap overflow-hidden">#{{ stats.rank }}</div>
-              <div class="text-xs text-neutral-600 dark:text-neutral-400">综合排名</div>
-            </div>
-          </div>
+      <UserWorks
+        :work-tabs="workTabs"
+        :active-tab="activeTab"
+        :sort-field="sortField"
+        :sort-order="sortOrder"
+        :works-pending="worksPending"
+        :works="works as any[] | null"
+        :displayed-works="displayedWorks"
+        :current-tab-label="currentTabLabel"
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        :authors="[{ name: user?.displayName || 'Unknown User', url: `/user/${wikidotId}` }]"
+        @update:active-tab="activeTab = $event"
+        @update:sort-field="sortField = $event as 'date' | 'rating'"
+        @update:sort-order="sortOrder = $event as 'asc' | 'desc'"
+        @update:current-page="currentPage = $event"
+      />
 
-          <!-- Activity Timeline -->
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-            <div v-if="user?.firstActivityAt" class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3">
-              <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">首次活动</div>
-              <div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">{{ formatDate(user.firstActivityAt) }}</div>
-              <div v-if="user?.firstActivityType && !isForumPostActivity(user?.firstActivityType)" class="text-xs text-neutral-500 dark:text-neutral-500 mt-1">
-                {{ formatActivityType(user.firstActivityType) }}
-              </div>
-              <div v-if="user?.firstActivityPageWikidotId || user?.firstActivityPageTitle" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden">
-                <div class="flex flex-wrap items-start gap-1">
-                  <NuxtLink :to="`/page/${user.firstActivityPageWikidotId}`" class="hover:text-[var(--g-accent)] truncate max-w-full block">
-                    {{ user.firstActivityPageTitle || '未知页面' }}
-                  </NuxtLink>
-                  <span v-if="user?.firstActivityType === 'VOTE'" :class="[
-                    'font-bold shrink-0',
-                    Number(user?.firstActivityDirection || 0) > 0 ? 'text-green-600 dark:text-green-400' : Number(user?.firstActivityDirection || 0) < 0 ? 'text-red-600 dark:text-red-400' : 'text-neutral-500 dark:text-neutral-500'
-                  ]">
-                    {{ Number(user?.firstActivityDirection || 0) > 0 ? '+1' : Number(user?.firstActivityDirection || 0) < 0 ? '-1' : '0' }}
-                  </span>
-                  <span v-else-if="user?.firstActivityType === 'REVISION' && user?.firstActivityRevisionType" class="text-neutral-500 dark:text-neutral-500 shrink-0">— {{ formatRevisionType(user.firstActivityRevisionType) }}</span>
-                </div>
-                <div v-if="user?.firstActivityComment" class="text-neutral-500 dark:text-neutral-500 mt-1 text-xs break-words overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;">
-                  — {{ user.firstActivityComment }}
-                </div>
-              </div>
-              <div v-else-if="isForumPostActivity(user?.firstActivityType)" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden">
-                <NuxtLink
-                  :to="forumPostLink(user?.firstActivityForumThreadId, user?.firstActivityForumPostId)"
-                  class="block text-xs font-medium text-neutral-700 dark:text-neutral-300 hover:text-[var(--g-accent)] break-words overflow-hidden"
-                  style="display: -webkit-box; -webkit-line-clamp: 1; line-clamp: 1; -webkit-box-orient: vertical;"
-                >
-                  发帖 - {{ user?.firstActivityForumThreadTitle || '论坛主题' }} - {{ user?.firstActivityForumPostTitle || '无标题' }}
-                </NuxtLink>
-                <div
-                  v-if="user?.firstActivityForumExcerpt"
-                  class="text-neutral-500 dark:text-neutral-500 mt-1 text-xs break-words overflow-hidden"
-                  style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;"
-                >
-                  {{ user.firstActivityForumExcerpt }}
-                </div>
-              </div>
-            </div>
-            <div v-if="user?.lastActivityAt" class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3">
-              <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">最近活动</div>
-              <div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">{{ formatDate(user.lastActivityAt) }}</div>
-              <div v-if="user?.lastActivityType && !isForumPostActivity(user?.lastActivityType)" class="text-xs text-neutral-500 dark:text-neutral-500 mt-1">
-                {{ formatActivityType(user.lastActivityType) }}
-              </div>
-              <div v-if="user?.lastActivityType === 'VOTE' && (user?.lastActivityPageWikidotId || user?.lastActivityPageTitle)" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden">
-                <div class="flex flex-wrap items-start gap-1">
-                  <span class="shrink-0">投票 ·</span>
-                  <NuxtLink :to="`/page/${user.lastActivityPageWikidotId}`" class="hover:text-[var(--g-accent)] truncate max-w-full block">
-                    {{ user.lastActivityPageTitle || '未知页面' }}
-                  </NuxtLink>
-                  <span :class="[
-                    'font-bold shrink-0',
-                    Number(user?.lastActivityDirection || 0) > 0 ? 'text-green-600 dark:text-green-400' : Number(user?.lastActivityDirection || 0) < 0 ? 'text-red-600 dark:text-red-400' : 'text-neutral-500 dark:text-neutral-500'
-                  ]">
-                    {{ Number(user?.lastActivityDirection || 0) > 0 ? '+1' : Number(user?.lastActivityDirection || 0) < 0 ? '-1' : '0' }}
-                  </span>
-                </div>
-              </div>
-              <div v-else-if="user?.lastActivityType === 'REVISION' && (user?.lastActivityPageWikidotId || user?.lastActivityPageTitle)" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden">
-                <div class="flex flex-wrap items-start gap-1">
-                  <span class="shrink-0">{{ formatRevisionType(user?.lastActivityRevisionType || '') }} ·</span>
-                  <NuxtLink :to="`/page/${user.lastActivityPageWikidotId}`" class="hover:text-[var(--g-accent)] truncate max-w-full block">
-                    {{ user.lastActivityPageTitle || '未知页面' }}
-                  </NuxtLink>
-                </div>
-                <div v-if="user?.lastActivityComment" class="text-neutral-500 dark:text-neutral-500 mt-1 text-xs break-words overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;">
-                  — {{ user.lastActivityComment }}
-                </div>
-              </div>
-              <div v-else-if="isForumPostActivity(user?.lastActivityType)" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden">
-                <NuxtLink
-                  :to="forumPostLink(user?.lastActivityForumThreadId, user?.lastActivityForumPostId)"
-                  class="block text-xs font-medium text-neutral-700 dark:text-neutral-300 hover:text-[var(--g-accent)] break-words overflow-hidden"
-                  style="display: -webkit-box; -webkit-line-clamp: 1; line-clamp: 1; -webkit-box-orient: vertical;"
-                >
-                  发帖 - {{ user?.lastActivityForumThreadTitle || '论坛主题' }} - {{ user?.lastActivityForumPostTitle || '无标题' }}
-                </NuxtLink>
-                <div
-                  v-if="user?.lastActivityForumExcerpt"
-                  class="text-neutral-500 dark:text-neutral-500 mt-1 text-xs break-words overflow-hidden"
-                  style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;"
-                >
-                  {{ user.lastActivityForumExcerpt }}
-                </div>
-              </div>
-            </div>
-          </div>
+      <UserPreferences
+        :fav-authors="favAuthors"
+        :fan-authors="fanAuthors"
+        :liker-authors-pending="likerAuthorsPending"
+        :fan-authors-pending="fanAuthorsPending"
+        :has-more-fav-authors="hasMoreFavAuthors"
+        :has-more-fan-authors="hasMoreFanAuthors"
+        :pref-authors-offset="prefAuthorsOffset"
+        :pref-fans-offset="prefFansOffset"
+        :fav-tags="favTags"
+        :hate-tags="hateTags"
+        :liker-tags-pending="likerTagsPending"
+        :hater-tags-pending="haterTagsPending"
+        :has-more-fav-tags="hasMoreFavTags"
+        :has-more-hate-tags="hasMoreHateTags"
+        :pref-fav-tags-offset="prefFavTagsOffset"
+        :pref-hate-tags-offset="prefHateTagsOffset"
+        @prev-fav-authors="prevFavAuthorsPage"
+        @next-fav-authors="nextFavAuthorsPage"
+        @prev-fan-authors="prevFanAuthorsPage"
+        @next-fan-authors="nextFanAuthorsPage"
+        @prev-fav-tags="prevFavTagsPage"
+        @next-fav-tags="nextFavTagsPage"
+        @prev-hate-tags="prevHateTagsPage"
+        @next-hate-tags="nextHateTagsPage"
+      />
 
-          <!-- Overall Stats Grid -->
-          <div v-if="statsPending" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mt-6">
-            <div v-for="n in 4" :key="`stats-skeleton-${n}`" class="bg-neutral-100 dark:bg-neutral-800 rounded-lg p-3 animate-pulse">
-              <div class="h-3 w-20 bg-neutral-300/70 dark:bg-neutral-700/70 rounded mb-3"></div>
-              <div class="h-8 bg-neutral-300/80 dark:bg-neutral-700/80 rounded"></div>
-            </div>
-          </div>
-          <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mt-6">
-            <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3 text-center">
-              <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">总评分</div>
-              <div class="text-2xl font-bold text-neutral-900 dark:text-neutral-100">{{ stats?.totalRating ?? '0' }}</div>
-            </div>
-            <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3 text-center">
-              <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">平均评分</div>
-              <div class="text-2xl font-bold text-neutral-900 dark:text-neutral-100">{{ stats?.meanRating ? Number(stats.meanRating).toFixed(1) : '0.0' }}</div>
-            </div>
-            <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3 text-center">
-              <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">作品数</div>
-              <div class="text-2xl font-bold text-neutral-900 dark:text-neutral-100">{{ stats?.pageCount ?? '0' }}</div>
-            </div>
-            <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-3 text-center">
-              <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">投票</div>
-              <div class="flex items-center justify-center gap-4">
-                <span class="text-2xl font-bold text-green-600 dark:text-green-400">{{ stats?.votesUp ?? '0' }}</span>
-                <span class="text-neutral-400">/</span>
-                <span class="text-2xl font-bold text-red-600 dark:text-red-400">{{ stats?.votesDown ?? '0' }}</span>
-              </div>
-            </div>
-          </div>
-        </div>
+      <UserVotes
+        :votes="recentVotes"
+        :pending="userVotesPending"
+        :offset="userVoteOffset"
+        :page-index="userVotePageIndex"
+        :total-pages="userVoteTotalPages"
+        :has-more="userHasMoreVotes"
+        @prev-page="prevUserVotePage"
+        @next-page="nextUserVotePage"
+      />
 
-        <!-- Category Rankings / Radar -->
-        <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
-          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
-            <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">分类表现</h3>
-            <div class="inline-flex w-full sm:w-auto rounded-md overflow-hidden border border-neutral-200 dark:border-neutral-800 justify-center sm:justify-start">
-              <button type="button" class="px-2 py-1 text-xs"
-                :class="categoryView==='list' ? 'bg-[var(--g-accent)] text-white' : 'bg-transparent text-neutral-600 dark:text-neutral-300'"
-                @click="categoryView='list'">列表</button>
-              <button type="button" class="px-2 py-1 text-xs"
-                :class="categoryView==='radar' ? 'bg-[var(--g-accent)] text-white' : 'bg-transparent text-neutral-600 dark:text-neutral-300'"
-                @click="categoryView='radar'">雷达</button>
-            </div>
-          </div>
-          <div v-if="statsPending">
-            <div class="space-y-3">
-              <div v-for="n in 6" :key="`category-skeleton-${n}`" class="h-10 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-800" />
-            </div>
-          </div>
-          <div v-else-if="stats">
-            <div v-if="categoryView==='list'" class="space-y-3">
-              <CategoryRank label="SCP" :rank="stats.scpRank ?? '-'" :rating="stats.scpRating ?? 0" :count="stats.pageCountScp ?? 0" />
-              <CategoryRank label="故事" :rank="stats.storyRank ?? '-'" :rating="stats.storyRating ?? 0" :count="stats.pageCountTale ?? 0" />
-              <CategoryRank label="GoI格式" :rank="stats.goiRank ?? '-'" :rating="stats.goiRating ?? 0" :count="stats.pageCountGoiFormat ?? 0" />
-              <CategoryRank label="翻译" :rank="stats.translationRank ?? '-'" :rating="stats.translationRating ?? 0" :count="stats.translationPageCount ?? 0" />
-              <CategoryRank label="被放逐者的图书馆" :rank="stats.wanderersRank ?? '-'" :rating="stats.wanderersRating ?? 0" :count="stats.wanderersPageCount ?? 0" />
-              <CategoryRank label="艺术作品" :rank="stats.artRank ?? '-'" :rating="stats.artRating ?? 0" :count="stats.pageCountArtwork ?? 0" />
-            </div>
-            <div v-else>
-              <ClientOnly>
-                <UserCategoryRadarChart :user-stats="stats" />
-                <template #fallback>
-                  <div class="h-72 flex items-center justify-center text-neutral-500 dark:text-neutral-400">加载雷达图中...</div>
-                </template>
-              </ClientOnly>
-            </div>
-          </div>
-          <div v-if="stats?.favTag" class="mt-4 pt-4 border-t border-neutral-200 dark:border-neutral-700">
-            <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-1">最爱标签</div>
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400">
-              #{{ stats.favTag }}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      <section
-        v-if="publicCollectionsLoading || publicCollections.length > 0"
-        class="relative overflow-hidden rounded-lg border border-neutral-200/80 bg-white p-6 shadow-sm dark:border-neutral-800/70 dark:bg-neutral-950"
-      >
-        <div class="space-y-6">
-          <div class="flex flex-wrap items-center justify-between gap-3">
-            <h3 class="flex items-center gap-2 text-base font-semibold text-neutral-800 dark:text-neutral-100">
-              <LucideIcon name="BookmarkPlus" class="h-5 w-5 text-[var(--g-accent)]" />
-              公开收藏夹
-            </h3>
-            <span v-if="!publicCollectionsLoading && publicCollections.length > 0" class="text-xs text-neutral-500 dark:text-neutral-400">
-              共 {{ publicCollections.length }} 个
-            </span>
-          </div>
-          <div v-if="publicCollectionsLoading" class="grid gap-4 md:grid-cols-2">
-            <div v-for="n in 3" :key="`collection-skeleton-${n}`" class="h-40 rounded-lg bg-neutral-100/80 animate-pulse dark:bg-neutral-800/60" />
-          </div>
-          <div v-else class="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-            <NuxtLink
-              v-for="collection in publicCollections"
-              :key="collection.id"
-              :to="`/user/${wikidotId}/collections/${collection.slug}`"
-              class="block rounded-lg focus:outline-none focus:ring-2 focus:ring-[var(--g-accent-border)]"
-            >
-              <CollectionCard :collection="collection" :show-visibility="false" :clickable="false">
-                <template #footer>
-                  <span class="inline-flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
-                    <LucideIcon name="ArrowUpRight" class="h-3 w-3" />
-                    查看详情
-                  </span>
-                </template>
-              </CollectionCard>
-            </NuxtLink>
-          </div>
-        </div>
-      </section>
-
-      <!-- Rating History Chart -->
-      <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
-        <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-4">评分历史趋势</h3>
-        <div v-if="ratingHistoryPending" class="h-64 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-800/70"></div>
-        <ClientOnly v-else-if="ratingHistory && ratingHistory.length > 0">
-          <RatingHistoryChart 
-            :data="ratingHistory" 
-            :first-activity-date="user?.firstActivityAt || '2022-06-15'"
-            :compact="true"
-            :allow-page-markers="true"
-            :target-total="stats?.totalRating || undefined"
-          />
-          <template #fallback>
-            <div class="h-64 flex items-center justify-center text-neutral-500 dark:text-neutral-400">
-              加载图表中...
-            </div>
-          </template>
-        </ClientOnly>
-        <div v-else class="text-sm text-neutral-500 dark:text-neutral-400">暂无评分历史数据</div>
-      </div>
-
-      
-      <!-- Activity Heatmap -->
-      <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
-        <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between mb-4">
-          <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">过去一年活跃热力图</h3>
-          <span class="text-xs text-neutral-500 dark:text-neutral-400">绿色越深代表当天的投票与创作更多</span>
-        </div>
-        <UserActivityHeatmap
-          :records="activityHeatmapRecords"
-          :requested-range="activityHeatmapRange"
-          :pending="userDailyStatsPending"
-          :error="userDailyStatsError"
-        />
-      </div>
-
-      
-      <!-- Works Tabs -->
-      <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg bg-white dark:bg-neutral-900 shadow-sm">
-        <div class="border-b border-neutral-200 dark:border-neutral-800">
-          <nav class="flex items-center justify-between px-6" aria-label="Tabs">
-            <button
-              v-for="tab in workTabs"
-              :key="tab.key"
-              @click="activeTab = tab.key"
-              :class="[
-                'py-3 px-1 border-b-2 font-medium text-sm transition-colors',
-                activeTab === tab.key
-                  ? 'border-[var(--g-accent)] text-[var(--g-accent)]'
-                  : 'border-transparent text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300'
-              ]"
-            >
-              {{ tab.label }}
-              <span v-if="tab.count !== null && tab.count !== undefined" class="ml-2 text-xs text-neutral-400">({{ tab.count }})</span>
-            </button>
-            <div class="flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400">
-              <label class="sr-only">排序</label>
-              <select v-model="sortField" class="px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">
-                <option value="date">按时间</option>
-                <option value="rating">按Rating</option>
-              </select>
-              <select v-model="sortOrder" class="px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">
-                <option value="desc">降序</option>
-                <option value="asc">升序</option>
-              </select>
-            </div>
-          </nav>
-          
-        </div>
-
-        <!-- Works List -->
-        <div class="p-6">
-          <div v-if="worksPending" class="text-center py-8">
-            <LucideIcon name="Loader2" class="w-5 h-5 animate-spin text-[var(--g-accent)] mx-auto" stroke-width="2" />
-          </div>
-          <div v-else-if="!works || works.length === 0" class="text-center py-8 text-neutral-500 dark:text-neutral-400">
-            暂无{{ currentTabLabel }}作品
-          </div>
-          <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-            <PageCard
-              v-for="work in displayedWorks"
-              :key="work.wikidotId"
-              size="md"
-              :p="normalizeWork(work)"
-              :authors="[{ name: user?.displayName || 'Unknown User', url: `/user/${wikidotId}` }]"
-            />
-          </div>
-
-          <!-- Pagination with selector -->
-          <div v-if="totalPages > 1" class="flex flex-wrap items-center justify-center gap-2 mt-6">
-            <button
-              @click="currentPage = Math.max(1, currentPage - 1)"
-              :disabled="currentPage === 1"
-              class="px-3 py-1 rounded text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700"
-            >上一页</button>
-            <div class="inline-flex items-center gap-1 text-sm text-neutral-600 dark:text-neutral-400">
-              第
-              <select v-model.number="currentPage" class="px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800">
-                <option v-for="n in totalPages" :key="`wp-${n}`" :value="n">{{ n }}</option>
-              </select>
-              / {{ totalPages }} 页
-            </div>
-            <button
-              @click="currentPage = Math.min(totalPages, currentPage + 1)"
-              :disabled="currentPage === totalPages"
-              class="px-3 py-1 rounded text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700"
-            >下一页</button>
-          </div>
-        </div>
-      </div>
-
-      <!-- Preferences Summary (2x2 on desktop, 1x4 on mobile) - moved below Works and above Recent Activity -->
-      <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
-        <div class="flex items-center justify-between mb-4">
-          <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300">偏好一览</h3>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <!-- Favorite Authors with avatar -->
-          <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-4">
-            <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-2">最喜欢的作者</div>
-            <div v-if="likerAuthorsPending" class="space-y-2">
-              <div v-for="n in 3" :key="`fav-author-skeleton-${n}`" class="h-10 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-700/60" />
-            </div>
-            <div v-else-if="favAuthors && favAuthors.length > 0" class="space-y-2">
-              <div v-for="a in favAuthors" :key="`fa-${a.userId}`" class="flex items-center justify-between gap-3">
-                <div class="flex items-center gap-2 min-w-0">
-                  <UserAvatar :wikidot-id="a.wikidotId" :name="a.displayName || String(a.wikidotId || a.userId)" :size="24" class="ring-1 ring-neutral-200 dark:ring-neutral-800" />
-                  <NuxtLink :to="`/user/${a.wikidotId}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] truncate">
-                    {{ a.displayName || a.wikidotId || a.userId }}
-                  </NuxtLink>
-                </div>
-                <div class="text-xs shrink-0 inline-flex items-center gap-1">
-                  <span class="px-2 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">+{{ a.uv }}</span>
-                  <span class="px-2 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">-{{ a.dv }}</span>
-                </div>
-              </div>
-            </div>
-            <div v-else class="text-xs text-neutral-500 dark:text-neutral-400">暂无数据</div>
-            <div class="flex items-center justify-end gap-2 mt-3">
-              <button @click="prevFavAuthorsPage" :disabled="prefAuthorsOffset===0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
-              <button @click="nextFavAuthorsPage" :disabled="!hasMoreFavAuthors" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
-            </div>
-          </div>
-
-          <!-- Fans -->
-          <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-4">
-            <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-2">我的粉丝</div>
-            <div v-if="fanAuthorsPending" class="space-y-2">
-              <div v-for="n in 3" :key="`fan-author-skeleton-${n}`" class="h-10 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-700/60" />
-            </div>
-            <div v-else-if="fanAuthors && fanAuthors.length > 0" class="space-y-2">
-              <div v-for="fan in fanAuthors" :key="`fan-${fan.userId}`" class="flex items-center justify-between gap-3">
-                <div class="flex items-center gap-2 min-w-0">
-                  <UserAvatar :wikidot-id="fan.wikidotId" :name="fan.displayName || String(fan.wikidotId || fan.userId)" :size="24" class="ring-1 ring-neutral-200 dark:ring-neutral-800" />
-                  <NuxtLink :to="`/user/${fan.wikidotId}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] truncate">
-                    {{ fan.displayName || fan.wikidotId || fan.userId }}
-                  </NuxtLink>
-                </div>
-                <div class="text-xs shrink-0 inline-flex items-center gap-1">
-                  <span class="px-2 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">+{{ fan.uv }}</span>
-                  <span class="px-2 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">-{{ fan.dv }}</span>
-                </div>
-              </div>
-            </div>
-            <div v-else class="text-xs text-neutral-500 dark:text-neutral-400">暂无数据</div>
-            <div class="flex items-center justify-end gap-2 mt-3">
-              <button @click="prevFanAuthorsPage" :disabled="prefFansOffset===0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
-              <button @click="nextFanAuthorsPage" :disabled="!hasMoreFanAuthors" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
-            </div>
-          </div>
-
-          <!-- Favorite Tags -->
-          <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-4">
-            <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-2">最喜欢的标签</div>
-            <div v-if="likerTagsPending" class="space-y-2">
-              <div v-for="n in 4" :key="`fav-tag-skeleton-${n}`" class="h-8 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-700/60" />
-            </div>
-            <div v-else-if="favTags && favTags.length > 0" class="space-y-2">
-              <div v-for="t in favTags" :key="`ft-${t.tag}`" class="flex items-center justify-between">
-                <NuxtLink :to="`/search?tags=${encodeURIComponent(t.tag)}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] truncate">
-                  #{{ t.tag }}
-                </NuxtLink>
-                <div class="text-xs shrink-0 inline-flex items-center gap-1">
-                  <span class="px-2 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">+{{ t.uv }}</span>
-                  <span class="px-2 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">-{{ t.dv }}</span>
-                </div>
-              </div>
-            </div>
-            <div v-else class="text-xs text-neutral-500 dark:text-neutral-400">暂无数据</div>
-            <div class="flex items-center justify-end gap-2 mt-3">
-              <button @click="prevFavTagsPage" :disabled="prefFavTagsOffset===0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
-              <button @click="nextFavTagsPage" :disabled="!hasMoreFavTags" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
-            </div>
-          </div>
-
-          <!-- Most Hated Tags -->
-          <div class="bg-neutral-50 dark:bg-neutral-800 rounded-lg p-4">
-            <div class="text-xs text-neutral-600 dark:text-neutral-400 mb-2">最讨厌的标签</div>
-            <div v-if="haterTagsPending" class="space-y-2">
-              <div v-for="n in 4" :key="`hate-tag-skeleton-${n}`" class="h-8 rounded-lg bg-neutral-100 animate-pulse dark:bg-neutral-700/60" />
-            </div>
-            <div v-else-if="hateTags && hateTags.length > 0" class="space-y-2">
-              <div v-for="t in hateTags" :key="`ht-${t.tag}`" class="flex items-center justify-between">
-                <NuxtLink :to="`/search?excludeTags=${encodeURIComponent(t.tag)}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] truncate">
-                  #{{ t.tag }}
-                </NuxtLink>
-                <div class="text-xs shrink-0 inline-flex items-center gap-1">
-                  <span class="px-2 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">-{{ t.dv }}</span>
-                  <span class="px-2 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">+{{ t.uv }}</span>
-                </div>
-              </div>
-            </div>
-            <div v-else class="text-xs text-neutral-500 dark:text-neutral-400">暂无数据</div>
-            <div class="flex items-center justify-end gap-2 mt-3">
-              <button @click="prevHateTagsPage" :disabled="prefHateTagsOffset===0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
-              <button @click="nextHateTagsPage" :disabled="!hasMoreHateTags" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Recent Activity -->
-      <div class="space-y-6">
-        <!-- Recent Votes -->
-        <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
-          <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-4">最近投票</h3>
-          <div v-if="userVotesPending" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-            <div v-for="n in 6" :key="`vote-skeleton-${n}`" class="h-16 rounded bg-neutral-100 animate-pulse dark:bg-neutral-800/70" />
-          </div>
-          <div v-else-if="recentVotes && recentVotes.length > 0" class="space-y-2">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-              <div v-for="vote in recentVotes" :key="`${vote.timestamp}-${vote.pageWikidotId}`" 
-                   :class="[
-                     'flex items-center justify-between p-2 rounded',
-                     vote.direction > 0 ? 'bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800/40' :
-                     vote.direction < 0 ? 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/40' :
-                     'bg-neutral-50 dark:bg-neutral-800'
-                   ]">
-                <div class="flex-1 min-w-0">
-                  <NuxtLink :to="`/page/${vote.pageWikidotId}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] truncate block">
-                    {{ composeTitle(vote.pageTitle, vote.pageAlternateTitle) || 'Untitled' }}
-                  </NuxtLink>
-                  <div class="text-xs text-neutral-600 dark:text-neutral-400">{{ formatRelativeTime(vote.timestamp) }}</div>
-                </div>
-                <div :class="[
-                  'text-lg font-bold ml-2',
-                  vote.direction > 0 ? 'text-green-600 dark:text-green-400' : 
-                  vote.direction < 0 ? 'text-red-600 dark:text-red-400' : 
-                  'text-neutral-600 dark:text-neutral-400'
-                ]">
-                  {{ vote.direction > 0 ? '+1' : vote.direction < 0 ? '-1' : '0' }}
-                </div>
-              </div>
-            </div>
-            <div class="flex items-center justify-between mt-3">
-              <button @click="prevUserVotePage" :disabled="userVoteOffset === 0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
-              <div class="text-xs text-neutral-500 dark:text-neutral-400">第 {{ userVotePageIndex + 1 }} / {{ userVoteTotalPages }} 页</div>
-              <button @click="nextUserVotePage" :disabled="!userHasMoreVotes" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
-            </div>
-          </div>
-          <div v-else class="text-sm text-neutral-500 dark:text-neutral-400">暂无数据</div>
-        </div>
-
-        <!-- Recent Revisions -->
-        <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
-          <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-4">最近编辑</h3>
-          <div v-if="userRevisionsPending" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-            <div v-for="n in 6" :key="`revision-skeleton-${n}`" class="h-20 rounded bg-neutral-100 animate-pulse dark:bg-neutral-800/70" />
-          </div>
-          <div v-else-if="recentRevisions && recentRevisions.length > 0" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-            <div v-for="revision in recentRevisions" :key="`${revision.timestamp}-${revision.pageWikidotId}`" 
-                 class="p-2 rounded border border-neutral-200 dark:border-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-800">
-              <div class="flex items-center justify-between gap-2">
-                <span :class="['inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium shrink-0 w-[120px] justify-center', revisionTypeClass(revision.type)]">
-                  {{ formatRevisionType(revision.type) }}
-                </span>
-                <div class="text-xs text-neutral-500 dark:text-neutral-400 whitespace-nowrap shrink-0">{{ formatRelativeTime(revision.timestamp) }}</div>
-              </div>
-              <NuxtLink :to="`/page/${revision.pageWikidotId}`" class="text-sm font-medium text-neutral-900 dark:text-neutral-100 hover:text-[var(--g-accent)] mt-1 block truncate">
-                {{ composeTitle(revision.pageTitle, revision.pageAlternateTitle) || 'Untitled' }}
-              </NuxtLink>
-              <div v-if="revision.comment" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;">{{ revision.comment }}</div>
-            </div>
-          </div>
-          <div v-else class="text-sm text-neutral-500 dark:text-neutral-400">暂无数据</div>
-          <div v-if="!userRevisionsPending && recentRevisions && recentRevisions.length > 0" class="flex items-center justify-between mt-3">
-            <button @click="prevUserRevPage" :disabled="userRevOffset === 0" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
-            <div class="text-xs text-neutral-500 dark:text-neutral-400">第 {{ userRevPageIndex + 1 }} / {{ userRevTotalPages }} 页</div>
-            <button @click="nextUserRevPage" :disabled="!userHasMoreRevisions" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
-          </div>
-        </div>
-      </div>
-
-      <!-- Recent Forum Posts -->
-      <ClientOnly>
-        <div class="border border-neutral-200 dark:border-neutral-800 rounded-lg p-6 bg-white dark:bg-neutral-900 shadow-sm">
-          <h3 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300 mb-4">最近论坛发帖</h3>
-          <div v-if="forumPostsPending" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-            <div v-for="n in 6" :key="`forum-skeleton-${n}`" class="h-20 rounded bg-neutral-100 animate-pulse dark:bg-neutral-800/70" />
-          </div>
-          <div v-else-if="forumPosts && forumPosts.length > 0" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-            <NuxtLink
-              v-for="post in forumPosts"
-              :key="post.id"
-              :to="`/forums/t/${post.threadId}`"
-              class="p-2 rounded border border-neutral-200 dark:border-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-800 block"
-            >
-              <div class="flex items-center justify-between gap-2">
-                <span v-if="post.categoryTitle" class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium shrink-0 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 max-w-[120px] truncate">{{ post.categoryTitle }}</span>
-                <div class="text-xs text-neutral-500 dark:text-neutral-400 whitespace-nowrap shrink-0">{{ formatRelativeTime(String(post.createdAt ?? '')) }}</div>
-              </div>
-              <div class="text-sm font-medium text-neutral-900 dark:text-neutral-100 mt-1 truncate">{{ post.threadTitle || post.title || '无标题' }}</div>
-              <div v-if="post.textHtml" class="text-xs text-neutral-600 dark:text-neutral-400 mt-1 break-words overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical;" v-html="stripHtml(post.textHtml)"></div>
-            </NuxtLink>
-          </div>
-          <div v-else class="text-sm text-neutral-500 dark:text-neutral-400">暂无论坛发帖</div>
-          <div v-if="!forumPostsPending && forumPosts && forumPosts.length > 0" class="flex items-center justify-between mt-3">
-            <button @click="prevForumPage" :disabled="forumPostPage === 1" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">上一页</button>
-            <div class="text-xs text-neutral-500 dark:text-neutral-400">第 {{ forumPostPage }} / {{ forumTotalPages }} 页</div>
-            <button @click="nextForumPage" :disabled="forumPostPage >= forumTotalPages" class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 disabled:opacity-50">下一页</button>
-          </div>
-        </div>
-      </ClientOnly>
+      <UserRevisions
+        :revisions="recentRevisions"
+        :revisions-pending="userRevisionsPending"
+        :rev-offset="userRevOffset"
+        :rev-page-index="userRevPageIndex"
+        :rev-total-pages="userRevTotalPages"
+        :rev-has-more="userHasMoreRevisions"
+        :forum-posts="forumPosts"
+        :forum-posts-pending="forumPostsPending"
+        :forum-post-page="forumPostPage"
+        :forum-total-pages="forumTotalPages"
+        @prev-rev-page="prevUserRevPage"
+        @next-rev-page="nextUserRevPage"
+        @prev-forum-page="prevForumPage"
+        @next-forum-page="nextForumPage"
+      />
 
       </div>
     </div>
@@ -606,10 +117,14 @@ definePageMeta({ key: route => route.fullPath })
 import { useAuth } from '~/composables/useAuth'
 import { useFollows } from '~/composables/useFollows'
 import { useCollections, type CollectionSummary } from '~/composables/useCollections'
-import CollectionCard from '~/components/collections/CollectionCard.vue'
 import { useViewerVotes } from '~/composables/useViewerVotes'
 import { orderTags } from '~/composables/useTagOrder'
-import { formatDateUtc8, formatDateIsoUtc8, diffUtc8CalendarDays, startOfUtc8Day, nowUtc8 } from '~/utils/timezone'
+import { formatDateUtc8, formatDateIsoUtc8, startOfUtc8Day, nowUtc8 } from '~/utils/timezone'
+import UserHeader from '~/components/user/UserHeader.vue'
+import UserWorks from '~/components/user/UserWorks.vue'
+import UserPreferences from '~/components/user/UserPreferences.vue'
+import UserVotes from '~/components/user/UserVotes.vue'
+import UserRevisions from '~/components/user/UserRevisions.vue'
 
 type UserDailyStatRecord = {
   date: string;
@@ -654,7 +169,6 @@ const currentPage = ref(1);
 // Sorting (server-side)
 const sortField = ref<'date'|'rating'>('date')
 const sortOrder = ref<'asc'|'desc'>('desc')
-const categoryView = ref<'list'|'radar'>('list')
 // Responsive items per page for works list
 const itemsPerPage = ref(10);
 if (isClient) {
@@ -689,31 +203,6 @@ const userPageTitle = computed(() => {
   return name ? '用户：' + name : '用户详情'
 })
 
-function revisionTypeClass(type: string) {
-  const t = String(type || '')
-  if (t === 'PAGE_CREATED' || t === 'PAGE_RESTORED') {
-    return 'bg-[var(--g-accent-soft)] dark:bg-[var(--g-accent-strong)] text-[var(--g-accent)]'
-  }
-  if (t === 'PAGE_EDITED') {
-    return 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
-  }
-  if (t === 'PAGE_RENAMED') {
-    return 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400'
-  }
-  if (t === 'PAGE_DELETED') {
-    return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400'
-  }
-  if (t === 'METADATA_CHANGED') {
-    return 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
-  }
-  if (t === 'TAGS_CHANGED') {
-    return 'bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400'
-  }
-  if (t === 'SOURCE_CHANGED') {
-    return 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400'
-  }
-  return 'bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300'
-}
 useHead(() => {
   const title = userPageTitle.value
   const description = user.value?.displayName
@@ -922,8 +411,8 @@ const { data: stats, pending: statsPending } = await useAsyncData(
 const { data: works, pending: worksPending, refresh: refreshWorks } = await useAsyncData(
   () => `user-works-${wikidotId.value}-${activeTab.value}-${sortField.value}-${sortOrder.value}-${currentPage.value}-${itemsPerPage.value}`,
   async () => {
-    const params: any = { 
-      limit: itemsPerPage.value, 
+    const params: any = {
+      limit: itemsPerPage.value,
       offset: (Math.max(1, Number(currentPage.value || 1)) - 1) * Math.max(1, Number(itemsPerPage.value || 10)),
       sortBy: (sortField.value === 'rating') ? 'rating' : 'date',
       sortDir: (sortOrder.value === 'asc') ? 'asc' : 'desc',
@@ -950,9 +439,9 @@ const userVotePageSize = ref(10)
 if (isClient) {
   const computeVotePageSize = () => {
     const width = window.innerWidth
-    if (width >= 1024) return 12 // 3列时每页12个
-    if (width >= 768) return 10  // 2列时每页10个
-    return 12                    // 1列时可多一些
+    if (width >= 1024) return 12
+    if (width >= 768) return 10
+    return 12
   }
   userVotePageSize.value = computeVotePageSize()
   window.addEventListener('resize', () => {
@@ -1024,8 +513,8 @@ const userRevPageSize = ref(10)
 if (isClient) {
   const computeRevPageSize = () => {
     const width = window.innerWidth
-    if (width >= 1024) return 12 // 3列
-    if (width >= 768) return 10  // 2列
+    if (width >= 1024) return 12
+    if (width >= 768) return 10
     return 12
   }
   userRevPageSize.value = computeRevPageSize()
@@ -1120,17 +609,14 @@ const forumTotalPages = computed(() => {
 })
 function prevForumPage() { if (forumPostPage.value > 1) forumPostPage.value-- }
 function nextForumPage() { if (forumPostPage.value < forumTotalPages.value) forumPostPage.value++ }
-function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, '').trim().slice(0, 200)
-}
 
 // Fetch rating history
 const { data: ratingHistory, pending: ratingHistoryPending } = await useAsyncData(
   () => `user-rating-history-${wikidotId.value}`,
-  () => $bff(`/users/${wikidotId.value}/rating-history`, { 
-    params: { 
-      granularity: 'week'  // 按周聚合，获取全部历史数据
-    } 
+  () => $bff(`/users/${wikidotId.value}/rating-history`, {
+    params: {
+      granularity: 'week'
+    }
   }),
   {
     watch: [() => route.params.wikidotId],
@@ -1183,31 +669,25 @@ const { data: tabCounts, pending: tabCountsPending } = await useAsyncData(
   }
 );
 
-// Works helpers and tag-based filters (counts computed from all works to avoid tab-switch bugs)
+// Works helpers and tag-based filters
 const allWorks = computed(() => Array.isArray(works.value) ? (works.value as any[]) : ([] as any[]))
 
 function hasTag(work: any, tag: string): boolean {
   return Array.isArray(work?.tags) && work.tags.includes(tag)
 }
 
-// Prefer server-side grouping when available
 const hasGroup = (w: any, key: string) => (w && typeof w.groupKey === 'string' && w.groupKey === key)
 const isOriginal = (w: any) => hasGroup(w, 'author') || hasTag(w, '原创')
 const isAuthorPage = (w: any) => hasTag(w, '作者')
 const isCoverPage = (w: any) => hasTag(w, '掩盖页')
 const isParagraph = (w: any) => hasTag(w, '段落')
-
 const isShortStories = (w: any) => hasGroup(w, 'short_stories') || (w?.category === 'short-stories')
 const isAnomalousLog = (w: any) => hasGroup(w, 'anomalous_log') || (w?.category === 'log-of-anomalous-items-cn')
 
-// Exclude short-stories & anomalous-log from original/translation/other
 const filterOriginal = (w: any) => isOriginal(w) && !isCoverPage(w) && !isParagraph(w) && !isShortStories(w) && !isAnomalousLog(w)
 const filterTranslation = (w: any) => hasGroup(w, 'translator') || (!isOriginal(w) && !isAuthorPage(w) && !isCoverPage(w) && !isParagraph(w) && !isShortStories(w) && !isAnomalousLog(w))
 const filterOther = (w: any) => hasGroup(w, 'other') || ((isAuthorPage(w) || isCoverPage(w) || isParagraph(w)) && !isShortStories(w) && !isAnomalousLog(w))
 
-// Category-based tabs
-
-// Hide-zero tabs: compute counts safely from BFF counts if available, else local
 const shortStoriesCount = computed(() => {
   if (tabCounts.value && typeof tabCounts.value.shortStories === 'number') return tabCounts.value.shortStories
   return allWorks.value.filter(isShortStories).length
@@ -1217,7 +697,6 @@ const anomalousLogCount = computed(() => {
   return allWorks.value.filter(isAnomalousLog).length
 })
 
-// Work tabs configuration
 const workTabs = computed(() => {
   const tabs = [
     { key: 'all', label: '全部作品', count: (tabCounts.value && typeof tabCounts.value.total === 'number') ? tabCounts.value.total : allWorks.value.length },
@@ -1230,7 +709,6 @@ const workTabs = computed(() => {
   if (al > 0) tabs.push({ key: 'ANOMALOUS_LOG', label: '异常物品记录', count: al })
   const otherCount = (tabCounts.value && typeof tabCounts.value.other === 'number') ? tabCounts.value.other : allWorks.value.filter(filterOther).length
   tabs.push({ key: 'OTHER', label: '其他', count: otherCount })
-  // hide tabs with zero count except 'all'
   return tabs.filter(t => t.key === 'all' || (t.count || 0) > 0)
 })
 
@@ -1272,31 +750,19 @@ const activeTabTotalCount = computed(() => {
 
 const filteredWorks = computed(() => {
   const all = allWorks.value
-  if (activeTab.value === 'AUTHOR') {
-    return all.filter(filterOriginal)
-  }
-  if (activeTab.value === 'TRANSLATOR') {
-    return all.filter(filterTranslation)
-  }
-  if (activeTab.value === 'SHORT_STORIES') {
-    return all.filter(isShortStories)
-  }
-  if (activeTab.value === 'ANOMALOUS_LOG') {
-    return all.filter(isAnomalousLog)
-  }
-  if (activeTab.value === 'OTHER') {
-    return all.filter(filterOther)
-  }
+  if (activeTab.value === 'AUTHOR') return all.filter(filterOriginal)
+  if (activeTab.value === 'TRANSLATOR') return all.filter(filterTranslation)
+  if (activeTab.value === 'SHORT_STORIES') return all.filter(isShortStories)
+  if (activeTab.value === 'ANOMALOUS_LOG') return all.filter(isAnomalousLog)
+  if (activeTab.value === 'OTHER') return all.filter(filterOther)
   return all
 });
 
-// Server-side sorted; keep client no-op to preserve existing bindings
 const sortedWorks = computed(() => filteredWorks.value)
 
 watch([sortField, sortOrder], () => { currentPage.value = 1 })
 
-// Server-side pagination: displayed list equals fetched page
-const displayedWorks = computed(() => sortedWorks.value);
+const displayedWorks = computed(() => sortedWorks.value.map(normalizeWork));
 
 watch(
   () => works.value,
@@ -1315,10 +781,7 @@ const totalPages = computed(() => {
   return Math.max(1, Math.ceil(total / size));
 });
 
-// Reset page when tab changes
-watch(activeTab, () => {
-  currentPage.value = 1;
-});
+watch(activeTab, () => { currentPage.value = 1; });
 
 watch(totalPages, (nextTotal) => {
   if (!Number.isFinite(nextTotal) || nextTotal <= 0) {
@@ -1330,7 +793,6 @@ watch(totalPages, (nextTotal) => {
   }
 });
 
-// Ensure active tab is visible; if hidden by zero-count, reset to 'all'
 watch(workTabs, (tabs) => {
   const exists = tabs.some(t => t.key === activeTab.value)
   if (!exists) activeTab.value = 'all'
@@ -1348,76 +810,6 @@ function computeHeatmapFetchRange(): HeatmapRange {
     startIso: formatDateIsoUtc8(start),
     endIso: formatDateIsoUtc8(end)
   };
-}
-
-function formatDateParam(date: Date) {
-  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
-  return formatDateIsoUtc8(date);
-}
-
-function formatDate(dateStr: string) {
-  if (!dateStr) return 'N/A';
-  return formatDateUtc8(dateStr, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric'
-  }) || 'N/A';
-}
-
-
-function formatActivityType(type: string) {
-  const typeMap: Record<string, string> = {
-    'PAGE_CREATED': '创建页面',
-    'PAGE_EDITED': '编辑页面',
-    'PAGE_TRANSLATED': '翻译页面',
-    'VOTE_CAST': '投票',
-    'COMMENT_POSTED': '发表评论',
-    'VOTE': '投票',
-    'REVISION': '修订',
-    'FORUM_POST': '论坛发帖',
-    'forum_post': '论坛发帖',
-    'attribution': '页面归属',
-    'revision': '修订',
-    'vote': '投票',
-  };
-  return typeMap[type] || type;
-}
-
-function isForumPostActivity(type: string | null | undefined) {
-  return String(type || '').toUpperCase() === 'FORUM_POST';
-}
-
-function forumPostLink(threadId: number | string | null | undefined, postId: number | string | null | undefined) {
-  const tid = Number(threadId);
-  if (!Number.isFinite(tid) || tid <= 0) return '/forums';
-  const pid = Number(postId);
-  if (Number.isFinite(pid) && pid > 0) {
-    return `/forums/t/${tid}?postId=${pid}`;
-  }
-  return `/forums/t/${tid}`;
-}
-
-function formatRevisionType(type: string) {
-  const typeMap: Record<string, string> = {
-    'PAGE_CREATED': '创建页面',
-    'PAGE_EDITED': '编辑内容',
-    'PAGE_RENAMED': '重命名',
-    'PAGE_DELETED': '删除',
-    'PAGE_RESTORED': '恢复',
-    'METADATA_CHANGED': '修改元数据',
-    'TAGS_CHANGED': '修改标签',
-    'SOURCE_CHANGED': '编辑内容',
-  };
-  return typeMap[type] || type;
-}
-
-// Removed inline CategoryRank to avoid hydration mismatch
-
-function composeTitle(title?: string | null, alternateTitle?: string | null) {
-  const base = typeof title === 'string' ? title.trim() : ''
-  const alt = typeof alternateTitle === 'string' ? alternateTitle.trim() : ''
-  if (alt) return base ? `${base} - ${alt}` : alt
-  return base
 }
 
 function normalizeWork(work: any) {


### PR DESCRIPTION
## 概述

拆分剩余的两个巨型前端文件为更小的子组件，提升可维护性和代码可读性。

### `pages/user/[wikidotId].vue` (1441 → 833 行，42% 减少)

提取 5 个子组件到 `components/user/`：
- **UserHeader.vue** — 用户头像、基本信息、统计概览、分类排名/雷达图、收藏夹、评分历史、热力图
- **UserWorks.vue** — 作品列表（标签页切换、排序、分页）
- **UserPreferences.vue** — 偏好一览（最爱作者/粉丝/标签）
- **UserVotes.vue** — 最近投票记录
- **UserRevisions.vue** — 最近编辑 + 论坛发帖

### `GachaTradePanel.vue` (2637 → 1094 行，59% 减少)

提取 4 个子组件到 `components/gacha/trade/`：
- **TradeSellForm.vue** — 发布挂牌表单（卡片选择、定价）
- **TradeListings.vue** — 公共挂牌列表（搜索、排序、分页）
- **TradeBuyForm.vue** — 发布求购表单 + 公共求购浏览
- **TradeDetail.vue** — 三种详情弹窗（我的挂牌/公共挂牌/求购详情）

### 设计决策

- `useAsyncData` 保留在页面级，子组件通过 props 接收数据，保持 SSR 兼容
- 交易面板 CSS 从 `scoped` 改为 `.trade-bazaar` 命名空间非 scoped 样式，使子组件可继承
- 使用显式 import 而非 Nuxt 自动注册，避免 `GachaTradeTradeDetail` 等冗长组件名

## 验证

- [x] `npm run build` 通过
- [ ] 用户详情页视觉回归验证
- [ ] 集换市场功能回归验证