### PR TITLE
fix: 修复搜索 SQL 语法错误

### DIFF
--- a/bff/src/web/routes/search.ts
+++ b/bff/src/web/routes/search.ts
@@ -406,7 +406,7 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
     // 避免候选池被不符合过滤条件的行占满而遗漏真正匹配的结果
     const buildCteInlineFilters = (includeDate: boolean): string => {
       const directFilters = `
-            ($2::text[] IS NULL OR COALESCE(pv.tags, ARRAY[]::text[]) @> $2::text[])
+            AND ($2::text[] IS NULL OR COALESCE(pv.tags, ARRAY[]::text[]) @> $2::text[])
             AND ($3::text[] IS NULL OR NOT (COALESCE(pv.tags, ARRAY[]::text[]) && $3::text[]))
             AND ($4::int IS NULL OR pv.rating >= $4)
             AND ($5::int IS NULL OR pv.rating <= $5)


### PR DESCRIPTION
## Summary
- `buildCteInlineFilters` 中 `directFilters` 模板字符串的第一个条件缺少 `AND` 关键字
- 导致生成无效 SQL：`... = false ($2::text[] IS NULL ...)`（`false` 后直接跟 `(`）
- 所有搜索请求（`/api/search/pages`）返回 500 Internal Server Error

## Root Cause
提交 7a7e4bd 将过滤条件下推到 CTE 内部时，`directFilters` 的第一个条件省略了 `AND`，但后续条件都有 `AND`，拼接后 SQL 语法错误。

## Fix
在 `directFilters` 的第一个条件前添加 `AND`。

## Test plan
- [x] BFF 已在生产重新构建并重启
- [x] `curl` 测试搜索 API 正常返回结果
- [x] BFF 错误日志不再出现 SQL syntax error