### PR TITLE
fix: 修复预览页面无法滚动和内容被屏蔽

### DIFF
--- a/bff/src/web/routes/page-preview.ts
+++ b/bff/src/web/routes/page-preview.ts
@@ -93,7 +93,18 @@ export function pagePreviewRouter(mainPool: pg.Pool) {
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.setHeader('Cache-Control', 'private, max-age=300');
       res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-      res.setHeader('Content-Security-Policy', "script-src 'none'; style-src 'self' 'unsafe-inline'; img-src * data:; frame-ancestors 'self'; default-src 'none'");
+      res.setHeader('Content-Security-Policy', [
+        "default-src 'self'",
+        "script-src 'unsafe-inline' 'self' https://d3g0gp89917ko0.cloudfront.net",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src * data:",
+        "font-src 'self' data: https://d3g0gp89917ko0.cloudfront.net https://*.wdfiles.com",
+        "media-src * data:",
+        "connect-src 'self'",
+        "frame-src 'none'",
+        "frame-ancestors 'self'",
+        "form-action 'none'"
+      ].join('; '));
       return res.send(contentResult.rows[0].full_page_html);
     } catch (err) {
       next(err);

--- a/frontend/pages/page/[wikidotId]/preview.vue
+++ b/frontend/pages/page/[wikidotId]/preview.vue
@@ -151,6 +151,7 @@ useHead({
 }
 
 .preview-iframe {
+  display: block;
   width: 100%;
   height: 100%;
   border: none;


### PR DESCRIPTION
## Summary

- 修复预览页面 CSP 过于严格（`script-src 'none'`）导致 Wikidot 页面 JS 被完全阻止
- JS 阻止导致页面布局崩坏（无法滚动）和某些模块显示"被屏蔽"错误

## Changes

- `page-preview.ts`: CSP 从 `script-src 'none'` 改为允许 inline + self + CloudFront CDN
  - `connect-src 'self'` 限制仅允许回调自身（阻止对外部 Wikidot API 的直接请求）
  - `form-action 'none'` 阻止表单提交
  - `frame-src 'none'` 阻止子 iframe
- `preview.vue`: iframe 添加 `display: block` 避免 inline 元素间距

## Test plan
- [ ] 打开有缓存的页面预览，确认可以正常滚动
- [ ] 确认折叠区、标签页等交互元素正常工作
- [ ] 确认不再显示"被屏蔽"错误
- [ ] 确认点击站内链接在新标签页打开