### PR TITLE
fix(avatar-agent): 图片抓取改为黑名单模式

### DIFF
--- a/avatar-agent/src/config.ts
+++ b/avatar-agent/src/config.ts
@@ -87,6 +87,10 @@ export const cfg = {
       .split(",")
       .map(s => s.trim().toLowerCase())
       .filter(Boolean),
+    blockedHosts: str("PAGE_IMAGE_BLOCKED_HOSTS", "")
+      .split(",")
+      .map(s => s.trim().toLowerCase())
+      .filter(Boolean),
     variantEnabled: bool("PAGE_IMAGE_VARIANT_ENABLED", true),
     variantMaxWidth: num("PAGE_IMAGE_VARIANT_MAX_WIDTH", 640),
     variantQuality: num("PAGE_IMAGE_VARIANT_QUALITY", 72)

--- a/avatar-agent/src/image-cache/worker.ts
+++ b/avatar-agent/src/image-cache/worker.ts
@@ -71,12 +71,20 @@ function resolveHost(url: string): string | null {
 
 function isAllowedImageHost(url: string): boolean {
   const allowed = cfg.imageCache.allowedHosts;
-  if (!allowed || allowed.length === 0) {
-    log.warn({ url }, 'PAGE_IMAGE_ALLOWED_HOSTS not configured, rejecting all image URLs');
-    return false;
-  }
+  const blocked = cfg.imageCache.blockedHosts;
   const host = resolveHost(url);
   if (!host) return false;
+
+  // Blocklist takes priority: reject if host matches or is a subdomain of a blocked entry
+  if (blocked && blocked.length > 0) {
+    for (const pattern of blocked) {
+      if (host === pattern || host.endsWith(`.${pattern}`)) return false;
+    }
+  }
+
+  // Wildcard or empty allowlist = allow all non-blocked hosts
+  if (!allowed || allowed.length === 0 || allowed.includes('*')) return true;
+
   return allowed.includes(host);
 }
 


### PR DESCRIPTION
## Summary
- `isAllowedImageHost` 从白名单模式改为黑名单模式：`PAGE_IMAGE_ALLOWED_HOSTS=*` 放行所有域名，新增 `PAGE_IMAGE_BLOCKED_HOSTS` 用于屏蔽指定域名（支持子域匹配）
- 修复 `PAGE_IMAGE_ALLOWED_HOSTS` 缺失导致所有新页面图片下载被拒的问题
- 受影响的约 12,947 张图片（"Host not allowed"）已重置为 PENDING 重新入列

## Context
"小猫月"活动页面（wikidotId 1468395631, voteCount 428 = GOLD）因全部 35 张图片下载失败，
触发 gacha-sync 的延迟逻辑（`imageRefCount > 0 && resolvedImages == 0`），导致卡牌从未生成。

## Test plan
- [x] avatar-agent 重启后不再报 "Host not allowed" / "PAGE_IMAGE_ALLOWED_HOSTS not configured"
- [x] 小猫月页面图片正在逐步 RESOLVED（5/35 已成功）
- [ ] 下一次 hourly gacha-sync 后确认卡牌生成