### PR TITLE
fix: 修复全站 rgba CSS 语法导致选中背景色不显示

### DIFF
--- a/frontend/assets/css/tailwind.css
+++ b/frontend/assets/css/tailwind.css
@@ -96,13 +96,13 @@
   /* 选中文本样式 */
   ::selection,
   ::-moz-selection {
-    background-color: rgba(var(--accent), 0.55);
+    background-color: rgb(var(--accent) / 0.55);
     color: #0b1120; /* ensure strong contrast on highlight */
   }
 
   html.dark ::selection,
   html.dark ::-moz-selection {
-    background-color: rgba(var(--accent-weak), 0.65);
+    background-color: rgb(var(--accent-weak) / 0.65);
     color: #0b1120;
   }
   

--- a/frontend/components/TagBoard.vue
+++ b/frontend/components/TagBoard.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="rounded-lg border border-[rgba(var(--panel-border),0.55)] bg-[rgba(var(--panel),0.9)] shadow-sm">
-    <div class="flex items-center justify-between border-b border-[rgba(var(--panel-border),0.45)] px-3 py-2">
+  <div class="rounded-lg border border-[rgb(var(--panel-border)_/_0.55)] bg-[rgb(var(--panel)_/_0.9)] shadow-sm">
+    <div class="flex items-center justify-between border-b border-[rgb(var(--panel-border)_/_0.45)] px-3 py-2">
       <NuxtLink
         :to="`/tag/${encodeURIComponent(tag)}`"
         class="text-sm font-semibold text-[rgb(var(--fg))] hover:text-[var(--g-accent)]"
       >
         #{{ tag }}
       </NuxtLink>
-      <div class="text-xs text-[rgba(var(--muted),0.85)]" v-if="lovers && haters">共 {{ Math.max(lovers.total, haters.total) }} 人</div>
+      <div class="text-xs text-[rgb(var(--muted)_/_0.85)]" v-if="lovers && haters">共 {{ Math.max(lovers.total, haters.total) }} 人</div>
     </div>
     <div class="p-3">
       <div v-if="pending" class="text-sm text-[rgb(var(--muted))]">加载中...</div>
@@ -15,10 +15,10 @@
       <div v-else class="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div>
           <div class="mb-2 text-xs font-medium text-[rgb(var(--success))]">Lovers（↑最多）</div>
-          <ul class="divide-y divide-[rgba(var(--panel-border),0.35)]">
+          <ul class="divide-y divide-[rgb(var(--panel-border)_/_0.35)]">
             <li v-for="(u, idx) in (lovers?.rows || [])" :key="`${tag}-lov-${idx}-${u.wikidotId}`" class="flex items-center justify-between gap-3 py-2">
               <div class="flex items-center gap-2 min-w-0">
-                <UserAvatar :wikidot-id="u.wikidotId" :name="u.displayName || String(u.wikidotId)" :size="24" class="ring-1 ring-[rgba(var(--panel-border),0.55)]" />
+                <UserAvatar :wikidot-id="u.wikidotId" :name="u.displayName || String(u.wikidotId)" :size="24" class="ring-1 ring-[rgb(var(--panel-border)_/_0.55)]" />
                 <NuxtLink :to="`/user/${u.wikidotId}`" class="truncate text-sm font-medium text-[rgb(var(--fg))] hover:text-[var(--g-accent)]">
                   {{ u.displayName || '未知用户' }}
                 </NuxtLink>
@@ -31,12 +31,12 @@
           </ul>
           <div class="flex items-center justify-between mt-2" v-if="lovers">
             <button
-              class="px-2 py-1 text-xs rounded border border-[rgba(var(--input-border),0.55)] bg-[rgba(var(--input-bg),0.96)] text-[rgb(var(--muted-strong))] transition hover:border-[var(--g-accent-border)] disabled:opacity-50"
+              class="px-2 py-1 text-xs rounded border border-[rgb(var(--input-border)_/_0.55)] bg-[rgb(var(--input-bg)_/_0.96)] text-[rgb(var(--muted-strong))] transition hover:border-[var(--g-accent-border)] disabled:opacity-50"
               :disabled="(lovers.offset || 0) <= 0"
               @click="emit('update:offset-lovers', Math.max(0, (lovers.offset || 0) - limit))"
             >上一页</button>
             <button
-              class="px-2 py-1 text-xs rounded border border-[rgba(var(--input-border),0.55)] bg-[rgba(var(--input-bg),0.96)] text-[rgb(var(--muted-strong))] transition hover:border-[var(--g-accent-border)] disabled:opacity-50"
+              class="px-2 py-1 text-xs rounded border border-[rgb(var(--input-border)_/_0.55)] bg-[rgb(var(--input-bg)_/_0.96)] text-[rgb(var(--muted-strong))] transition hover:border-[var(--g-accent-border)] disabled:opacity-50"
               :disabled="(lovers.offset || 0) + (lovers.limit || 0) >= (lovers.total || 0)"
               @click="emit('update:offset-lovers', (lovers.offset || 0) + limit)"
             >下一页</button>
@@ -45,10 +45,10 @@
 
         <div>
           <div class="mb-2 text-xs font-medium text-[rgb(var(--danger))]">Haters（↓最多）</div>
-          <ul class="divide-y divide-[rgba(var(--panel-border),0.35)]">
+          <ul class="divide-y divide-[rgb(var(--panel-border)_/_0.35)]">
             <li v-for="(u, idx) in (haters?.rows || [])" :key="`${tag}-hat-${idx}-${u.wikidotId}`" class="flex items-center justify-between gap-3 py-2">
               <div class="flex items-center gap-2 min-w-0">
-                <UserAvatar :wikidot-id="u.wikidotId" :name="u.displayName || String(u.wikidotId)" :size="24" class="ring-1 ring-[rgba(var(--panel-border),0.55)]" />
+                <UserAvatar :wikidot-id="u.wikidotId" :name="u.displayName || String(u.wikidotId)" :size="24" class="ring-1 ring-[rgb(var(--panel-border)_/_0.55)]" />
                 <NuxtLink :to="`/user/${u.wikidotId}`" class="truncate text-sm font-medium text-[rgb(var(--fg))] hover:text-[var(--g-accent)]">
                   {{ u.displayName || '未知用户' }}
                 </NuxtLink>
@@ -61,12 +61,12 @@
           </ul>
           <div class="flex items-center justify-between mt-2" v-if="haters">
             <button
-              class="px-2 py-1 text-xs rounded border border-[rgba(var(--input-border),0.55)] bg-[rgba(var(--input-bg),0.96)] text-[rgb(var(--muted-strong))] transition hover:border-[var(--g-accent-border)] disabled:opacity-50"
+              class="px-2 py-1 text-xs rounded border border-[rgb(var(--input-border)_/_0.55)] bg-[rgb(var(--input-bg)_/_0.96)] text-[rgb(var(--muted-strong))] transition hover:border-[var(--g-accent-border)] disabled:opacity-50"
               :disabled="(haters.offset || 0) <= 0"
               @click="emit('update:offset-haters', Math.max(0, (haters.offset || 0) - limit))"
             >上一页</button>
             <button
-              class="px-2 py-1 text-xs rounded border border-[rgba(var(--input-border),0.55)] bg-[rgba(var(--input-bg),0.96)] text-[rgb(var(--muted-strong))] transition hover:border-[var(--g-accent-border)] disabled:opacity-50"
+              class="px-2 py-1 text-xs rounded border border-[rgb(var(--input-border)_/_0.55)] bg-[rgb(var(--input-bg)_/_0.96)] text-[rgb(var(--muted-strong))] transition hover:border-[var(--g-accent-border)] disabled:opacity-50"
               :disabled="(haters.offset || 0) + (haters.limit || 0) >= (haters.total || 0)"
               @click="emit('update:offset-haters', (haters.offset || 0) + limit)"
             >下一页</button>
@@ -153,18 +153,18 @@ watch(() => [props.tag, props.limit, props.offsetLovers, props.offsetHaters], fe
   padding: 0.25rem 0.5rem;
   border-radius: 9999px;
   font-weight: 600;
-  background-color: rgba(var(--tag-bg), 0.32);
+  background-color: rgb(var(--tag-bg) / 0.32);
   color: rgb(var(--tag-text));
-  border: 1px solid rgba(var(--tag-border), 0.5);
+  border: 1px solid rgb(var(--tag-border) / 0.5);
 }
 .tag-chip.success {
-  background-color: rgba(var(--success), 0.18);
+  background-color: rgb(var(--success) / 0.18);
   color: rgb(var(--success-strong));
-  border-color: rgba(var(--success), 0.4);
+  border-color: rgb(var(--success) / 0.4);
 }
 .tag-chip.danger {
-  background-color: rgba(var(--danger), 0.18);
+  background-color: rgb(var(--danger) / 0.18);
   color: rgb(var(--danger-strong));
-  border-color: rgba(var(--danger), 0.4);
+  border-color: rgb(var(--danger) / 0.4);
 }
 </style>

--- a/frontend/components/account/AppearanceSettings.vue
+++ b/frontend/components/account/AppearanceSettings.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="space-y-8">
-    <section class="rounded-lg border border-[rgba(var(--panel-border),0.45)] bg-[rgba(var(--panel),0.78)] p-6 shadow-sm backdrop-blur-xl dark:shadow-lg">
+    <section class="rounded-lg border border-[rgb(var(--panel-border)_/_0.45)] bg-[rgb(var(--panel)_/_0.78)] p-6 shadow-sm backdrop-blur-xl dark:shadow-lg">
       <header class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
           <h2 class="text-lg font-semibold text-[rgb(var(--fg))]">主题模式</h2>
           <p class="text-sm text-neutral-600 dark:text-neutral-400">切换浅色或深色，并实时预览。</p>
         </div>
-        <div class="inline-flex rounded-full border border-[rgba(var(--panel-border),0.5)] bg-[rgba(var(--panel),0.7)] p-1 text-sm">
+        <div class="inline-flex rounded-full border border-[rgb(var(--panel-border)_/_0.5)] bg-[rgb(var(--panel)_/_0.7)] p-1 text-sm">
           <button
             v-for="modeOption in modeOptions"
             :key="modeOption.key"
@@ -21,12 +21,12 @@
           </button>
         </div>
       </header>
-      <p class="mt-4 rounded-lg border border-dashed border-[rgba(var(--panel-border),0.45)] bg-[rgba(var(--panel),0.55)] px-4 py-3 text-xs leading-relaxed text-neutral-500 dark:text-neutral-400">
+      <p class="mt-4 rounded-lg border border-dashed border-[rgb(var(--panel-border)_/_0.45)] bg-[rgb(var(--panel)_/_0.55)] px-4 py-3 text-xs leading-relaxed text-neutral-500 dark:text-neutral-400">
         当前正在编辑 <span class="font-semibold text-[var(--g-accent)]">{{ editingModeLabel }}</span> 配置。切换模式将立即应用新主题，方便对比效果。
       </p>
     </section>
 
-    <section class="rounded-lg border border-[rgba(var(--panel-border),0.45)] bg-[rgba(var(--panel),0.78)] p-6 shadow-sm backdrop-blur-xl dark:shadow-lg">
+    <section class="rounded-lg border border-[rgb(var(--panel-border)_/_0.45)] bg-[rgb(var(--panel)_/_0.78)] p-6 shadow-sm backdrop-blur-xl dark:shadow-lg">
       <header class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
           <h2 class="text-lg font-semibold text-[rgb(var(--fg))]">快速配色</h2>
@@ -34,7 +34,7 @@
         </div>
         <button
           type="button"
-          class="inline-flex items-center gap-2 rounded-full border border-[rgba(var(--panel-border),0.55)] px-3 py-1.5 text-xs font-semibold text-neutral-600 hover:text-[var(--g-accent)] dark:text-neutral-300"
+          class="inline-flex items-center gap-2 rounded-full border border-[rgb(var(--panel-border)_/_0.55)] px-3 py-1.5 text-xs font-semibold text-neutral-600 hover:text-[var(--g-accent)] dark:text-neutral-300"
           @click="handleResetPresets"
         >
           <LucideIcon name="RotateCcw" class="h-4 w-4" stroke-width="2" />
@@ -49,8 +49,8 @@
           :aria-pressed="colorScheme === preset.key"
           class="group flex items-center justify-between gap-3 rounded-lg border px-4 py-3 text-left transition"
           :class="colorScheme === preset.key
-            ? 'border-[var(--g-accent-border)] bg-[rgba(var(--panel),0.85)] shadow-sm text-[var(--g-accent)]'
-            : 'border-[rgba(var(--panel-border),0.4)] bg-[rgba(var(--panel),0.6)] text-neutral-600 hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:text-neutral-300'"
+            ? 'border-[var(--g-accent-border)] bg-[rgb(var(--panel)_/_0.85)] shadow-sm text-[var(--g-accent)]'
+            : 'border-[rgb(var(--panel-border)_/_0.4)] bg-[rgb(var(--panel)_/_0.6)] text-neutral-600 hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:text-neutral-300'"
           @click="handlePresetSelect(preset.key)"
         >
           <div class="flex flex-col gap-1">
@@ -65,7 +65,7 @@
       </div>
     </section>
 
-    <section class="rounded-lg border border-[rgba(var(--panel-border),0.45)] bg-[rgba(var(--panel),0.78)] p-6 shadow-sm backdrop-blur-xl dark:shadow-lg">
+    <section class="rounded-lg border border-[rgb(var(--panel-border)_/_0.45)] bg-[rgb(var(--panel)_/_0.78)] p-6 shadow-sm backdrop-blur-xl dark:shadow-lg">
       <header class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
           <h2 class="text-lg font-semibold text-[rgb(var(--fg))]">自定义颜色</h2>
@@ -73,7 +73,7 @@
         </div>
         <div class="flex items-center gap-2 text-xs">
           <span class="text-neutral-500 dark:text-neutral-400">编辑模式：</span>
-          <div class="inline-flex rounded-full border border-[rgba(var(--panel-border),0.5)] bg-[rgba(var(--panel),0.65)] p-0.5">
+          <div class="inline-flex rounded-full border border-[rgb(var(--panel-border)_/_0.5)] bg-[rgb(var(--panel)_/_0.65)] p-0.5">
             <button
               v-for="modeOption in modeOptions"
               :key="`editor-${modeOption.key}`"
@@ -94,7 +94,7 @@
         <div
           v-for="group in tokenGroups"
           :key="group.key"
-          class="rounded-lg border border-[rgba(var(--panel-border),0.35)] bg-[rgba(var(--panel),0.55)] p-4"
+          class="rounded-lg border border-[rgb(var(--panel-border)_/_0.35)] bg-[rgb(var(--panel)_/_0.55)] p-4"
         >
           <header class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
             <div>
@@ -115,7 +115,7 @@
             <div
               v-for="token in group.tokens"
               :key="`${group.key}-${token.key}`"
-              class="flex items-center justify-between gap-3 rounded-xl border border-[rgba(var(--panel-border),0.3)] bg-[rgba(var(--panel),0.5)] px-3 py-3"
+              class="flex items-center justify-between gap-3 rounded-xl border border-[rgb(var(--panel-border)_/_0.3)] bg-[rgb(var(--panel)_/_0.5)] px-3 py-3"
             >
               <div class="min-w-0">
                 <div class="text-sm font-medium text-[rgb(var(--fg))]">{{ token.label }}</div>
@@ -128,14 +128,14 @@
                 <input
                   :id="`picker-${editingMode}-${token.key}`"
                   type="color"
-                  class="h-10 w-10 cursor-pointer rounded-xl border border-[rgba(var(--panel-border),0.4)] bg-transparent"
+                  class="h-10 w-10 cursor-pointer rounded-xl border border-[rgb(var(--panel-border)_/_0.4)] bg-transparent"
                   :value="getColorValue(editingMode, token.key)"
                   @input="handleColorChange(editingMode, token.key, $event)"
                 />
                 <button
                   v-if="isOverridden(editingMode, token.key)"
                   type="button"
-                  class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[rgba(var(--panel-border),0.5)] text-neutral-500 hover:text-[var(--g-accent)]"
+                  class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[rgb(var(--panel-border)_/_0.5)] text-neutral-500 hover:text-[var(--g-accent)]"
                   @click="clearOverride(editingMode, token.key)"
                   aria-label="清除该颜色的覆盖"
                 >
@@ -148,7 +148,7 @@
       </div>
     </section>
 
-    <section class="rounded-lg border border-[rgba(var(--panel-border),0.45)] bg-[rgba(var(--panel),0.78)] p-6 shadow-sm backdrop-blur-xl dark:shadow-lg">
+    <section class="rounded-lg border border-[rgb(var(--panel-border)_/_0.45)] bg-[rgb(var(--panel)_/_0.78)] p-6 shadow-sm backdrop-blur-xl dark:shadow-lg">
       <header class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 class="text-lg font-semibold text-[rgb(var(--fg))]">导入与导出</h2>
@@ -182,7 +182,7 @@
           </button>
           <button
             type="button"
-            class="inline-flex items-center gap-2 rounded-full border border-[rgba(var(--panel-border),0.55)] bg-[rgba(var(--panel),0.7)] px-4 py-2 text-sm font-semibold text-neutral-600 hover:text-[var(--g-accent)] dark:text-neutral-300"
+            class="inline-flex items-center gap-2 rounded-full border border-[rgb(var(--panel-border)_/_0.55)] bg-[rgb(var(--panel)_/_0.7)] px-4 py-2 text-sm font-semibold text-neutral-600 hover:text-[var(--g-accent)] dark:text-neutral-300"
             @click="triggerImport"
           >
             <LucideIcon name="Download" class="h-4 w-4" stroke-width="2" />
@@ -191,7 +191,7 @@
         </div>
         <button
           type="button"
-          class="inline-flex items-center gap-2 rounded-full border border-[rgba(var(--panel-border),0.55)] px-4 py-2 text-sm font-semibold text-neutral-600 hover:text-[var(--g-accent)] dark:text-neutral-300 disabled:opacity-40 disabled:cursor-not-allowed"
+          class="inline-flex items-center gap-2 rounded-full border border-[rgb(var(--panel-border)_/_0.55)] px-4 py-2 text-sm font-semibold text-neutral-600 hover:text-[var(--g-accent)] dark:text-neutral-300 disabled:opacity-40 disabled:cursor-not-allowed"
           :disabled="!hasOverrides"
           @click="handleResetOverrides"
         >
@@ -387,8 +387,8 @@ let messageTimer: number | null = null;
 const messageClass = computed(() => {
   if (!message.value) return '';
   return message.value.type === 'success'
-    ? 'bg-[rgba(var(--success),0.12)] text-[rgb(var(--success-strong))]'
-    : 'bg-[rgba(var(--danger),0.12)] text-[rgb(var(--danger-strong))]';
+    ? 'bg-[rgb(var(--success)_/_0.12)] text-[rgb(var(--success-strong))]'
+    : 'bg-[rgb(var(--danger)_/_0.12)] text-[rgb(var(--danger-strong))]';
 });
 
 const fileInputRef = ref<HTMLInputElement | null>(null);

--- a/frontend/components/annual2025/Annual2025AchievementsSlide.vue
+++ b/frontend/components/annual2025/Annual2025AchievementsSlide.vue
@@ -3,7 +3,7 @@
     <div class="slide-content">
       <div v-if="!hasUserData" class="max-w-md w-full mx-auto px-4 text-center">
         <div class="bg-[rgb(var(--panel))] border border-[rgb(var(--panel-border))] rounded-lg p-8 md:p-12">
-          <div class="w-20 h-20 mx-auto mb-6 bg-[rgba(var(--fg),0.1)] rounded-full flex items-center justify-center">
+          <div class="w-20 h-20 mx-auto mb-6 bg-[rgb(var(--fg)_/_0.1)] rounded-full flex items-center justify-center">
             <LucideIcon name="Award" class="w-10 h-10 text-[rgb(var(--muted))]" />
           </div>
           <h2 class="text-xl md:text-2xl font-bold text-[rgb(var(--fg))] mb-3">年度成就</h2>
@@ -22,7 +22,7 @@
             <button
               @click.stop="prevAchievementPage"
               :disabled="achievementPageIndex === 0"
-              class="p-1.5 md:p-2 rounded-lg hover:bg-[rgba(var(--fg),0.1)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              class="p-1.5 md:p-2 rounded-lg hover:bg-[rgb(var(--fg)_/_0.1)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             >
               <LucideIcon name="ChevronLeft" class="w-4 h-4 md:w-5 md:h-5" />
             </button>
@@ -32,7 +32,7 @@
             <button
               @click.stop="nextAchievementPage"
               :disabled="achievementPageIndex >= achievementTotalPages - 1"
-              class="p-1.5 md:p-2 rounded-lg hover:bg-[rgba(var(--fg),0.1)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              class="p-1.5 md:p-2 rounded-lg hover:bg-[rgb(var(--fg)_/_0.1)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             >
               <LucideIcon name="ChevronRight" class="w-4 h-4 md:w-5 md:h-5" />
             </button>
@@ -144,7 +144,7 @@ const trophyBgClass = (period?: string | null) => {
     month: 'bg-blue-500/20',
     week: 'bg-emerald-500/20',
     day: 'bg-slate-500/20',
-    other: 'bg-[rgba(var(--fg),0.1)]'
+    other: 'bg-[rgb(var(--fg)_/_0.1)]'
   }
   return map[key] || map.other
 }

--- a/frontend/components/annual2025/Annual2025CategoryBestSlide.vue
+++ b/frontend/components/annual2025/Annual2025CategoryBestSlide.vue
@@ -13,7 +13,7 @@
           <div
             v-for="(item, idx) in siteData.categoryBest"
             :key="idx"
-            class="bg-[rgb(var(--panel))] border border-[rgb(var(--panel-border))] rounded-xl md:rounded-lg p-4 md:p-6 flex items-start gap-3 md:gap-4 hover:bg-[rgba(var(--fg),0.03)] transition-colors"
+            class="bg-[rgb(var(--panel))] border border-[rgb(var(--panel-border))] rounded-xl md:rounded-lg p-4 md:p-6 flex items-start gap-3 md:gap-4 hover:bg-[rgb(var(--fg)_/_0.03)] transition-colors"
           >
             <div class="p-2 md:p-3 rounded-lg md:rounded-xl" :class="item.iconBgClass">
               <LucideIcon :name="item.icon" class="w-5 h-5 md:w-6 md:h-6" :class="item.iconClass" />
@@ -27,7 +27,7 @@
                   v-if="item.original"
                   :to="item.original.wikidotId ? `/page/${item.original.wikidotId}` : undefined"
                   target="_blank"
-                  class="flex items-start justify-between gap-3 hover:bg-[rgba(var(--fg),0.05)] -mx-2 px-2 py-1 rounded-lg transition-colors"
+                  class="flex items-start justify-between gap-3 hover:bg-[rgb(var(--fg)_/_0.05)] -mx-2 px-2 py-1 rounded-lg transition-colors"
                 >
                   <div class="min-w-0">
                     <div class="text-[10px] md:text-xs text-green-400 font-bold uppercase tracking-wider">原创最高分</div>
@@ -42,7 +42,7 @@
                   v-if="item.translation"
                   :to="item.translation.wikidotId ? `/page/${item.translation.wikidotId}` : undefined"
                   target="_blank"
-                  class="flex items-start justify-between gap-3 hover:bg-[rgba(var(--fg),0.05)] -mx-2 px-2 py-1 rounded-lg transition-colors"
+                  class="flex items-start justify-between gap-3 hover:bg-[rgb(var(--fg)_/_0.05)] -mx-2 px-2 py-1 rounded-lg transition-colors"
                 >
                   <div class="min-w-0">
                     <div class="text-[10px] md:text-xs text-blue-400 font-bold uppercase tracking-wider">翻译最高分</div>

--- a/frontend/components/annual2025/Annual2025CategoryDetailsSlide.vue
+++ b/frontend/components/annual2025/Annual2025CategoryDetailsSlide.vue
@@ -104,7 +104,7 @@
                     :key="idx"
                     :to="page.wikidotId ? `/page/${page.wikidotId}` : undefined"
                     target="_blank"
-                    class="flex items-center gap-2 p-1.5 bg-[rgba(var(--fg),0.05)] rounded-lg hover:bg-[rgba(var(--fg),0.1)] transition-colors"
+                    class="flex items-center gap-2 p-1.5 bg-[rgb(var(--fg)_/_0.05)] rounded-lg hover:bg-[rgb(var(--fg)_/_0.1)] transition-colors"
                   >
                     <span class="w-5 h-5 rounded-full text-[10px] font-bold flex items-center justify-center"
                       :class="idx === 0 ? 'bg-yellow-500 text-black' : idx === 1 ? 'bg-gray-400 text-black' : 'bg-amber-700 text-white'">{{ idx + 1 }}</span>
@@ -127,7 +127,7 @@
                     :key="idx"
                     :to="page.wikidotId ? `/page/${page.wikidotId}` : undefined"
                     target="_blank"
-                    class="flex items-center gap-2 p-1.5 bg-[rgba(var(--fg),0.05)] rounded-lg hover:bg-[rgba(var(--fg),0.1)] transition-colors"
+                    class="flex items-center gap-2 p-1.5 bg-[rgb(var(--fg)_/_0.05)] rounded-lg hover:bg-[rgb(var(--fg)_/_0.1)] transition-colors"
                   >
                     <span class="w-5 h-5 rounded-full text-[10px] font-bold flex items-center justify-center"
                       :class="idx === 0 ? 'bg-yellow-500 text-black' : idx === 1 ? 'bg-gray-400 text-black' : 'bg-amber-700 text-white'">{{ idx + 1 }}</span>
@@ -159,10 +159,10 @@
                     :key="idx"
                     :to="author.wikidotId ? `/user/${author.wikidotId}` : undefined"
                     target="_blank"
-                    class="flex items-center gap-2 p-1.5 bg-[rgba(var(--fg),0.05)] rounded-lg hover:bg-[rgba(var(--fg),0.1)] transition-colors"
+                    class="flex items-center gap-2 p-1.5 bg-[rgb(var(--fg)_/_0.05)] rounded-lg hover:bg-[rgb(var(--fg)_/_0.1)] transition-colors"
                   >
                     <span class="w-5 h-5 rounded-full text-[10px] font-bold flex items-center justify-center"
-                      :class="idx === 0 ? 'bg-[var(--g-accent)] text-white' : 'bg-[rgba(var(--fg),0.1)] text-[rgb(var(--fg))]'">{{ idx + 1 }}</span>
+                      :class="idx === 0 ? 'bg-[var(--g-accent)] text-white' : 'bg-[rgb(var(--fg)_/_0.1)] text-[rgb(var(--fg))]'">{{ idx + 1 }}</span>
                     <UserAvatar
                       :wikidot-id="author.wikidotId"
                       :name="author.displayName"
@@ -186,10 +186,10 @@
                     :key="idx"
                     :to="author.wikidotId ? `/user/${author.wikidotId}` : undefined"
                     target="_blank"
-                    class="flex items-center gap-2 p-1.5 bg-[rgba(var(--fg),0.05)] rounded-lg hover:bg-[rgba(var(--fg),0.1)] transition-colors"
+                    class="flex items-center gap-2 p-1.5 bg-[rgb(var(--fg)_/_0.05)] rounded-lg hover:bg-[rgb(var(--fg)_/_0.1)] transition-colors"
                   >
                     <span class="w-5 h-5 rounded-full text-[10px] font-bold flex items-center justify-center"
-                      :class="idx === 0 ? 'bg-[var(--g-accent)] text-white' : 'bg-[rgba(var(--fg),0.1)] text-[rgb(var(--fg))]'">{{ idx + 1 }}</span>
+                      :class="idx === 0 ? 'bg-[var(--g-accent)] text-white' : 'bg-[rgb(var(--fg)_/_0.1)] text-[rgb(var(--fg))]'">{{ idx + 1 }}</span>
                     <UserAvatar
                       :wikidot-id="author.wikidotId"
                       :name="author.displayName"

--- a/frontend/components/annual2025/Annual2025ContentBreakdownSlide.vue
+++ b/frontend/components/annual2025/Annual2025ContentBreakdownSlide.vue
@@ -80,7 +80,7 @@
                   <button
                     @click.stop="prevBranchPage"
                     :disabled="branchPageIndex === 0"
-                    class="p-0.5 md:p-1 rounded hover:bg-[rgba(var(--fg),0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
+                    class="p-0.5 md:p-1 rounded hover:bg-[rgb(var(--fg)_/_0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
                   >
                     <LucideIcon name="ChevronLeft" class="w-3 h-3 md:w-4 md:h-4" />
                   </button>
@@ -88,7 +88,7 @@
                   <button
                     @click.stop="nextBranchPage"
                     :disabled="branchPageIndex >= branchTotalPages - 1"
-                    class="p-0.5 md:p-1 rounded hover:bg-[rgba(var(--fg),0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
+                    class="p-0.5 md:p-1 rounded hover:bg-[rgb(var(--fg)_/_0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
                   >
                     <LucideIcon name="ChevronRight" class="w-3 h-3 md:w-4 md:h-4" />
                   </button>
@@ -149,7 +149,7 @@
                   <button
                     @click.stop="prevNewTagsPage"
                     :disabled="newTagsPageIndex === 0"
-                    class="p-0.5 md:p-1 rounded hover:bg-[rgba(var(--fg),0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
+                    class="p-0.5 md:p-1 rounded hover:bg-[rgb(var(--fg)_/_0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
                   >
                     <LucideIcon name="ChevronLeft" class="w-3 h-3 md:w-4 md:h-4" />
                   </button>
@@ -157,7 +157,7 @@
                   <button
                     @click.stop="nextNewTagsPage"
                     :disabled="newTagsPageIndex >= newTagsTotalPages - 1"
-                    class="p-0.5 md:p-1 rounded hover:bg-[rgba(var(--fg),0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
+                    class="p-0.5 md:p-1 rounded hover:bg-[rgb(var(--fg)_/_0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
                   >
                     <LucideIcon name="ChevronRight" class="w-3 h-3 md:w-4 md:h-4" />
                   </button>

--- a/frontend/components/annual2025/Annual2025CreativeDnaSlide.vue
+++ b/frontend/components/annual2025/Annual2025CreativeDnaSlide.vue
@@ -3,7 +3,7 @@
     <div class="slide-content">
       <div v-if="!hasUserData" class="max-w-md w-full mx-auto px-4 text-center">
         <div class="bg-[rgb(var(--panel))] border border-[rgb(var(--panel-border))] rounded-lg p-8 md:p-12">
-          <div class="w-20 h-20 mx-auto mb-6 bg-[rgba(var(--fg),0.1)] rounded-full flex items-center justify-center">
+          <div class="w-20 h-20 mx-auto mb-6 bg-[rgb(var(--fg)_/_0.1)] rounded-full flex items-center justify-center">
             <LucideIcon name="PenTool" class="w-10 h-10 text-[rgb(var(--muted))]" />
           </div>
           <h2 class="text-xl md:text-2xl font-bold text-[rgb(var(--fg))] mb-3">创作数据</h2>
@@ -164,7 +164,7 @@
                   <button
                     @click.stop="prevTimelinePage"
                     :disabled="timelinePageIndex === 0"
-                    class="p-0.5 md:p-1 rounded hover:bg-[rgba(var(--fg),0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
+                    class="p-0.5 md:p-1 rounded hover:bg-[rgb(var(--fg)_/_0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
                   >
                     <LucideIcon name="ChevronLeft" class="w-3 h-3 md:w-4 md:h-4" />
                   </button>
@@ -172,7 +172,7 @@
                   <button
                     @click.stop="nextTimelinePage"
                     :disabled="timelinePageIndex >= timelineTotalPages - 1"
-                    class="p-0.5 md:p-1 rounded hover:bg-[rgba(var(--fg),0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
+                    class="p-0.5 md:p-1 rounded hover:bg-[rgb(var(--fg)_/_0.1)] disabled:opacity-30 disabled:cursor-not-allowed"
                   >
                     <LucideIcon name="ChevronRight" class="w-3 h-3 md:w-4 md:h-4" />
                   </button>

--- a/frontend/components/annual2025/Annual2025DeletedPagesSlide.vue
+++ b/frontend/components/annual2025/Annual2025DeletedPagesSlide.vue
@@ -112,7 +112,7 @@
               <div
                 v-for="author in stats.topAuthors.slice(0, 5)"
                 :key="author.userId"
-                class="flex items-center gap-2 p-2 rounded-lg bg-[rgba(var(--fg),0.03)]"
+                class="flex items-center gap-2 p-2 rounded-lg bg-[rgb(var(--fg)_/_0.03)]"
               >
                 <div class="w-6 h-6 md:w-8 md:h-8 rounded-full bg-red-500/20 flex items-center justify-center text-xs md:text-sm font-bold text-red-400">
                   {{ author.rank }}
@@ -134,7 +134,7 @@
       </div>
     </div>
     <div class="slide-bg">
-      <div class="w-full h-full bg-[radial-gradient(rgba(var(--fg),0.03)_1px,transparent_1px)] bg-[length:24px_24px]" />
+      <div class="w-full h-full bg-[radial-gradient(rgb(var(--fg) / 0.03)_1px,transparent_1px)] bg-[length:24px_24px]" />
     </div>
   </section>
 </template>

--- a/frontend/components/annual2025/Annual2025NoDataEndSlide.vue
+++ b/frontend/components/annual2025/Annual2025NoDataEndSlide.vue
@@ -3,7 +3,7 @@
     <div class="slide-content">
       <div class="max-w-lg w-full mx-auto px-4 text-center">
         <div class="bg-[rgb(var(--panel))] border border-[rgb(var(--panel-border))] rounded-lg p-8 md:p-12">
-          <div class="w-20 h-20 mx-auto mb-6 bg-[rgba(var(--fg),0.1)] rounded-full flex items-center justify-center">
+          <div class="w-20 h-20 mx-auto mb-6 bg-[rgb(var(--fg)_/_0.1)] rounded-full flex items-center justify-center">
             <LucideIcon name="PartyPopper" class="w-10 h-10 text-[var(--g-accent)]" />
           </div>
           <h2 class="text-xl md:text-2xl font-bold text-[rgb(var(--fg))] mb-3">2025 站点数据回顾完毕</h2>

--- a/frontend/components/annual2025/Annual2025ProgressNav.vue
+++ b/frontend/components/annual2025/Annual2025ProgressNav.vue
@@ -19,7 +19,7 @@
     />
   </div>
 
-  <div class="sm:hidden fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 bg-[rgba(var(--bg),0.9)] backdrop-blur-md px-3 py-1.5 rounded-full border border-[rgb(var(--panel-border))]">
+  <div class="sm:hidden fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 bg-[rgb(var(--bg)_/_0.9)] backdrop-blur-md px-3 py-1.5 rounded-full border border-[rgb(var(--panel-border))]">
     <span class="text-xs text-[rgb(var(--muted))]">{{ currentSlideIndex + 1 }}/{{ totalSlides }}</span>
     <span class="text-[10px] text-[var(--g-accent)]">{{ slideLabels[currentSlideIndex] }}</span>
   </div>

--- a/frontend/components/annual2025/Annual2025RecordsSlide.vue
+++ b/frontend/components/annual2025/Annual2025RecordsSlide.vue
@@ -173,7 +173,7 @@
       </div>
     </div>
     <div class="slide-bg">
-      <div class="w-full h-full bg-[radial-gradient(rgba(var(--fg),0.03)_1px,transparent_1px)] bg-[length:24px_24px]" />
+      <div class="w-full h-full bg-[radial-gradient(rgb(var(--fg) / 0.03)_1px,transparent_1px)] bg-[length:24px_24px]" />
     </div>
   </section>
 </template>

--- a/frontend/components/annual2025/Annual2025ScpDetailsSlide.vue
+++ b/frontend/components/annual2025/Annual2025ScpDetailsSlide.vue
@@ -47,7 +47,7 @@
                   class="w-full h-full rounded-full shadow-inner"
                   :style="{ background: scpClassPieGradient }"
                 />
-                <div class="absolute inset-3 rounded-full bg-[rgb(var(--bg))] border border-[rgba(var(--fg),0.08)] flex flex-col items-center justify-center text-center">
+                <div class="absolute inset-3 rounded-full bg-[rgb(var(--bg))] border border-[rgb(var(--fg)_/_0.08)] flex flex-col items-center justify-center text-center">
                   <span class="text-[9px] md:text-[10px] text-[rgb(var(--muted))]">总计</span>
                   <span class="text-lg md:text-xl font-black text-[rgb(var(--fg))]">{{ formatNumber(scpClassTotal) }}</span>
                 </div>
@@ -137,7 +137,7 @@
                     :key="idx"
                     :to="page.wikidotId ? `/page/${page.wikidotId}` : undefined"
                     target="_blank"
-                    class="flex items-center gap-2 p-1.5 bg-[rgba(var(--fg),0.05)] rounded-lg hover:bg-[rgba(var(--fg),0.1)] transition-colors"
+                    class="flex items-center gap-2 p-1.5 bg-[rgb(var(--fg)_/_0.05)] rounded-lg hover:bg-[rgb(var(--fg)_/_0.1)] transition-colors"
                   >
                     <span class="w-5 h-5 rounded-full text-[10px] font-bold flex items-center justify-center"
                       :class="idx === 0 ? 'bg-yellow-500 text-black' : idx === 1 ? 'bg-gray-400 text-black' : 'bg-amber-700 text-white'">{{ idx + 1 }}</span>
@@ -160,7 +160,7 @@
                     :key="idx"
                     :to="page.wikidotId ? `/page/${page.wikidotId}` : undefined"
                     target="_blank"
-                    class="flex items-center gap-2 p-1.5 bg-[rgba(var(--fg),0.05)] rounded-lg hover:bg-[rgba(var(--fg),0.1)] transition-colors"
+                    class="flex items-center gap-2 p-1.5 bg-[rgb(var(--fg)_/_0.05)] rounded-lg hover:bg-[rgb(var(--fg)_/_0.1)] transition-colors"
                   >
                     <span class="w-5 h-5 rounded-full text-[10px] font-bold flex items-center justify-center"
                       :class="idx === 0 ? 'bg-yellow-500 text-black' : idx === 1 ? 'bg-gray-400 text-black' : 'bg-amber-700 text-white'">{{ idx + 1 }}</span>
@@ -192,10 +192,10 @@
                     :key="idx"
                     :to="author.wikidotId ? `/user/${author.wikidotId}` : undefined"
                     target="_blank"
-                    class="flex items-center gap-2 p-1.5 bg-[rgba(var(--fg),0.05)] rounded-lg hover:bg-[rgba(var(--fg),0.1)] transition-colors"
+                    class="flex items-center gap-2 p-1.5 bg-[rgb(var(--fg)_/_0.05)] rounded-lg hover:bg-[rgb(var(--fg)_/_0.1)] transition-colors"
                   >
                     <span class="w-5 h-5 rounded-full text-[10px] font-bold flex items-center justify-center"
-                      :class="idx === 0 ? 'bg-[var(--g-accent)] text-white' : 'bg-[rgba(var(--fg),0.1)] text-[rgb(var(--fg))]'">{{ idx + 1 }}</span>
+                      :class="idx === 0 ? 'bg-[var(--g-accent)] text-white' : 'bg-[rgb(var(--fg)_/_0.1)] text-[rgb(var(--fg))]'">{{ idx + 1 }}</span>
                     <UserAvatar
                       :wikidot-id="author.wikidotId"
                       :name="author.displayName"
@@ -219,10 +219,10 @@
                     :key="idx"
                     :to="author.wikidotId ? `/user/${author.wikidotId}` : undefined"
                     target="_blank"
-                    class="flex items-center gap-2 p-1.5 bg-[rgba(var(--fg),0.05)] rounded-lg hover:bg-[rgba(var(--fg),0.1)] transition-colors"
+                    class="flex items-center gap-2 p-1.5 bg-[rgb(var(--fg)_/_0.05)] rounded-lg hover:bg-[rgb(var(--fg)_/_0.1)] transition-colors"
                   >
                     <span class="w-5 h-5 rounded-full text-[10px] font-bold flex items-center justify-center"
-                      :class="idx === 0 ? 'bg-[var(--g-accent)] text-white' : 'bg-[rgba(var(--fg),0.1)] text-[rgb(var(--fg))]'">{{ idx + 1 }}</span>
+                      :class="idx === 0 ? 'bg-[var(--g-accent)] text-white' : 'bg-[rgb(var(--fg)_/_0.1)] text-[rgb(var(--fg))]'">{{ idx + 1 }}</span>
                     <UserAvatar
                       :wikidot-id="author.wikidotId"
                       :name="author.displayName"
@@ -281,7 +281,7 @@ const scpClassPieGradient = computed(() => {
   const items = props.siteData.breakdown.scpByClass
   const total = scpClassTotal.value
   if (!items.length || total === 0) {
-    return 'conic-gradient(rgba(var(--fg),0.08) 0deg 360deg)'
+    return 'conic-gradient(rgb(var(--fg) / 0.08) 0deg 360deg)'
   }
 
   let currentAngle = 0
@@ -295,6 +295,6 @@ const scpClassPieGradient = computed(() => {
     currentAngle = end
   })
 
-  return segments.length ? `conic-gradient(${segments.join(', ')})` : 'conic-gradient(rgba(var(--fg),0.08) 0deg 360deg)'
+  return segments.length ? `conic-gradient(${segments.join(', ')})` : 'conic-gradient(rgb(var(--fg) / 0.08) 0deg 360deg)'
 })
 </script>

--- a/frontend/components/annual2025/Annual2025ShareCardSlide.vue
+++ b/frontend/components/annual2025/Annual2025ShareCardSlide.vue
@@ -3,7 +3,7 @@
     <div class="slide-content">
       <div v-if="!hasUserData" class="max-w-md w-full mx-auto px-4 text-center">
         <div class="bg-[rgb(var(--panel))] border border-[rgb(var(--panel-border))] rounded-lg p-8 md:p-12">
-          <div class="w-20 h-20 mx-auto mb-6 bg-[rgba(var(--fg),0.1)] rounded-full flex items-center justify-center">
+          <div class="w-20 h-20 mx-auto mb-6 bg-[rgb(var(--fg)_/_0.1)] rounded-full flex items-center justify-center">
             <LucideIcon name="Share2" class="w-10 h-10 text-[rgb(var(--muted))]" />
           </div>
           <h2 class="text-xl md:text-2xl font-bold text-[rgb(var(--fg))] mb-3">分享报告</h2>
@@ -152,7 +152,7 @@
               <h3 class="text-lg font-bold text-[rgb(var(--fg))]">选择展示的成就</h3>
               <button
                 @click="showAchievementPicker = false"
-                class="p-1.5 hover:bg-[rgba(var(--fg),0.1)] rounded-lg transition-colors"
+                class="p-1.5 hover:bg-[rgb(var(--fg)_/_0.1)] rounded-lg transition-colors"
               >
                 <LucideIcon name="X" class="w-5 h-5 text-[rgb(var(--muted))]" />
               </button>
@@ -166,7 +166,7 @@
                 class="w-full flex items-start gap-3 p-3 rounded-xl border transition-all text-left"
                 :class="selectedIndices.includes(idx)
                   ? 'bg-[var(--g-accent-soft)] border-[var(--g-accent)]'
-                  : 'bg-[rgba(var(--fg),0.03)] border-transparent hover:border-[rgba(var(--fg),0.1)]'"
+                  : 'bg-[rgb(var(--fg)_/_0.03)] border-transparent hover:border-[rgb(var(--fg)_/_0.1)]'"
               >
                 <div
                   class="w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 mt-0.5"

--- a/frontend/components/annual2025/Annual2025SiteOverviewSlide.vue
+++ b/frontend/components/annual2025/Annual2025SiteOverviewSlide.vue
@@ -18,7 +18,7 @@
             <div class="text-4xl md:text-6xl font-black text-[rgb(var(--fg))] mb-2">
               <Annual2025CountUp :end="siteData.overview.pages.total" />
             </div>
-            <div class="flex items-center gap-1 md:gap-2 text-[rgb(var(--success))] bg-[rgba(var(--success),0.1)] w-fit px-2 py-1 rounded text-xs md:text-sm mb-3 md:mb-4">
+            <div class="flex items-center gap-1 md:gap-2 text-[rgb(var(--success))] bg-[rgb(var(--success)_/_0.1)] w-fit px-2 py-1 rounded text-xs md:text-sm mb-3 md:mb-4">
               <LucideIcon name="TrendingUp" class="w-3 h-3 md:w-4 md:h-4" /> {{ siteData.overview.pages.growth }} 同比增长
             </div>
             <div class="mt-4 md:mt-6 flex-1 flex flex-col justify-center gap-1.5">
@@ -81,7 +81,7 @@
       </div>
     </div>
     <div class="slide-bg">
-      <div class="w-full h-full bg-[radial-gradient(rgba(var(--fg),0.03)_1px,transparent_1px)] bg-[length:24px_24px]" />
+      <div class="w-full h-full bg-[radial-gradient(rgb(var(--fg) / 0.03)_1px,transparent_1px)] bg-[length:24px_24px]" />
     </div>
   </section>
 </template>

--- a/frontend/components/annual2025/Annual2025TrendsSlide.vue
+++ b/frontend/components/annual2025/Annual2025TrendsSlide.vue
@@ -22,7 +22,7 @@
                 <span
                   v-for="t in siteData.pageRankings.topOriginal.tags"
                   :key="t"
-                  class="px-2 py-1 bg-[rgba(var(--fg),0.1)] rounded text-[10px] md:text-xs text-[rgb(var(--muted))]"
+                  class="px-2 py-1 bg-[rgb(var(--fg)_/_0.1)] rounded text-[10px] md:text-xs text-[rgb(var(--muted))]"
                 >
                   #{{ t }}
                 </span>
@@ -49,7 +49,7 @@
                 <span
                   v-for="t in siteData.pageRankings.topTranslation.tags"
                   :key="t"
-                  class="px-2 py-1 bg-[rgba(var(--fg),0.1)] rounded text-[10px] md:text-xs text-[rgb(var(--muted))]"
+                  class="px-2 py-1 bg-[rgb(var(--fg)_/_0.1)] rounded text-[10px] md:text-xs text-[rgb(var(--muted))]"
                 >
                   #{{ t }}
                 </span>

--- a/frontend/components/annual2025/Annual2025UserIdentitySlide.vue
+++ b/frontend/components/annual2025/Annual2025UserIdentitySlide.vue
@@ -3,7 +3,7 @@
     <div class="slide-content">
       <div v-if="!hasUserData" class="max-w-md w-full mx-auto px-4 text-center">
         <div class="bg-[rgb(var(--panel))] border border-[rgb(var(--panel-border))] rounded-lg p-8 md:p-12">
-          <div class="w-20 h-20 mx-auto mb-6 bg-[rgba(var(--fg),0.1)] rounded-full flex items-center justify-center">
+          <div class="w-20 h-20 mx-auto mb-6 bg-[rgb(var(--fg)_/_0.1)] rounded-full flex items-center justify-center">
             <LucideIcon name="User" class="w-10 h-10 text-[rgb(var(--muted))]" />
           </div>
           <h2 class="text-xl md:text-2xl font-bold text-[rgb(var(--fg))] mb-3">个人年度报告</h2>
@@ -35,7 +35,7 @@
             <div class="flex-1 text-center md:text-left w-full">
               <div class="flex flex-col md:flex-row items-center justify-center md:justify-start gap-2 md:gap-3 mb-2">
                 <h1 class="text-2xl md:text-4xl font-bold text-[rgb(var(--fg))]">{{ userData.displayName }}</h1>
-                <span class="px-2 md:px-3 py-1 rounded-full bg-[rgba(var(--success),0.2)] text-[rgb(var(--success))] text-[10px] md:text-xs font-bold border border-[rgba(var(--success),0.3)]">
+                <span class="px-2 md:px-3 py-1 rounded-full bg-[rgb(var(--success)_/_0.2)] text-[rgb(var(--success))] text-[10px] md:text-xs font-bold border border-[rgb(var(--success)_/_0.3)]">
                   {{ userData.rankings.overall.percentileLabel }}
                 </span>
               </div>
@@ -44,21 +44,21 @@
               </p>
 
               <div class="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-3">
-                <div class="text-center bg-[rgba(var(--fg),0.05)] p-2 md:p-3 rounded-lg md:rounded-xl border border-[rgba(var(--fg),0.05)]">
+                <div class="text-center bg-[rgb(var(--fg)_/_0.05)] p-2 md:p-3 rounded-lg md:rounded-xl border border-[rgb(var(--fg)_/_0.05)]">
                   <div class="text-[10px] md:text-xs text-[rgb(var(--muted))] uppercase">全站排名</div>
                   <div class="text-lg md:text-2xl font-black text-[rgb(var(--fg))]">#{{ userData.overview.rankChange.endRank }}</div>
                 </div>
-                <div class="text-center bg-[rgba(var(--fg),0.05)] p-2 md:p-3 rounded-lg md:rounded-xl border border-[rgba(var(--fg),0.05)]">
+                <div class="text-center bg-[rgb(var(--fg)_/_0.05)] p-2 md:p-3 rounded-lg md:rounded-xl border border-[rgb(var(--fg)_/_0.05)]">
                   <div class="text-[10px] md:text-xs text-[rgb(var(--muted))] uppercase">作品数</div>
                   <div class="text-lg md:text-2xl font-black text-[rgb(var(--fg))]">{{ userData.overview.creation.totalCount }}</div>
                   <div class="text-[10px] md:text-xs text-[rgb(var(--muted))]">原创{{ userData.overview.creation.originals }} 翻译{{ userData.overview.creation.translations }}</div>
                 </div>
-                <div class="text-center bg-[rgba(var(--fg),0.05)] p-2 md:p-3 rounded-lg md:rounded-xl border border-[rgba(var(--fg),0.05)]">
+                <div class="text-center bg-[rgb(var(--fg)_/_0.05)] p-2 md:p-3 rounded-lg md:rounded-xl border border-[rgb(var(--fg)_/_0.05)]">
                   <div class="text-[10px] md:text-xs text-[rgb(var(--muted))] uppercase">获得 UpVotes</div>
                   <div class="text-lg md:text-2xl font-black text-[rgb(var(--fg))]">{{ userData.overview.votesReceived.up }}</div>
                   <div class="text-[10px] md:text-xs text-[rgb(var(--muted))]">UpVote 率 {{ (userData.overview.votesReceived.upRate * 100).toFixed(0) }}%</div>
                 </div>
-                <div class="text-center bg-[rgba(var(--fg),0.05)] p-2 md:p-3 rounded-lg md:rounded-xl border border-[rgba(var(--fg),0.05)]">
+                <div class="text-center bg-[rgb(var(--fg)_/_0.05)] p-2 md:p-3 rounded-lg md:rounded-xl border border-[rgb(var(--fg)_/_0.05)]">
                   <div class="text-[10px] md:text-xs text-[rgb(var(--muted))] uppercase">总字数</div>
                   <div class="text-lg md:text-2xl font-black text-[rgb(var(--fg))]">{{ formatNumber(userData.overview.creation.totalWords) }}</div>
                   <div class="text-[10px] md:text-xs text-[rgb(var(--muted))]">{{ userData.overview.creation.totalCount > 0 ? Math.round(userData.overview.creation.totalWords / userData.overview.creation.totalCount).toLocaleString() : 0 }} 字/篇</div>
@@ -70,7 +70,7 @@
       </div>
     </div>
     <div class="slide-bg">
-      <div class="w-full h-full bg-[radial-gradient(rgba(var(--fg),0.03)_1px,transparent_1px)] bg-[length:24px_24px]" />
+      <div class="w-full h-full bg-[radial-gradient(rgb(var(--fg) / 0.03)_1px,transparent_1px)] bg-[length:24px_24px]" />
     </div>
   </section>
 </template>

--- a/frontend/components/annual2025/Annual2025VoteAnalyticsSlide.vue
+++ b/frontend/components/annual2025/Annual2025VoteAnalyticsSlide.vue
@@ -87,11 +87,11 @@
               <LucideIcon name="BarChart2" class="w-4 h-4 md:w-5 md:h-5 text-[var(--g-accent)]" />
             </div>
             <div class="grid grid-cols-2 gap-3 mt-3">
-              <div class="text-center p-3 bg-[rgba(var(--fg),0.03)] rounded-lg">
+              <div class="text-center p-3 bg-[rgb(var(--fg)_/_0.03)] rounded-lg">
                 <div class="text-xl md:text-2xl font-bold text-green-500">{{ formatNumber(siteData.overview.votes.up) }}</div>
                 <div class="text-[10px] text-[rgb(var(--muted))]">UpVotes</div>
               </div>
-              <div class="text-center p-3 bg-[rgba(var(--fg),0.03)] rounded-lg">
+              <div class="text-center p-3 bg-[rgb(var(--fg)_/_0.03)] rounded-lg">
                 <div class="text-xl md:text-2xl font-bold text-red-400">{{ formatNumber(siteData.overview.votes.down) }}</div>
                 <div class="text-[10px] text-[rgb(var(--muted))]">DownVotes</div>
               </div>

--- a/frontend/components/annual2025/Annual2025VotingStyleSlide.vue
+++ b/frontend/components/annual2025/Annual2025VotingStyleSlide.vue
@@ -3,7 +3,7 @@
     <div class="slide-content">
       <div v-if="!hasUserData" class="max-w-md w-full mx-auto px-4 text-center">
         <div class="bg-[rgb(var(--panel))] border border-[rgb(var(--panel-border))] rounded-lg p-8 md:p-12">
-          <div class="w-20 h-20 mx-auto mb-6 bg-[rgba(var(--fg),0.1)] rounded-full flex items-center justify-center">
+          <div class="w-20 h-20 mx-auto mb-6 bg-[rgb(var(--fg)_/_0.1)] rounded-full flex items-center justify-center">
             <LucideIcon name="Vote" class="w-10 h-10 text-[rgb(var(--muted))]" />
           </div>
           <h2 class="text-xl md:text-2xl font-bold text-[rgb(var(--fg))] mb-3">投票风格</h2>
@@ -165,7 +165,7 @@
       </div>
     </div>
     <div class="slide-bg">
-      <div class="w-full h-full bg-[radial-gradient(rgba(var(--fg),0.03)_1px,transparent_1px)] bg-[length:24px_24px]" />
+      <div class="w-full h-full bg-[radial-gradient(rgb(var(--fg) / 0.03)_1px,transparent_1px)] bg-[length:24px_24px]" />
     </div>
   </section>
 </template>

--- a/frontend/components/auth/LoginPanel.vue
+++ b/frontend/components/auth/LoginPanel.vue
@@ -43,7 +43,7 @@
 
         <button
           type="submit"
-          class="flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--g-accent)] px-4 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgba(var(--accent),0.6)] disabled:opacity-60 disabled:cursor-not-allowed dark:focus:ring-offset-neutral-950"
+          class="flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--g-accent)] px-4 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgb(var(--accent)_/_0.6)] disabled:opacity-60 disabled:cursor-not-allowed dark:focus:ring-offset-neutral-950"
           :disabled="!canSubmit || isSubmitting"
         >
           <LucideIcon v-if="isSubmitting" name="Loader2" class="h-4 w-4 animate-spin" stroke-width="2" />

--- a/frontend/components/collections/CollectionManager.vue
+++ b/frontend/components/collections/CollectionManager.vue
@@ -90,7 +90,7 @@
               type="button"
               class="group relative w-full overflow-hidden rounded-lg border border-transparent bg-white/90 p-5 text-left shadow-sm backdrop-blur-sm transition duration-300 hover:-translate-y-1 hover:shadow-sm dark:bg-neutral-900/80 dark:shadow-lg"
               :class="collection.id === activeId
-                ? 'ring-2 ring-[var(--g-accent-border)] shadow dark:ring-[rgba(var(--accent),0.5)]'
+                ? 'ring-2 ring-[var(--g-accent-border)] shadow dark:ring-[rgb(var(--accent)_/_0.5)]'
                 : 'border-neutral-200/80 hover:border-[var(--g-accent-border)] dark:border-neutral-800/70'"
               @click="select(collection.id)"
             >

--- a/frontend/components/tools/CalendarTool.vue
+++ b/frontend/components/tools/CalendarTool.vue
@@ -110,7 +110,7 @@
                   <div
                     v-if="seg.isHead || (segmentsByMonth[mIdx][wIdx].visible.length === 1 && segmentsByMonth[mIdx][wIdx].overflow === 0)"
                     :key="'s-' + seg.key + '-expanded'"
-                    class="absolute group box-border flex h-full items-center overflow-hidden px-1.5 text-[10px] font-medium leading-tight shadow-sm cursor-pointer focus:outline-none focus:ring-2 focus:ring-[rgba(var(--accent),0.5)] z-10"
+                    class="absolute group box-border flex h-full items-center overflow-hidden px-1.5 text-[10px] font-medium leading-tight shadow-sm cursor-pointer focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent)_/_0.5)] z-10"
                     :style="segmentStyleExpanded(seg)"
                     role="button"
                     tabindex="0"
@@ -653,7 +653,7 @@ onUnmounted(() => {
   position: absolute;
   inset: -2px -5px;
   border-radius: 9999px;
-  box-shadow: 0 0 0 1.5px rgba(var(--accent), 0.75) inset;
+  box-shadow: 0 0 0 1.5px rgb(var(--accent) / 0.75) inset;
 }
 
 /* Animations */
@@ -664,7 +664,7 @@ onUnmounted(() => {
 
 /* Improve focus visibility for keyboard users */
 :focus-visible {
-  outline: 2px solid rgba(var(--accent), 0.6);
+  outline: 2px solid rgb(var(--accent) / 0.6);
   outline-offset: 2px;
 }
 </style>

--- a/frontend/components/tools/TagCheckTool.vue
+++ b/frontend/components/tools/TagCheckTool.vue
@@ -14,7 +14,7 @@
       </div>
       <button
         type="button"
-        class="self-start inline-flex items-center gap-1.5 rounded-full border border-neutral-200/80 bg-white/80 px-4 py-2 text-sm font-medium text-neutral-600 shadow-sm transition hover:border-[rgba(var(--accent),0.4)] hover:text-[var(--g-accent)] dark:border-neutral-700/70 dark:bg-neutral-900/70 dark:text-neutral-200"
+        class="self-start inline-flex items-center gap-1.5 rounded-full border border-neutral-200/80 bg-white/80 px-4 py-2 text-sm font-medium text-neutral-600 shadow-sm transition hover:border-[rgb(var(--accent)_/_0.4)] hover:text-[var(--g-accent)] dark:border-neutral-700/70 dark:bg-neutral-900/70 dark:text-neutral-200"
         @click="reload"
       >
         <span class="inline-block w-2 h-2 rounded-full" :class="loading ? 'animate-ping bg-[var(--g-accent)]' : 'bg-neutral-400 dark:bg-neutral-500'" />

--- a/frontend/components/user/UserHeader.vue
+++ b/frontend/components/user/UserHeader.vue
@@ -14,7 +14,7 @@
           :title="isFollowingThis ? '取消收藏作者' : '收藏作者'"
           class="inline-flex items-center justify-center h-9 w-9 rounded-full border transition shadow-sm"
           :class="isFollowingThis
-            ? 'border-[rgba(var(--accent),0.45)] bg-[var(--g-accent-soft)] text-[var(--g-accent)] dark:border-[rgba(var(--accent),0.45)]'
+            ? 'border-[rgb(var(--accent)_/_0.45)] bg-[var(--g-accent-soft)] text-[var(--g-accent)] dark:border-[rgb(var(--accent)_/_0.45)]'
             : 'border-neutral-200 bg-white/80 text-neutral-600 hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:bg-neutral-800/80 dark:text-neutral-300'"
           @click="$emit('toggle-follow')"
         >

--- a/frontend/pages/account/index.vue
+++ b/frontend/pages/account/index.vue
@@ -293,7 +293,7 @@
               :class="[
                 'rounded-lg border p-5 shadow-sm transition',
                 followGroupUnreadCount(group) > 0
-                  ? 'border-[var(--g-accent-border)] bg-[var(--g-accent-soft)] hover:border-[rgba(var(--accent),0.6)] dark:border-[rgba(var(--accent),0.55)] dark:bg-[var(--g-accent-medium)] dark:hover:border-[rgba(var(--accent),0.7)]'
+                  ? 'border-[var(--g-accent-border)] bg-[var(--g-accent-soft)] hover:border-[rgb(var(--accent)_/_0.6)] dark:border-[rgb(var(--accent)_/_0.55)] dark:bg-[var(--g-accent-medium)] dark:hover:border-[rgb(var(--accent)_/_0.7)]'
                   : 'border-neutral-200 bg-white/80 hover:border-neutral-300 dark:border-neutral-700 dark:bg-neutral-900/70 dark:hover:border-neutral-600'
               ]"
             >
@@ -343,7 +343,7 @@
                   class="rounded-xl border px-3 py-2"
                   :class="alert.acknowledgedAt
                     ? 'border-transparent bg-neutral-100/70 text-neutral-600 dark:bg-neutral-900/60 dark:text-neutral-300'
-                    : 'border-[var(--g-accent-border)] bg-white/90 text-neutral-700 shadow-sm dark:border-[rgba(var(--accent),0.55)] dark:bg-neutral-900/80 dark:text-neutral-100'"
+                    : 'border-[var(--g-accent-border)] bg-white/90 text-neutral-700 shadow-sm dark:border-[rgb(var(--accent)_/_0.55)] dark:bg-neutral-900/80 dark:text-neutral-100'"
                 >
                   <div class="flex flex-wrap items-center gap-2">
                     <span
@@ -437,7 +437,7 @@
                 'rounded-lg border p-5 shadow-sm transition',
                 item.acknowledgedAt
                   ? 'border-neutral-200 bg-white/80 hover:border-neutral-300 dark:border-neutral-700 dark:bg-neutral-900/70 dark:hover:border-neutral-600'
-                  : 'border-[var(--g-accent-border)] bg-[var(--g-accent-soft)] hover:border-[rgba(var(--accent),0.6)] dark:border-[rgba(var(--accent),0.55)] dark:bg-[var(--g-accent-medium)] dark:hover:border-[rgba(var(--accent),0.7)]'
+                  : 'border-[var(--g-accent-border)] bg-[var(--g-accent-soft)] hover:border-[rgb(var(--accent)_/_0.6)] dark:border-[rgb(var(--accent)_/_0.55)] dark:bg-[var(--g-accent-medium)] dark:hover:border-[rgb(var(--accent)_/_0.7)]'
               ]"
             >
               <div class="flex flex-wrap items-start justify-between gap-4">
@@ -539,7 +539,7 @@
                 class="inline-flex items-center gap-1 rounded-full border px-3 py-1.5 font-semibold transition"
                 :class="activeMetricMuted
                   ? 'border-neutral-200 bg-white/60 text-neutral-500 hover:border-neutral-300 dark:border-neutral-700 dark:bg-neutral-900/60 dark:text-neutral-400'
-                  : 'border-[var(--g-accent-border)] bg-[var(--g-accent-soft)] text-[var(--g-accent)] hover:border-[rgba(var(--accent),0.55)] dark:border-[var(--g-accent-border)] dark:bg-neutral-900/70 dark:text-[var(--g-accent)]'"
+                  : 'border-[var(--g-accent-border)] bg-[var(--g-accent-soft)] text-[var(--g-accent)] hover:border-[rgb(var(--accent)_/_0.55)] dark:border-[var(--g-accent-border)] dark:bg-neutral-900/70 dark:text-[var(--g-accent)]'"
                 :disabled="alertPreferencesLoading || alertPreferencesSaving || metricMutePending"
                 @click="handleToggleMetricMute"
               >{{ metricMutePending ? '处理中…' : (activeMetricMuted ? '开启提醒' : '关闭提醒') }}</button>

--- a/frontend/pages/admin/index.vue
+++ b/frontend/pages/admin/index.vue
@@ -148,7 +148,7 @@
                     <ul>
                       <li v-for="u in wikidotResults" :key="u.wikidotId" class="flex items-center justify-between gap-2 border-b border-neutral-200/70 px-3 py-2 last:border-none dark:border-neutral-800/60">
                         <div class="truncate"><span class="font-medium">{{ u.displayName }}</span> <span class="text-neutral-500">#{{ u.wikidotId }}</span></div>
-                        <button class="rounded border border-[rgba(var(--accent),0.5)] px-2 py-1 text-xs font-semibold text-[rgb(var(--accent-strong))] hover:bg-[var(--g-accent-soft)]" @click="selectWikidot(u)">选择</button>
+                        <button class="rounded border border-[rgb(var(--accent)_/_0.5)] px-2 py-1 text-xs font-semibold text-[rgb(var(--accent-strong))] hover:bg-[var(--g-accent-soft)]" @click="selectWikidot(u)">选择</button>
                       </li>
                     </ul>
                   </div>

--- a/frontend/pages/annual2025.vue
+++ b/frontend/pages/annual2025.vue
@@ -472,7 +472,7 @@ onUnmounted(() => {
 }
 
 .annual-summary :deep(.bar-track) {
-  @apply bg-[rgba(var(--fg),0.12)] rounded-full flex;
+  @apply bg-[rgb(var(--fg)_/_0.12)] rounded-full flex;
 }
 
 /* 水平 bar 基础样式 */
@@ -538,14 +538,14 @@ onUnmounted(() => {
 }
 
 .annual-summary :deep(.clock-ring) {
-  stroke: rgba(var(--fg), 0.12);
+  stroke: rgb(var(--fg) / 0.12);
   stroke-width: 1.2;
   fill: none;
 }
 
 .annual-summary :deep(.clock-core) {
   fill: rgb(var(--bg));
-  stroke: rgba(var(--fg), 0.08);
+  stroke: rgb(var(--fg) / 0.08);
   stroke-width: 1;
 }
 
@@ -576,7 +576,7 @@ onUnmounted(() => {
 
 .annual-summary :deep(.contributor-card-mini) {
   @apply bg-[rgb(var(--panel))] border rounded-xl p-4 relative overflow-hidden;
-  @apply hover:bg-[rgba(var(--fg),0.03)] transition-all duration-300;
+  @apply hover:bg-[rgb(var(--fg)_/_0.03)] transition-all duration-300;
 }
 
 .annual-summary :deep(.contributor-avatar) {

--- a/frontend/pages/auth/register.vue
+++ b/frontend/pages/auth/register.vue
@@ -53,7 +53,7 @@
             >
             <button
               type="button"
-              class="inline-flex items-center justify-center rounded-xl border border-[var(--g-accent-border)] bg-[var(--g-accent-soft)] px-4 py-3 text-sm font-medium text-[var(--g-accent)] transition hover:bg-[var(--g-accent-strong)] focus:outline-none focus:ring-2 focus:ring-[rgba(var(--accent),0.4)] disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto w-full"
+              class="inline-flex items-center justify-center rounded-xl border border-[var(--g-accent-border)] bg-[var(--g-accent-soft)] px-4 py-3 text-sm font-medium text-[var(--g-accent)] transition hover:bg-[var(--g-accent-strong)] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent)_/_0.4)] disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto w-full"
               :disabled="isSendingCode || isSubmitting || !isEmailValid || cooldown > 0"
               @click="handleSendCode"
             >
@@ -105,7 +105,7 @@
 
         <button
           type="submit"
-          class="inline-flex w-full items-center justify-center rounded-xl border border-[rgba(var(--accent),0.4)] bg-[var(--g-accent)] px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgba(var(--accent),0.4)] disabled:cursor-not-allowed disabled:opacity-60 dark:bg-[rgb(var(--accent-strong))] dark:text-neutral-100"
+          class="inline-flex w-full items-center justify-center rounded-xl border border-[rgb(var(--accent)_/_0.4)] bg-[var(--g-accent)] px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgb(var(--accent)_/_0.4)] disabled:cursor-not-allowed disabled:opacity-60 dark:bg-[rgb(var(--accent-strong))] dark:text-neutral-100"
           :disabled="isSubmitting || !canSubmit"
         >
           <span v-if="isSubmitting">正在注册...</span>

--- a/frontend/pages/newbee2025.vue
+++ b/frontend/pages/newbee2025.vue
@@ -10,12 +10,12 @@
             <h1 class="text-3xl font-semibold text-neutral-900 dark:text-neutral-50 sm:text-4xl">2025“群雄逐鹿”新秀竞赛</h1>
           </div>
         </div>
-        <div class="rounded-lg border border-[rgba(var(--accent),0.4)] bg-[var(--g-accent-soft)] px-6 py-5 text-sm text-[rgb(var(--accent-strong))]">
+        <div class="rounded-lg border border-[rgb(var(--accent)_/_0.4)] bg-[var(--g-accent-soft)] px-6 py-5 text-sm text-[rgb(var(--accent-strong))]">
           <div class="font-semibold">当前更新时间</div>
           <div class="mt-1 font-mono text-lg tracking-wide">
             {{ nowFormatted }}
           </div>
-          <div class="mt-2 text-xs text-[rgba(var(--accent-strong),0.7)]">基于浏览器本地时间</div>
+          <div class="mt-2 text-xs text-[rgb(var(--accent-strong)_/_0.7)]">基于浏览器本地时间</div>
         </div>
       </div>
     </section>
@@ -34,7 +34,7 @@
           class="relative rounded-lg border p-5 transition-colors"
           :class="[
             'border-neutral-200/80 bg-white/80 dark:border-neutral-800/70 dark:bg-neutral-900/80 backdrop-blur',
-            milestone.key === nextMilestoneKey && milestone.status === 'upcoming' ? 'ring-2 ring-[rgba(var(--accent),0.65)]' : ''
+            milestone.key === nextMilestoneKey && milestone.status === 'upcoming' ? 'ring-2 ring-[rgb(var(--accent)_/_0.65)]' : ''
           ]"
         >
           <div class="flex items-start justify-between gap-4">
@@ -75,7 +75,7 @@
         </div>
         <button
           type="button"
-          class="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:border-[rgba(var(--accent),0.5)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
+          class="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:border-[rgb(var(--accent)_/_0.5)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
           @click="refreshTrackHighlights"
           :disabled="entriesPending"
         >
@@ -151,7 +151,7 @@
         </div>
         <button
           type="button"
-          class="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:border-[rgba(var(--accent),0.5)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
+          class="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:border-[rgb(var(--accent)_/_0.5)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
           @click="refreshThemeHighlights"
           :disabled="entriesPending"
         >
@@ -226,7 +226,7 @@
           <button
             v-if="orderMode === 'random'"
             type="button"
-            class="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:border-[rgba(var(--accent),0.5)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
+            class="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:border-[rgb(var(--accent)_/_0.5)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
             @click="reshuffleEntries"
             :disabled="entriesPending"
           >

--- a/frontend/pages/ranking.vue
+++ b/frontend/pages/ranking.vue
@@ -676,7 +676,7 @@ useHead({ title: '作者排行' });
   pointer-events: none;
   border-radius: 0px;                     /* 需要无圆角可设为 0 */
 }
-.dark .rank-row::before{ background-color: rgba(var(--accent-strong),0.22); }
+.dark .rank-row::before{ background-color: rgb(var(--accent-strong) / 0.22); }
 
 /* —— 表头列高亮（仅在右侧网格内） —— */
 .metric-head-grid{ position: relative; }
@@ -690,7 +690,7 @@ useHead({ title: '作者排行' });
   pointer-events: none;
   border-radius: 6px;
 }
-.dark .metric-head-grid::before{ background-color: rgba(var(--accent-strong),0.22); }
+.dark .metric-head-grid::before{ background-color: rgb(var(--accent-strong) / 0.22); }
 
 /* —— 表头按钮（填满单元格，不影响列高亮） —— */
 .th-btn{

--- a/frontend/pages/sample/index.vue
+++ b/frontend/pages/sample/index.vue
@@ -598,7 +598,7 @@ definePageMeta({ layout: 'default' })
   @apply w-5 h-5 mr-3 text-[rgb(var(--muted))];
 }
 .search-input {
-  @apply flex-1 bg-transparent border-none outline-none text-lg text-[rgb(var(--fg))] placeholder-[rgb(var(--muted)/0.7)];
+  @apply flex-1 bg-transparent border-none outline-none text-lg text-[rgb(var(--fg))] placeholder-[rgb(var(--muted)_/_0.7)];
 }
 .search-btn {
   @apply w-10 h-10 rounded-full flex items-center justify-center bg-[rgb(var(--fg))] text-[rgb(var(--panel))] transition-transform active:scale-95;
@@ -675,7 +675,7 @@ definePageMeta({ layout: 'default' })
   @apply space-y-6;
 }
 .section-header {
-  @apply flex items-center justify-between pb-2 border-b border-[rgb(var(--panel-border)/0.6)];
+  @apply flex items-center justify-between pb-2 border-b border-[rgb(var(--panel-border)_/_0.6)];
 }
 .title-group {
   @apply flex items-center gap-3;
@@ -803,7 +803,7 @@ definePageMeta({ layout: 'default' })
   @apply grid grid-cols-2 gap-3;
 }
 .matrix-item {
-  @apply bg-[rgb(var(--bg))] p-3 rounded border border-[rgb(var(--panel-border)/0.5)] flex flex-col items-center text-center;
+  @apply bg-[rgb(var(--bg))] p-3 rounded border border-[rgb(var(--panel-border)_/_0.5)] flex flex-col items-center text-center;
 }
 .matrix-label {
   @apply text-[10px] uppercase;
@@ -814,7 +814,7 @@ definePageMeta({ layout: 'default' })
   font-family: 'Times New Roman', serif;
 }
 .widget-footer {
-  @apply mt-4 pt-3 border-t border-[rgb(var(--panel-border)/0.5)] text-center;
+  @apply mt-4 pt-3 border-t border-[rgb(var(--panel-border)_/_0.5)] text-center;
 }
 .update-time {
   @apply text-xs;
@@ -826,7 +826,7 @@ definePageMeta({ layout: 'default' })
   @apply flex flex-col gap-3;
 }
 .author-item {
-  @apply flex items-center gap-3 rounded-md border border-[rgb(var(--panel-border)/0.5)] bg-[rgb(var(--bg))] p-2;
+  @apply flex items-center gap-3 rounded-md border border-[rgb(var(--panel-border)_/_0.5)] bg-[rgb(var(--bg))] p-2;
 }
 .author-avatar {
   @apply border border-[rgb(var(--panel-border))];

--- a/frontend/pages/scpcn4k.vue
+++ b/frontend/pages/scpcn4k.vue
@@ -27,12 +27,12 @@
             </div>
           </div>
         </div>
-        <div class="rounded-lg border border-[rgba(var(--accent),0.4)] bg-[var(--g-accent-soft)] px-6 py-5 text-sm text-[rgb(var(--accent-strong))]">
+        <div class="rounded-lg border border-[rgb(var(--accent)_/_0.4)] bg-[var(--g-accent-soft)] px-6 py-5 text-sm text-[rgb(var(--accent-strong))]">
           <div class="font-semibold">当前更新时间</div>
           <div class="mt-1 font-mono text-lg tracking-wide">
             {{ nowFormatted }}
           </div>
-          <div class="mt-2 text-xs text-[rgba(var(--accent-strong),0.7)]">基于浏览器本地时间</div>
+          <div class="mt-2 text-xs text-[rgb(var(--accent-strong)_/_0.7)]">基于浏览器本地时间</div>
         </div>
       </div>
       <div
@@ -109,7 +109,7 @@
           class="relative rounded-lg border p-5 transition-colors"
           :class="[
             'border-neutral-200/80 bg-white/80 dark:border-neutral-800/70 dark:bg-neutral-900/80 backdrop-blur',
-            phase.key === nextPhaseKey || phase.status === 'ongoing' ? 'ring-2 ring-[rgba(var(--accent),0.65)]' : ''
+            phase.key === nextPhaseKey || phase.status === 'ongoing' ? 'ring-2 ring-[rgb(var(--accent)_/_0.65)]' : ''
           ]"
         >
           <div class="flex items-start justify-between gap-4">
@@ -140,7 +140,7 @@
         </div>
         <button
           type="button"
-          class="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:border-[rgba(var(--accent),0.5)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
+          class="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:border-[rgb(var(--accent)_/_0.5)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
           @click="refreshHighlights"
           :disabled="entriesPending"
         >
@@ -192,7 +192,7 @@
           <button
             v-if="orderMode === 'random'"
             type="button"
-            class="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:border-[rgba(var(--accent),0.5)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
+            class="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:border-[rgb(var(--accent)_/_0.5)] hover:text-[var(--g-accent)] dark:border-neutral-700 dark:text-neutral-300"
             @click="reshuffleAll"
             :disabled="entriesPending"
           >

--- a/frontend/pages/tag/[tag].vue
+++ b/frontend/pages/tag/[tag].vue
@@ -16,7 +16,7 @@
       <div class="flex flex-wrap items-center gap-3">
         <button
           type="button"
-          class="inline-flex items-center gap-2 rounded-full border border-neutral-200/80 bg-white/80 px-4 py-2 text-sm font-medium text-neutral-600 shadow-sm transition hover:border-[rgba(var(--accent),0.4)] hover:text-[var(--g-accent)] dark:border-neutral-700/70 dark:bg-neutral-900/70 dark:text-neutral-200"
+          class="inline-flex items-center gap-2 rounded-full border border-neutral-200/80 bg-white/80 px-4 py-2 text-sm font-medium text-neutral-600 shadow-sm transition hover:border-[rgb(var(--accent)_/_0.4)] hover:text-[var(--g-accent)] dark:border-neutral-700/70 dark:bg-neutral-900/70 dark:text-neutral-200"
           @click="navigateToSearch"
         >
           <LucideIcon name="Search" class="h-4 w-4" />
@@ -24,7 +24,7 @@
         </button>
         <button
           type="button"
-          class="inline-flex items-center gap-2 rounded-full border border-neutral-200/80 bg-white/80 px-4 py-2 text-sm font-medium text-neutral-600 shadow-sm transition hover:border-[rgba(var(--accent),0.4)] hover:text-[var(--g-accent)] dark:border-neutral-700/70 dark:bg-neutral-900/70 dark:text-neutral-200"
+          class="inline-flex items-center gap-2 rounded-full border border-neutral-200/80 bg-white/80 px-4 py-2 text-sm font-medium text-neutral-600 shadow-sm transition hover:border-[rgb(var(--accent)_/_0.4)] hover:text-[var(--g-accent)] dark:border-neutral-700/70 dark:bg-neutral-900/70 dark:text-neutral-200"
           @click="reload"
         >
           <LucideIcon name="RefreshCcw" class="h-4 w-4" />
@@ -115,7 +115,7 @@
         <article
           v-for="page in recentPages.slice(0, 8)"
           :key="`recent-${page.wikidotId || page.title}`"
-          class="rounded-lg border border-neutral-200/70 bg-white/85 p-4 transition hover:-translate-y-0.5 hover:border-[rgba(var(--accent),0.4)] dark:border-neutral-800/70 dark:bg-neutral-900/80"
+          class="rounded-lg border border-neutral-200/70 bg-white/85 p-4 transition hover:-translate-y-0.5 hover:border-[rgb(var(--accent)_/_0.4)] dark:border-neutral-800/70 dark:bg-neutral-900/80"
         >
           <div class="flex items-start justify-between gap-3">
             <NuxtLink :to="`/page/${page.wikidotId}`" class="font-medium text-neutral-900 hover:text-[var(--g-accent)] dark:text-neutral-100">

--- a/frontend/pages/tools/index.vue
+++ b/frontend/pages/tools/index.vue
@@ -33,7 +33,7 @@
             <h3 class="text-lg font-semibold text-neutral-900 transition-colors group-hover:text-[var(--g-accent)] dark:text-neutral-100">{{ item.title }}</h3>
             <p class="text-sm text-neutral-500 dark:text-neutral-400">{{ item.description }}</p>
           </div>
-          <span class="absolute right-6 top-6 text-xs font-medium uppercase tracking-wide text-[rgba(var(--accent),0.7)]">
+          <span class="absolute right-6 top-6 text-xs font-medium uppercase tracking-wide text-[rgb(var(--accent)_/_0.7)]">
             {{ item.badge }}
           </span>
         </NuxtLink>

--- a/frontend/pages/user/[wikidotId]/collections/[slug].vue
+++ b/frontend/pages/user/[wikidotId]/collections/[slug].vue
@@ -95,7 +95,7 @@
             :class="[
               'group relative overflow-hidden rounded-lg border p-5 shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-sm',
               item.pinned
-                ? 'border-[rgba(var(--accent),0.45)] bg-[var(--g-accent-hover)] dark:border-[rgba(var(--accent),0.45)] dark:bg-[var(--g-accent-medium)]'
+                ? 'border-[rgb(var(--accent)_/_0.45)] bg-[var(--g-accent-hover)] dark:border-[rgb(var(--accent)_/_0.45)] dark:bg-[var(--g-accent-medium)]'
                 : 'border-neutral-200/80 bg-white/95 dark:border-neutral-800/70 dark:bg-neutral-900/80'
             ]"
           >
@@ -104,7 +104,7 @@
             </div>
             <span
               v-if="item.pinned"
-              class="absolute right-5 top-5 inline-flex items-center gap-1 rounded-full bg-[rgba(var(--accent),0.9)] px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white shadow-lg"
+              class="absolute right-5 top-5 inline-flex items-center gap-1 rounded-full bg-[rgb(var(--accent)_/_0.9)] px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white shadow-lg"
             >
               <LucideIcon name="Star" class="h-3 w-3" />
               置顶

--- a/frontend/pages/winter-contest-2026.vue
+++ b/frontend/pages/winter-contest-2026.vue
@@ -30,7 +30,7 @@
           <div class="mt-1 font-mono text-lg tracking-wide">
             <ClientOnly>{{ nowFormatted }}<template #fallback>--</template></ClientOnly>
           </div>
-          <div class="mt-2 text-xs text-[rgba(var(--accent-strong),0.7)]">基于浏览器本地时间</div>
+          <div class="mt-2 text-xs text-[rgb(var(--accent-strong)_/_0.7)]">基于浏览器本地时间</div>
         </div>
       </div>
       <div
@@ -71,7 +71,7 @@
           class="relative rounded-lg border p-5 transition-colors"
           :class="[
             'border-neutral-200/80 bg-white/80 dark:border-neutral-800/70 dark:bg-neutral-900/80 backdrop-blur',
-            milestone.key === nextMilestoneKey && milestone.status === 'upcoming' ? 'ring-2 ring-[rgba(var(--accent),0.65)]' : ''
+            milestone.key === nextMilestoneKey && milestone.status === 'upcoming' ? 'ring-2 ring-[rgb(var(--accent)_/_0.65)]' : ''
           ]"
         >
           <div class="flex items-start justify-between gap-4">


### PR DESCRIPTION
## Summary
- `--accent` 等 CSS 变量使用空格分隔 RGB 值 (`10 132 255`)，与逗号分隔的 `rgba()` 混用产生无效 CSS `rgba(10 132 255, 0.5)`
- 统一替换为现代 CSS 语法 `rgb(var(--xxx) / alpha)`
- Tailwind 任意值中使用下划线语法 `rgb(var(--xxx)_/_alpha)`
- 影响 36 个文件、133 处引用，涵盖选中态、hover、border、shadow 等样式

## Test plan
- [x] `npm run build` 构建通过
- [ ] 检查排名页、账户页、年度报告页的选中/active 样式是否正常显示背景色
- [ ] 暗色模式下 accent 相关样式是否正确渲染
- [ ] 移动端 bottom tabs active 状态确认