### PR TITLE
fix(bff): LIMIT 分页缺 tiebreaker 导致漏行/重复

### DIFF
--- a/bff/src/web/routes/forums.ts
+++ b/bff/src/web/routes/forums.ts
@@ -111,7 +111,7 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
                    "createdAt", "postCount", "pageId", "isDeleted"
             FROM "ForumThread"
             WHERE "categoryId" = $1 AND "isDeleted" = false
-            ORDER BY "createdAt" DESC NULLS LAST
+            ORDER BY "createdAt" DESC NULLS LAST, id DESC
             LIMIT $2 OFFSET $3
           `, [categoryId, limit, offset]),
           readPool.query(`

--- a/bff/src/web/routes/pages.ts
+++ b/bff/src/web/routes/pages.ts
@@ -735,7 +735,7 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
           AND ($7::timestamptz IS NULL OR pv."createdAt" >= $7::timestamptz)
           AND ($8::timestamptz IS NULL OR pv."createdAt" <= $8::timestamptz)
           
-        ORDER BY ${orderColumn} ${dir} NULLS LAST
+        ORDER BY ${orderColumn} ${dir} NULLS LAST, p.id DESC
         LIMIT $9::int OFFSET $10::int
       `;
 


### PR DESCRIPTION
## 背景

性能/正确性审计发现 BFF 两处 ORDER BY + LIMIT 的排序列非唯一，导致：
- 多行排序值相等时，PostgreSQL 对 \`LIMIT N OFFSET M\` 返回的行是**不确定**的
- 并发插入与排序值相同的场景下，翻页会**漏行**或**重复**返回同一行

## 修复

在两处 ORDER BY 末尾追加主键作为 tiebreaker：

| 文件 | 场景 | 改动 |
|---|---|---|
| \`bff/src/web/routes/forums.ts:114\` | 论坛线程按创建时间分页 | 追加 \`, id DESC\` |
| \`bff/src/web/routes/pages.ts:738\` | 按 wikidotId 查询的 PageVersion 列表排序 | 追加 \`, p.id DESC\` |

## 为什么 pages.ts 选 \`p.id\`

\`WHERE pv."validTo" IS NULL\` 过滤后每个 Page 只剩一个当前版本。\`Page.id\` 是主键，在结果集中唯一，比 \`pv.id\` 更直观。

## 审计复核

\`analytics.ts:308-313\` 最初在审计清单里，但复核源码后确认该处 ORDER BY 末尾已经有 \`b.id DESC\`，无需修改。

## 影响

- 仅 SQL 改动，不影响业务语义
- 对 PostgreSQL 查询计划影响极小（主键已有索引）
- 修复两个真实的分页漏/重 bug

## 验证

- \`npm run build\` 在 bff 目录通过（TypeScript 编译 OK）
- 改动是 SQL 字符串，不影响代码逻辑，不需新增测试