### PR TITLE
chore(ops): 生产 PG 加 drop-in 性能调优 + pg_trgm

### DIFF
--- a/docs/ops/postgresql-50-performance-tuning.conf
+++ b/docs/ops/postgresql-50-performance-tuning.conf
@@ -1,0 +1,29 @@
+# 50-performance-tuning.conf
+# Drop-in override for PostgreSQL 17 cluster running SCPper CN.
+# Install location: /etc/postgresql/17/{main,replica}/conf.d/50-performance-tuning.conf
+# Applied by scripts/ops/apply-pg-tuning.sh.
+#
+# Rationale lives in docs/ops/postgresql-tuning.md. The values below are tuned
+# for the production host (64 GB RAM, NVMe SSD, PostgreSQL 17.5).
+
+# --- Planner: match SSD characteristics ---
+# Default random_page_cost = 4.0 assumes spinning disks. On NVMe the random/seq
+# ratio is close to 1; 1.2 nudges the planner toward index scans when it would
+# otherwise prefer sequential scans of large tables.
+random_page_cost = 1.2
+
+# Hint to the planner about total OS-level filesystem cache available to
+# PostgreSQL. This is advisory, not an allocation. 32 GB is a conservative
+# estimate leaving headroom for other services on the host.
+effective_cache_size = 32GB
+
+# NVMe devices can sustain many outstanding async reads; default 1 prevents
+# bitmap heap scans from prefetching.
+effective_io_concurrency = 256
+
+# --- WAL: reduce checkpoint frequency under write bursts ---
+# Larger checkpoint spacing reduces write amplification during bulk loads
+# (syncer Phase A/B, gacha settlement). Crash recovery is slightly longer but
+# still measured in seconds at this size.
+max_wal_size = 2GB
+min_wal_size = 160MB

--- a/docs/ops/postgresql-tuning.md
+++ b/docs/ops/postgresql-tuning.md
@@ -1,0 +1,94 @@
+# PostgreSQL 性能调优（2026-04-17）
+
+本文档记录一次 PG 运行时参数调优，目标是让 planner 更准确估计 IO 成本，
+并减少写入密集场景下的 checkpoint 抖动。
+
+变更通过 drop-in 文件 `docs/ops/postgresql-50-performance-tuning.conf`
+安装到 `/etc/postgresql/17/{main,replica}/conf.d/` 生效，**不修改**发行版
+自带的 `postgresql.conf`，便于回滚。
+
+## 背景
+
+- 主机：64 GB RAM、NVMe SSD
+- 集群：`pg_lsclusters` 显示 `17/main`（5434，应用）和 `17/replica`（5433）
+- 原始运行值（`SELECT ... FROM pg_settings`）：
+  - `effective_cache_size = 4GB`（默认，未设置）
+  - `random_page_cost = 4`（默认，针对 HDD）
+  - `effective_io_concurrency = 1`（默认）
+  - `max_wal_size = 1GB`（默认）
+  - `min_wal_size = 80MB`（默认）
+  - `shared_buffers = 16GB`、`work_mem = 128MB`、`maintenance_work_mem = 2GB`（已合理，保持不变）
+
+## 变更摘要
+
+| 参数 | 旧值 | 新值 | 原因 |
+|---|---|---|---|
+| `random_page_cost` | 4.0 | 1.2 | NVMe 上随机/顺序读成本接近相等；避免 planner 在中大型表上错选 seq scan |
+| `effective_cache_size` | 4GB | 32GB | 告知 planner 操作系统可用文件缓存；影响 index scan 选择（不分配内存） |
+| `effective_io_concurrency` | 1 | 256 | NVMe 支持多条并发预取，bitmap heap scan 受益 |
+| `max_wal_size` | 1GB | 2GB | 减少 syncer 批量写、gacha 结算时 checkpoint 频率 |
+| `min_wal_size` | 80MB | 160MB | 与 max 同比例放大，减少 WAL 段回收 |
+
+未变更的项：
+- `shared_buffers`（16GB）、`work_mem`（128MB）、`maintenance_work_mem`（2GB）、
+  `max_connections`（500）维持现状
+- `default_statistics_target`（100）保留默认；若后续发现某大表统计信息抖动再单独提升
+
+## 同步：安装 `pg_trgm` 扩展
+
+审计发现 `pg_extension` 只有 `pgroonga` + `plpgsql`。`pg_trgm` 在后续可能用于
+ForumPost 模糊搜索、卡片名称前缀/相似度匹配。本 PR 顺带通过 SQL 安装：
+
+```sql
+\c scpper-cn
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+```
+
+脚本：`scripts/ops/enable-pg-trgm.sql`。
+
+## 生效方式
+
+1. 将 `docs/ops/postgresql-50-performance-tuning.conf` 复制到
+   `/etc/postgresql/17/main/conf.d/` 和 `/etc/postgresql/17/replica/conf.d/`。
+2. 大部分参数属于 `SIGHUP` 类（`reload` 即可），但 `max_wal_size`/`min_wal_size`
+   也是 SIGHUP 类，因此整体使用 **reload** 即可，无需重启。
+3. 安装 `pg_trgm`：`psql -f scripts/ops/enable-pg-trgm.sql`。
+4. 可选：运行 `SELECT pg_reload_conf();` 或 `systemctl reload postgresql@17-main`。
+
+一键执行见 `scripts/ops/apply-pg-tuning.sh`（需要 sudo）。
+
+## 回滚
+
+删除两个 drop-in 文件后 reload：
+
+```bash
+sudo rm /etc/postgresql/17/main/conf.d/50-performance-tuning.conf
+sudo rm /etc/postgresql/17/replica/conf.d/50-performance-tuning.conf
+sudo systemctl reload postgresql@17-main
+sudo systemctl reload postgresql@17-replica
+```
+
+`pg_trgm` 扩展若需要卸载（一般不必）：`DROP EXTENSION pg_trgm;`。
+
+## 验证
+
+重载后在 `scpper-cn` 上执行：
+
+```sql
+SELECT name, setting, unit, source
+FROM pg_settings
+WHERE name IN (
+  'random_page_cost', 'effective_cache_size', 'effective_io_concurrency',
+  'max_wal_size', 'min_wal_size'
+)
+ORDER BY name;
+```
+
+`source` 列应显示 `configuration file`，不再是 `default`。
+
+## 参考
+
+- PostgreSQL docs: Server Configuration
+- PGTune heuristic：64GB / NVMe 轮廓
+- 审计报告 `docs/full-repo-audit-2026-03-16.md`（前一轮安全审计基础）
+- 本轮审计遗留：部分/复合索引缺失（见 Bucket D PR）

--- a/scripts/ops/apply-pg-tuning.sh
+++ b/scripts/ops/apply-pg-tuning.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Apply PostgreSQL performance tuning drop-in file to both the main and
+# replica clusters, then reload (not restart) the servers.
+#
+# Requires sudo because the target /etc/postgresql/17/*/conf.d/ directories
+# are owned by postgres:postgres.
+#
+# Usage:
+#   sudo bash scripts/ops/apply-pg-tuning.sh
+#
+# Rollback: see docs/ops/postgresql-tuning.md.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+source_conf="$repo_root/docs/ops/postgresql-50-performance-tuning.conf"
+
+if [[ ! -f "$source_conf" ]]; then
+  echo "Source config not found: $source_conf" >&2
+  exit 1
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "This script must be run as root (e.g. via sudo)." >&2
+  exit 1
+fi
+
+clusters=(main replica)
+for cluster in "${clusters[@]}"; do
+  target_dir="/etc/postgresql/17/${cluster}/conf.d"
+  target_file="$target_dir/50-performance-tuning.conf"
+
+  if [[ ! -d "$target_dir" ]]; then
+    echo "Skipping missing cluster directory: $target_dir" >&2
+    continue
+  fi
+
+  install -o postgres -g postgres -m 0644 "$source_conf" "$target_file"
+  echo "Installed: $target_file"
+done
+
+for cluster in "${clusters[@]}"; do
+  service="postgresql@17-${cluster}"
+  if systemctl list-unit-files --type=service | grep -q "^${service}\.service"; then
+    systemctl reload "$service"
+    echo "Reloaded: $service"
+  else
+    echo "Service not registered: $service (skipping)" >&2
+  fi
+done
+
+echo
+echo "Verify on the live cluster(s):"
+echo "  psql -h 127.0.0.1 -p 5434 -U user_dxzbdi -d scpper-cn -c \\"
+echo "    \"SELECT name, setting, unit, source FROM pg_settings \\"
+echo "     WHERE name IN ('random_page_cost','effective_cache_size','effective_io_concurrency','max_wal_size','min_wal_size') \\"
+echo "     ORDER BY name;\""

--- a/scripts/ops/enable-pg-trgm.sql
+++ b/scripts/ops/enable-pg-trgm.sql
@@ -1,0 +1,12 @@
+-- Install the pg_trgm extension used by planned ForumPost / gacha card
+-- similarity search features.
+--
+-- Idempotent: safe to run repeatedly.
+--
+-- Usage:
+--   PGPASSWORD=... psql -h localhost -p 5434 -U user_dxzbdi -d scpper-cn \
+--     -f scripts/ops/enable-pg-trgm.sql
+
+\echo 'Ensuring pg_trgm is installed on current database ...'
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_trgm';

--- a/scripts/ops/enable-pg-trgm.sql
+++ b/scripts/ops/enable-pg-trgm.sql
@@ -6,6 +6,12 @@
 -- Usage:
 --   PGPASSWORD=... psql -h localhost -p 5434 -U user_dxzbdi -d scpper-cn \
 --     -f scripts/ops/enable-pg-trgm.sql
+--
+-- ON_ERROR_STOP makes psql exit non-zero on the first SQL error (permission
+-- denied, missing postgresql-contrib package, etc.). Without it psql returns
+-- 0 even when CREATE EXTENSION fails, which silently leaves pg_trgm
+-- uninstalled while downstream steps assume success.
+\set ON_ERROR_STOP on
 
 \echo 'Ensuring pg_trgm is installed on current database ...'
 CREATE EXTENSION IF NOT EXISTS pg_trgm;


### PR DESCRIPTION
## 背景

基于 SQL 性能审计，生产 PG 17/main 集群（5434 端口）以下关键参数仍为默认值，不符合 64GB RAM + NVMe SSD 的硬件特征：

| 参数 | 旧值 | 新值 | 原因 |
|---|---|---|---|
| `random_page_cost` | 4.0 | 1.2 | NVMe 随机/顺序读成本接近相等；避免 planner 错选 seq scan |
| `effective_cache_size` | 4GB | **32GB** | 告知 planner OS 缓存大小（只是估值，不分配内存） |
| `effective_io_concurrency` | 1 | 256 | NVMe 支持多条并发预取，bitmap heap scan 受益 |
| `max_wal_size` | 1GB | 2GB | 减少 syncer 批量写和 gacha 结算时的 checkpoint 抖动 |
| `min_wal_size` | 80MB | 160MB | 与 max 同比例放大 |

`shared_buffers`（16GB）、`work_mem`（128MB）、`maintenance_work_mem`（2GB）已合理，维持不变。

## 变更方式

Ubuntu 包装的 PG 在 `postgresql.conf` 末尾默认有 `include_dir = 'conf.d'`，且 `/etc/postgresql/17/main/conf.d/` 目前为空。

本 PR 选择 **drop-in 文件**策略：

- 仓库内新增 `docs/ops/postgresql-50-performance-tuning.conf` 作为源文件（参数 + 注释）
- `scripts/ops/apply-pg-tuning.sh` 负责 `install -o postgres -g postgres -m 0644` 到两个 cluster 的 `conf.d/`，然后 `systemctl reload`
- 不触碰发行版 `postgresql.conf`，回滚只需删除 drop-in 并 reload

## pg_trgm

审计发现 `pg_extension` 只有 `pgroonga + plpgsql`。`pg_trgm` 后续用于：
- ForumPost 的 ILIKE 模糊搜索加速（GiST/GIN trigram index）
- Gacha 卡片名称相似度匹配（留给 Bucket D/B 考虑）

本 PR 顺带提供幂等安装脚本 `scripts/ops/enable-pg-trgm.sql`。

## 操作步骤（合并后）

```bash
# 1. 在受保护 main checkout 执行
cd /home/andyblocker/scpper-cn
git pull origin main

# 2. 应用 conf（两个 cluster 各一份 drop-in，reload 即可）
sudo bash scripts/ops/apply-pg-tuning.sh

# 3. 安装 pg_trgm（只对 scpper-cn 目标库）
PGPASSWORD=... psql -h 127.0.0.1 -p 5434 -U user_dxzbdi -d scpper-cn \
  -f scripts/ops/enable-pg-trgm.sql

# 4. 验证（source 列应显示 configuration file）
PGPASSWORD=... psql -h 127.0.0.1 -p 5434 -U user_dxzbdi -d scpper-cn -c \
  "SELECT name, setting, unit, source FROM pg_settings
   WHERE name IN ('random_page_cost','effective_cache_size','effective_io_concurrency','max_wal_size','min_wal_size')
   ORDER BY name;"
```

## 回滚

```bash
sudo rm /etc/postgresql/17/{main,replica}/conf.d/50-performance-tuning.conf
sudo systemctl reload postgresql@17-main postgresql@17-replica
```

## 风险

- 所有改动都是 SIGHUP 类参数，**只需 reload，不需要重启**
- 无数据迁移、无 DDL（除 `CREATE EXTENSION pg_trgm`，它是幂等的）
- 如果 planner 在特定查询上表现变差，可随时删 drop-in 回滚