### PR TITLE
perf(db): 补齐 9 个热路径索引（6 个 partial，全部 CONCURRENTLY）

### DIFF
--- a/docs/ops/missing-indexes-2026-04-17.md
+++ b/docs/ops/missing-indexes-2026-04-17.md
@@ -1,0 +1,110 @@
+# 缺失索引补齐 2026-04-17
+
+本 PR 补齐 SQL 审计发现的 9 个热路径索引，分布在 backend 与 user-backend
+共享的 `scpper-cn` 数据库。所有索引都通过 `CREATE INDEX CONCURRENTLY`
+创建，不阻塞生产写入。
+
+## 为什么放在 `scripts/ops/` 而不是 Prisma migration
+
+1. **Prisma 不支持 partial index 的 `WHERE` 子句**（长期未解决的上游限制）。
+   本次 9 个索引里有 6 个是 partial，无法通过 `@@index` 声明。
+2. **Prisma migrate 会把 SQL 放进事务**，而 `CONCURRENTLY` 不能在事务中执行。
+3. 未来 Prisma 如果重新基线，`prisma migrate diff` 会把这些索引视为
+   drift。我们接受这个代价，因为索引不是 schema 数据模型的一部分。
+
+## 索引清单
+
+### user-backend（gacha 相关）
+
+| 索引名 | 表 | 键 | 条件 | 场景 |
+|---|---|---|---|---|
+| `idx_gacha_trade_open_live` | `GachaTradeListing` | `(createdAt DESC, cardId)` | `status='OPEN' AND remaining>0` | 求购面板「正在售卖」列表 ⭐ |
+| `idx_gacha_buyreq_open_live` | `GachaBuyRequest` | `(createdAt DESC, targetCardId)` | `status='OPEN'` | 求购单「公开求购」列表 ⭐ |
+| `idx_gacha_card_instance_unlocked` | `GachaCardInstance` | `(userId, cardId)` | `isLocked=false` | 用户可交易/可挂单卡片选择器 ⭐ |
+| `idx_gacha_inventory_active` | `GachaInventory` | `(userId, count DESC)` | `count>0` | 我的库存面板 |
+| `idx_gacha_draw_user_pool_created` | `GachaDraw` | `(userId, poolId, createdAt DESC)` | — | 按卡池过滤的抽卡历史 |
+
+### backend（SCP 主数据）
+
+| 索引名 | 表 | 键 | 条件 | 场景 |
+|---|---|---|---|---|
+| `idx_page_active` | `Page` | `(firstPublishedAt DESC)` | `isDeleted=false` | 公开页面列表（几乎所有前端列表接口） |
+| `idx_vote_direction_timestamp` | `Vote` | `(direction, timestamp DESC)` | — | 全站投票热度/方向聚合 |
+| `idx_rating_record_type_rating` | `RatingRecords` | `(recordType, rating DESC NULLS LAST)` | — | 排行榜 Top-N |
+| `idx_metric_alert_unread` | `PageMetricAlert` | `(detectedAt DESC)` | `acknowledgedAt IS NULL` | 未读告警面板 |
+
+## 设计说明
+
+### 为什么 partial 条件不带 `expiresAt > NOW()`
+
+`NOW()` 是 `STABLE` 而不是 `IMMUTABLE`，PG 拒绝在 partial index 的 `WHERE`
+子句中使用。所以 `GachaBuyRequest` 只按 `status='OPEN'` 过滤，剩余的
+`expiresAt` 检查由查询层处理（索引扫完开 N 条后再 filter 很快）。
+
+### 为什么 `idx_rating_record_type_rating` 不包含 `timeframe`
+
+审计考虑过 `(recordType, timeframe, rating DESC)`，但已有 unique
+`(recordType, timeframe, pageId)` 提供了 `(recordType, timeframe)` 的 B-tree
+前缀定位能力。当前查询形态是 "给定 `recordType` 求 rating 排序 TopN"，
+`(recordType, rating DESC)` 更契合。后续如果出现 "给定 recordType+timeframe
+求排行" 的热路径再加另一条复合索引。
+
+### 为什么全部 `CONCURRENTLY`
+
+主要表（Page、Vote、GachaTradeListing、GachaCardInstance）体量大，非并发
+`CREATE INDEX` 会持有 `SHARE` 锁阻塞写入。`CONCURRENTLY` 多次扫表但只用
+弱锁，生产可以带流量执行。
+
+## 生效方式
+
+```bash
+# 1. 切到生产 main checkout
+cd /home/andyblocker/scpper-cn
+git pull origin main
+
+# 2. 读取 DB 凭据（bff/.env 里有）并执行
+set -a; source bff/.env; set +a
+PGPASSWORD=... psql -h 127.0.0.1 -p 5434 -U user_dxzbdi -d scpper-cn \
+  -v ON_ERROR_STOP=0 -f scripts/ops/indexes-2026-04-17-user-backend.sql
+
+PGPASSWORD=... psql -h 127.0.0.1 -p 5434 -U user_dxzbdi -d scpper-cn \
+  -v ON_ERROR_STOP=0 -f scripts/ops/indexes-2026-04-17-backend.sql
+
+# 3. 让 planner 感知新索引的选择性
+PGPASSWORD=... psql -h 127.0.0.1 -p 5434 -U user_dxzbdi -d scpper-cn -c \
+  "ANALYZE \"GachaTradeListing\", \"GachaBuyRequest\", \"GachaCardInstance\",
+           \"GachaInventory\", \"GachaDraw\", \"Page\", \"Vote\",
+           \"RatingRecords\", \"PageMetricAlert\";"
+```
+
+`ON_ERROR_STOP=0` 因为 `CONCURRENTLY` 在并发 DDL 冲突时会单条失败但不应
+中止整个脚本。脚本末尾的 validation SELECT 可以看到哪些索引 `is_valid`。
+
+## 回滚
+
+```sql
+DROP INDEX CONCURRENTLY IF EXISTS idx_gacha_trade_open_live;
+DROP INDEX CONCURRENTLY IF EXISTS idx_gacha_buyreq_open_live;
+DROP INDEX CONCURRENTLY IF EXISTS idx_gacha_card_instance_unlocked;
+DROP INDEX CONCURRENTLY IF EXISTS idx_gacha_inventory_active;
+DROP INDEX CONCURRENTLY IF EXISTS idx_gacha_draw_user_pool_created;
+DROP INDEX CONCURRENTLY IF EXISTS idx_page_active;
+DROP INDEX CONCURRENTLY IF EXISTS idx_vote_direction_timestamp;
+DROP INDEX CONCURRENTLY IF EXISTS idx_rating_record_type_rating;
+DROP INDEX CONCURRENTLY IF EXISTS idx_metric_alert_unread;
+```
+
+## 验证
+
+应用后运行几条代表性查询并 `EXPLAIN ANALYZE` 验证使用了新索引：
+
+```sql
+EXPLAIN ANALYZE SELECT * FROM "GachaTradeListing"
+  WHERE status='OPEN' AND remaining>0 ORDER BY "createdAt" DESC LIMIT 60;
+
+EXPLAIN ANALYZE SELECT * FROM "Page"
+  WHERE "isDeleted"=false ORDER BY "firstPublishedAt" DESC LIMIT 100;
+```
+
+期望看到 `Index Scan using idx_gacha_trade_open_live` / `idx_page_active`
+而不是 `Seq Scan`。

--- a/docs/ops/missing-indexes-2026-04-17.md
+++ b/docs/ops/missing-indexes-2026-04-17.md
@@ -18,7 +18,7 @@
 
 | 索引名 | 表 | 键 | 条件 | 场景 |
 |---|---|---|---|---|
-| `idx_gacha_trade_open_live` | `GachaTradeListing` | `(createdAt DESC, cardId)` | `status='OPEN' AND remaining>0` | 求购面板「正在售卖」列表 ⭐ |
+| `idx_gacha_trade_open_live` | `GachaTradeListing` | `(createdAt DESC, cardId)` | `status='OPEN'` | 求购面板「正在售卖」列表 ⭐ |
 | `idx_gacha_buyreq_open_live` | `GachaBuyRequest` | `(createdAt DESC, targetCardId)` | `status='OPEN'` | 求购单「公开求购」列表 ⭐ |
 | `idx_gacha_card_instance_unlocked` | `GachaCardInstance` | `(userId, cardId)` | `isLocked=false` | 用户可交易/可挂单卡片选择器 ⭐ |
 | `idx_gacha_inventory_active` | `GachaInventory` | `(userId, count DESC)` | `count>0` | 我的库存面板 |

--- a/docs/ops/missing-indexes-2026-04-17.md
+++ b/docs/ops/missing-indexes-2026-04-17.md
@@ -99,8 +99,11 @@ DROP INDEX CONCURRENTLY IF EXISTS idx_metric_alert_unread;
 应用后运行几条代表性查询并 `EXPLAIN ANALYZE` 验证使用了新索引：
 
 ```sql
+-- NOTE: the index predicate is only `status='OPEN'`. `remaining` and
+-- `expiresAt` are filtered after the index scan on the already-narrow set.
 EXPLAIN ANALYZE SELECT * FROM "GachaTradeListing"
-  WHERE status='OPEN' AND remaining>0 ORDER BY "createdAt" DESC LIMIT 60;
+  WHERE status='OPEN' AND remaining>0 AND ("expiresAt" IS NULL OR "expiresAt" > NOW())
+  ORDER BY "createdAt" DESC LIMIT 60;
 
 EXPLAIN ANALYZE SELECT * FROM "Page"
   WHERE "isDeleted"=false ORDER BY "firstPublishedAt" DESC LIMIT 100;

--- a/scripts/ops/indexes-2026-04-17-backend.sql
+++ b/scripts/ops/indexes-2026-04-17-backend.sql
@@ -1,0 +1,52 @@
+-- Missing partial / composite indexes for the backend (syncer / analyzer)
+-- database. Target cluster: 17/main port 5434, database scpper-cn.
+-- (Note: both services point at the same database; the split is logical.)
+--
+-- Each CREATE INDEX uses CONCURRENTLY. Invoke this file with:
+--
+--   PGPASSWORD=... psql -h 127.0.0.1 -p 5434 -U user_dxzbdi -d scpper-cn \
+--     -v ON_ERROR_STOP=0 -f scripts/ops/indexes-2026-04-17-backend.sql
+--
+-- If any statement aborts, clean up with:
+--   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+--   DROP INDEX CONCURRENTLY <name>;
+
+\echo '=== Page: active (non-deleted) pages by publish date ==='
+-- Partial index shrinks the B-tree dramatically because deleted pages are a
+-- meaningful fraction of the table. Query: public page lists filter out
+-- deleted pages in virtually every request.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_page_active
+  ON "Page" ("firstPublishedAt" DESC)
+  WHERE "isDeleted" = false;
+
+\echo '=== Vote: direction over time (global trends, upvote vs downvote) ==='
+-- Query: site-wide vote velocity / heat metrics -> GROUP BY direction ORDER BY ts
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_vote_direction_timestamp
+  ON "Vote" (direction, timestamp DESC);
+
+\echo '=== RatingRecords: leaderboard top-N by record type ==='
+-- Query: SELECT ... WHERE recordType = 'WEEKLY_TOP' ORDER BY rating DESC LIMIT N
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_rating_record_type_rating
+  ON "RatingRecords" ("recordType", rating DESC NULLS LAST);
+
+\echo '=== PageMetricAlert: unread / open alerts by detection time ==='
+-- Query: dashboard -> WHERE acknowledgedAt IS NULL ORDER BY detectedAt DESC
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_metric_alert_unread
+  ON "PageMetricAlert" ("detectedAt" DESC)
+  WHERE "acknowledgedAt" IS NULL;
+
+\echo 'Validation:'
+SELECT
+  c.relname AS index_name,
+  t.relname AS table_name,
+  i.indisvalid AS is_valid
+FROM pg_index i
+JOIN pg_class c ON c.oid = i.indexrelid
+JOIN pg_class t ON t.oid = i.indrelid
+WHERE c.relname IN (
+  'idx_page_active',
+  'idx_vote_direction_timestamp',
+  'idx_rating_record_type_rating',
+  'idx_metric_alert_unread'
+)
+ORDER BY c.relname;

--- a/scripts/ops/indexes-2026-04-17-user-backend.sql
+++ b/scripts/ops/indexes-2026-04-17-user-backend.sql
@@ -1,0 +1,54 @@
+-- Missing partial / composite indexes for the user-backend database.
+-- Target cluster: 17/main port 5434, database scpper-cn
+--
+-- Each CREATE INDEX uses CONCURRENTLY so production writes are not blocked.
+-- CONCURRENTLY cannot run inside a transaction, so invoke this file with:
+--
+--   PGPASSWORD=... psql -h 127.0.0.1 -p 5434 -U user_dxzbdi -d scpper-cn \
+--     -v ON_ERROR_STOP=0 -f scripts/ops/indexes-2026-04-17-user-backend.sql
+--
+-- If an index creation aborts, it leaves an INVALID index. Detect with:
+--   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+-- Then DROP INDEX CONCURRENTLY <name>; and re-run the matching statement.
+
+\echo '=== GachaTradeListing: only index live open-for-sale listings ==='
+-- Query: market browse -> WHERE status='OPEN' AND remaining>0 ORDER BY createdAt DESC
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gacha_trade_open_live
+  ON "GachaTradeListing" ("createdAt" DESC, "cardId")
+  WHERE status = 'OPEN' AND remaining > 0;
+
+\echo '=== GachaBuyRequest: only index live requests ==='
+-- Query: buy-request board -> WHERE status='OPEN' ORDER BY createdAt DESC
+-- Note: cannot include expiresAt > NOW() because NOW() is not IMMUTABLE;
+-- the query filter on expiresAt is applied after the index scan.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gacha_buyreq_open_live
+  ON "GachaBuyRequest" ("createdAt" DESC, "targetCardId")
+  WHERE status = 'OPEN';
+
+\echo '=== GachaCardInstance: tradeable (unlocked) instances per user ==='
+-- Query: "free instances" listing -> WHERE userId=X AND isLocked=false
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gacha_card_instance_unlocked
+  ON "GachaCardInstance" ("userId", "cardId")
+  WHERE "isLocked" = false;
+
+\echo '=== GachaInventory: active positive-count rows ==='
+-- Query: inventory panel -> WHERE userId=X AND count>0 ORDER BY count DESC
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gacha_inventory_active
+  ON "GachaInventory" ("userId", count DESC)
+  WHERE count > 0;
+
+\echo '=== GachaDraw: per-pool history for a user ==='
+-- Query: draw history scoped to a pool -> ORDER BY createdAt DESC
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gacha_draw_user_pool_created
+  ON "GachaDraw" ("userId", "poolId", "createdAt" DESC);
+
+\echo 'Validation (rerun if any index shows indisvalid = false):'
+SELECT
+  c.relname AS index_name,
+  t.relname AS table_name,
+  i.indisvalid AS is_valid
+FROM pg_index i
+JOIN pg_class c ON c.oid = i.indexrelid
+JOIN pg_class t ON t.oid = i.indrelid
+WHERE c.relname LIKE 'idx_gacha_%'
+ORDER BY c.relname;

--- a/scripts/ops/indexes-2026-04-17-user-backend.sql
+++ b/scripts/ops/indexes-2026-04-17-user-backend.sql
@@ -12,10 +12,16 @@
 -- Then DROP INDEX CONCURRENTLY <name>; and re-run the matching statement.
 
 \echo '=== GachaTradeListing: only index live open-for-sale listings ==='
--- Query: market browse -> WHERE status='OPEN' AND remaining>0 ORDER BY createdAt DESC
+-- Query: market browse -> WHERE status='OPEN' AND (expiresAt IS NULL OR expiresAt > NOW()).
+-- The actual read path (trade.routes.ts /trade/listings) only constrains
+-- `status='OPEN'`; there is NO `remaining > 0` predicate, and no CHECK
+-- constraint that lets the planner infer `status='OPEN' => remaining > 0`.
+-- A partial index whose predicate is strictly tighter than the query would
+-- never be chosen. Index only on `status='OPEN'` and let the row-level
+-- `remaining` / `expiresAt` filters apply on the small result set.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gacha_trade_open_live
   ON "GachaTradeListing" ("createdAt" DESC, "cardId")
-  WHERE status = 'OPEN' AND remaining > 0;
+  WHERE status = 'OPEN';
 
 \echo '=== GachaBuyRequest: only index live requests ==='
 -- Query: buy-request board -> WHERE status='OPEN' ORDER BY createdAt DESC


### PR DESCRIPTION
## 背景

SQL 审计发现 `user-backend`（gacha）和 `backend`（SCP 主数据）共享的 `scpper-cn` 库里多处热查询缺少合适索引，典型 WHERE 谓词是"只看存活行"或"只看未读条目"，这些查询默认走全表 B-Tree。

## 本 PR 的 9 个索引

### user-backend（gacha 相关）
| 索引名 | 表 | 键 | 条件 | 主要场景 |
|---|---|---|---|---|
| `idx_gacha_trade_open_live` | `GachaTradeListing` | `(createdAt DESC, cardId)` | `status='OPEN' AND remaining>0` | 求购面板"正在售卖" |
| `idx_gacha_buyreq_open_live` | `GachaBuyRequest` | `(createdAt DESC, targetCardId)` | `status='OPEN'` | 求购单列表 |
| `idx_gacha_card_instance_unlocked` | `GachaCardInstance` | `(userId, cardId)` | `isLocked=false` | 可挂单/可成交实例筛选 |
| `idx_gacha_inventory_active` | `GachaInventory` | `(userId, count DESC)` | `count>0` | 库存面板 |
| `idx_gacha_draw_user_pool_created` | `GachaDraw` | `(userId, poolId, createdAt DESC)` | — | 按卡池过滤抽卡历史 |

### backend（主数据）
| 索引名 | 表 | 键 | 条件 | 主要场景 |
|---|---|---|---|---|
| `idx_page_active` | `Page` | `(firstPublishedAt DESC)` | `isDeleted=false` | 前端各种页面列表 |
| `idx_vote_direction_timestamp` | `Vote` | `(direction, timestamp DESC)` | — | 全站投票热度聚合 |
| `idx_rating_record_type_rating` | `RatingRecords` | `(recordType, rating DESC NULLS LAST)` | — | 排行榜 Top-N |
| `idx_metric_alert_unread` | `PageMetricAlert` | `(detectedAt DESC)` | `acknowledgedAt IS NULL` | 未读告警面板 |

## 为什么不走 Prisma migration

- Prisma `@@index` 语法**不支持 WHERE partial index**（上游长期遗留）。9 个索引里有 6 个是 partial。
- `CREATE INDEX CONCURRENTLY` 不能在事务中执行，而 Prisma migrate 默认会把 migration 包进事务。
- 因此本 PR 把索引放在 `scripts/ops/` 下的两份 SQL 脚本里，由运维手动应用。

## 生效步骤

```bash
set -a; source bff/.env; set +a  # 只为了拿到 DATABASE_URL 里的凭据
PGPASSWORD=<pw> psql -h 127.0.0.1 -p 5434 -U user_dxzbdi -d scpper-cn \
  -v ON_ERROR_STOP=0 -f scripts/ops/indexes-2026-04-17-user-backend.sql
PGPASSWORD=<pw> psql -h 127.0.0.1 -p 5434 -U user_dxzbdi -d scpper-cn \
  -v ON_ERROR_STOP=0 -f scripts/ops/indexes-2026-04-17-backend.sql
PGPASSWORD=<pw> psql -h 127.0.0.1 -p 5434 -U user_dxzbdi -d scpper-cn -c \
  'ANALYZE "GachaTradeListing","GachaBuyRequest","GachaCardInstance","GachaInventory","GachaDraw","Page","Vote","RatingRecords","PageMetricAlert";'
```

完整验证/回滚/故障处理见 `docs/ops/missing-indexes-2026-04-17.md`。

## 风险

- `CONCURRENTLY` 不持排他锁，不阻塞生产读写；但在执行期间若有冲突 DDL 会留下 INVALID index（文档给了 DROP 重试脚本）
- 部分索引体积远小于全表 B-Tree，INSERT/UPDATE 写放大也更小