### PR TITLE
perf(gacha): 求购面板卡片目录改输入驱动搜索

### DIFF
--- a/frontend/components/gacha/GachaTradePanel.vue
+++ b/frontend/components/gacha/GachaTradePanel.vue
@@ -129,6 +129,7 @@ const emit = defineEmits<{
   'refresh-buy-requests': [options?: { resetPublic?: boolean }]
   'request-inventory': []
   'request-catalog': []
+  'search-catalog': [query: string]
   'activity-page-change': [page: number]
   'request-activity': []
 }>()
@@ -288,7 +289,10 @@ function searchableTags(tags: string[] | null | undefined) {
   })
 }
 
-// Pre-compute search text for catalog pages
+// Catalog pages are now the server-side search result for `brTargetSearch`.
+// The parent populates `props.pageCatalog` via the `search-catalog` emit
+// below; no client-side filter is needed anymore. The authoring-text index is
+// kept for secondary use (e.g. highlighting author matches in the picker).
 const catalogSearchIndex = computed(() => {
   const index = new Map<string, string>()
   for (const p of props.pageCatalog) {
@@ -299,15 +303,17 @@ const catalogSearchIndex = computed(() => {
   return index
 })
 
-const brFilteredCatalog = computed(() => {
-  const keyword = brTargetSearch.value.trim().toLowerCase()
-  if (!keyword) return props.pageCatalog
-  const idx = catalogSearchIndex.value
-  return props.pageCatalog.filter((p) => {
-    const key = String(p.pageId ?? p.variants[0]?.id ?? p.title)
-    const text = idx.get(key) || ''
-    return text.includes(keyword)
-  })
+const brFilteredCatalog = computed(() => props.pageCatalog)
+
+// Debounced emit so each keystroke doesn't hammer the backend.
+const BR_TARGET_SEARCH_DEBOUNCE_MS = 280
+let brTargetSearchTimer: ReturnType<typeof setTimeout> | null = null
+watch(brTargetSearch, (value) => {
+  if (brTargetSearchTimer) clearTimeout(brTargetSearchTimer)
+  brTargetSearchTimer = setTimeout(() => {
+    emit('search-catalog', value.trim())
+    brTargetSearchTimer = null
+  }, BR_TARGET_SEARCH_DEBOUNCE_MS)
 })
 
 const brDerivedPayloads = computed<BuyRequestDraft[]>(() => {

--- a/frontend/composables/api/gachaBuyRequest.ts
+++ b/frontend/composables/api/gachaBuyRequest.ts
@@ -108,6 +108,30 @@ export function useGachaBuyRequestApi(core: GachaCoreContext) {
     }
   }
 
+  async function searchPages(q: string, limit = 30) {
+    try {
+      const res = await $bff<ApiResponse<{ pages: PageCatalogEntry[]; total?: number }>>('/gacha/trade/buy-requests/page-search', {
+        method: 'GET',
+        params: { q, limit: String(limit) }
+      })
+      if (res?.ok) {
+        const pages = (res.pages ?? []).map(page => ({
+          ...page,
+          title: withCardVariant({ title: page.title, imageUrl: null }).title,
+          variants: page.variants.map(v => ({
+            id: v.id,
+            imageUrl: withCardVariant({ title: '', imageUrl: v.imageUrl }).imageUrl ?? null,
+            isRetired: !!v.isRetired
+          }))
+        }))
+        return { ok: true as const, data: pages, total: res.total ?? pages.length }
+      }
+      return { ok: false as const, error: res?.error || '搜索卡片失败' }
+    } catch (error: unknown) {
+      return { ok: false as const, error: normalizeError(error, '搜索卡片失败') }
+    }
+  }
+
   async function createBuyRequest(payload: {
     targetCardId: string
     matchLevel?: BuyRequestMatchLevel
@@ -201,6 +225,7 @@ export function useGachaBuyRequestApi(core: GachaCoreContext) {
     getMyBuyRequests,
     getCardCatalog,
     getPageCatalog,
+    searchPages,
     createBuyRequest,
     fulfillBuyRequest,
     cancelBuyRequest

--- a/frontend/composables/useGachaTrade.ts
+++ b/frontend/composables/useGachaTrade.ts
@@ -655,18 +655,44 @@ export function useGachaTrade(page: GachaPageContext) {
     }
   }
 
-  /** Refresh card catalog on demand */
-  async function refreshCardCatalog() {
+  /**
+   * Populate `cardCatalog` with server-side search results.
+   *
+   * The old model pre-loaded the entire card catalog (~2 MB, ~5k cards)
+   * when the buy-request form opened, then filtered locally on each
+   * keystroke. The new model keeps `cardCatalog` empty until the user
+   * types, then replaces it with a small (up to 30) set of matching
+   * pages returned by the backend.
+   *
+   * Callers must debounce on their side; this function does no throttling.
+   * Passing an empty string resets `cardCatalog` to an empty list so the
+   * picker renders a "type to search" placeholder.
+   */
+  async function searchCatalogPages(q: string) {
+    const query = (q ?? '').trim()
+    if (!query) {
+      cardCatalog.value = []
+      return
+    }
     try {
-      const catalogRes = await gacha.getPageCatalog()
-      if (catalogRes.ok) {
-        cardCatalog.value = catalogRes.data ?? []
+      const res = await gacha.searchPages(query, 30)
+      if (res.ok) {
+        cardCatalog.value = res.data ?? []
         seedAuthorCacheForCatalog(cardCatalog.value)
         queueAuthorHydration(cardCatalog.value.map((p) => p.wikidotId))
       }
     } catch (error) {
-      console.warn('[gacha] load card catalog failed', error)
+      console.warn('[gacha] search card catalog failed', error)
     }
+  }
+
+  /**
+   * @deprecated retained as a no-op so existing `@request-catalog` callers
+   * don't need to be edited. Use `searchCatalogPages` from the picker's
+   * input event instead.
+   */
+  async function refreshCardCatalog() {
+    // Intentionally empty: see searchCatalogPages above.
   }
 
   // ═══════════════════════════════════════════════════════
@@ -914,17 +940,10 @@ export function useGachaTrade(page: GachaPageContext) {
           }
         })
       ]
-      if (loadCatalog && cardCatalog.value.length === 0) {
-        promises.push(
-          gacha.getPageCatalog().then((catalogRes) => {
-            if (catalogRes.ok) {
-              cardCatalog.value = catalogRes.data ?? []
-              seedAuthorCacheForCatalog(cardCatalog.value)
-              queueAuthorHydration(cardCatalog.value.map((p) => p.wikidotId))
-            }
-          })
-        )
-      }
+      // `loadCatalog` used to trigger a full /card-catalog preload here.
+      // Catalog pages are now fetched on demand via `searchCatalogPages`
+      // (triggered by the picker's search input); nothing else to preload.
+      void loadCatalog
       const results = await Promise.all(promises)
       const publicRes = results[0] as { ok: boolean; stale?: boolean; error?: string }
       if (!publicRes.ok && !publicRes.stale) emitError(publicRes.error || '加载求购列表失败')
@@ -1196,6 +1215,7 @@ export function useGachaTrade(page: GachaPageContext) {
     // Lazy-load helpers
     refreshOwnedCardIds,
     refreshCardCatalog,
+    searchCatalogPages,
 
     // Lifecycle
     loadInitial,

--- a/frontend/composables/useGachaTrade.ts
+++ b/frontend/composables/useGachaTrade.ts
@@ -667,21 +667,34 @@ export function useGachaTrade(page: GachaPageContext) {
    * Callers must debounce on their side; this function does no throttling.
    * Passing an empty string resets `cardCatalog` to an empty list so the
    * picker renders a "type to search" placeholder.
+   *
+   * Stale-response guarding: each call is tagged with a monotonically
+   * increasing sequence number. When the response resolves we only mutate
+   * `cardCatalog` if our sequence is still the latest. Without this, a slow
+   * in-flight request for an older query can resolve after a newer one and
+   * overwrite the fresh results — including "repopulating" the list after
+   * the user cleared the input.
    */
+  let catalogSearchSeq = 0
   async function searchCatalogPages(q: string) {
     const query = (q ?? '').trim()
+    const mySeq = ++catalogSearchSeq
     if (!query) {
+      // The empty-query reset also needs to respect sequence order:
+      // a slow non-empty response from before the clear must not repopulate.
       cardCatalog.value = []
       return
     }
     try {
       const res = await gacha.searchPages(query, 30)
+      if (mySeq !== catalogSearchSeq) return
       if (res.ok) {
         cardCatalog.value = res.data ?? []
         seedAuthorCacheForCatalog(cardCatalog.value)
         queueAuthorHydration(cardCatalog.value.map((p) => p.wikidotId))
       }
     } catch (error) {
+      if (mySeq !== catalogSearchSeq) return
       console.warn('[gacha] search card catalog failed', error)
     }
   }

--- a/frontend/pages/gachas/trade.vue
+++ b/frontend/pages/gachas/trade.vue
@@ -72,6 +72,7 @@
             @refresh-buy-requests="refreshBuyRequestPanel"
             @request-inventory="handleRequestInventory"
             @request-catalog="handleRequestCatalog"
+            @search-catalog="handleSearchCatalog"
             @activity-page-change="loadActivityPage"
             @request-activity="loadActivityPage(1)"
           />
@@ -209,7 +210,7 @@ const {
   activityItems, activityLoading, activityTotal, activityPage, activityLoaded,
   loadActivityPage,
   // Lazy-load helpers
-  refreshOwnedCardIds, refreshCardCatalog,
+  refreshOwnedCardIds, refreshCardCatalog, searchCatalogPages,
   cleanup: cleanupTrade
 } = idx
 
@@ -429,10 +430,15 @@ function handleRequestInventory() {
   }
 }
 
-// Lazy-load card catalog when the buy-request form opens
+// The old "Lazy-load full card catalog" behaviour is gone — opening the
+// buy-request form no longer pulls ~2 MB of card data. The picker's search
+// input drives `handleSearchCatalog` below instead.
 function handleRequestCatalog() {
-  if (cardCatalog.value.length === 0) {
-    void refreshCardCatalog()
-  }
+  // retained as a no-op so the existing emit still has a handler
+  void refreshCardCatalog
+}
+
+function handleSearchCatalog(q: string) {
+  void searchCatalogPages(q)
 }
 </script>

--- a/user-backend/src/routes/gacha/trade.routes.ts
+++ b/user-backend/src/routes/gacha/trade.routes.ts
@@ -670,6 +670,84 @@ export function registerTradeRoutes(router: Router) {
   // BUY REQUEST ENDPOINTS
   // ═══════════════════════════════════════════════════════
 
+  // ─── Page search (input-driven, supersedes card-catalog) ──────
+  // Returns a page-grouped list matching `q` (title / author keywords).
+  // Page size defaults to 30 — the caller debounces keystrokes so the server
+  // load is bounded. Empty `q` returns an empty list: the UI uses this to
+  // render a "type to search" placeholder instead of eagerly loading ~5000
+  // cards like the old /card-catalog endpoint did.
+  router.get('/trade/buy-requests/page-search', async (req, res, next) => {
+    try {
+      if (!req.authUser) return res.status(401).json({ error: '未登录' });
+      const q = String(req.query?.q ?? '').trim();
+      const rawLimit = Number(req.query?.limit ?? '30');
+      const limit = Math.min(Math.max(Number.isFinite(rawLimit) ? rawLimit : 30, 1), 60);
+
+      const pools = await h.fetchActivePools(prisma);
+      if (pools.length === 0 || q.length === 0) {
+        return res.json({ ok: true, enabled: h.FEATURE_FLAGS.buyRequest, pages: [], total: 0, query: q });
+      }
+
+      const authorMatchedCardIds = await h.findCardIdsByAuthorKeyword(q);
+      const where: Prisma.GachaCardDefinitionWhereInput = {
+        poolId: { in: pools.map((p) => p.id) },
+        OR: [
+          { title: { contains: q, mode: 'insensitive' } },
+          ...(authorMatchedCardIds.length > 0 ? [{ id: { in: authorMatchedCardIds } }] : [])
+        ]
+      };
+
+      // Fetch enough cards to build `limit` groups (pages). Each page can have
+      // several variants × rarities, so 20x gives healthy headroom.
+      const cards = await prisma.gachaCardDefinition.findMany({
+        where,
+        select: { id: true, title: true, rarity: true, imageUrl: true, tags: true, wikidotId: true, pageId: true, poolId: true, weight: true },
+        orderBy: [{ rarity: 'asc' }, { title: 'asc' }],
+        take: limit * 20
+      });
+
+      const pageMap = new Map<number | string, typeof cards>();
+      let nullIdx = 0;
+      for (const c of cards) {
+        const key = c.pageId != null ? c.pageId : `__null_${nullIdx++}`;
+        const group = pageMap.get(key);
+        if (group) { group.push(c); } else { pageMap.set(key, [c]); }
+      }
+      const allPages = Array.from(pageMap.values()).map((group) => {
+        const first = group[0]!;
+        return {
+          pageId: first.pageId ?? null,
+          title: first.title,
+          rarity: first.rarity,
+          tags: first.tags ?? [],
+          authors: h.resolveCardAuthorsFromTags(first.tags),
+          wikidotId: first.wikidotId ?? null,
+          isRetired: group.every((card) => h.isRetiredCard(card)),
+          variants: h.buildImageVariants(group.map((c) => ({
+            id: c.id,
+            imageUrl: c.imageUrl ?? null,
+            poolId: c.poolId,
+            weight: c.weight
+          })))
+        };
+      });
+
+      res.json({
+        ok: true,
+        enabled: h.FEATURE_FLAGS.buyRequest,
+        pages: allPages.slice(0, limit),
+        total: allPages.length,
+        query: q,
+        limit
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // DEPRECATED: kept for one release to ease rollback. The frontend has moved
+  // to /page-search; this route will be removed in a follow-up PR once no
+  // client version relies on it.
   router.get('/trade/buy-requests/card-catalog', async (req, res, next) => {
     try {
       if (!req.authUser) return res.status(401).json({ error: '未登录' });


### PR DESCRIPTION
## 问题

打开"发起求购"表单会 `/trade/buy-requests/card-catalog` 拉全量卡片定义（~5000+ 行，500KB~2MB JSON），前端存进 `cardCatalog` ref 并在每次输入时本地 filter。Vue reactivity 处理大数组导致输入卡顿，带宽也浪费。

## 方案（确认的方案 a）

### 后端
新增 `GET /gacha/trade/buy-requests/page-search?q=xxx&limit=30`
- 只在 `q` 非空时查询
- `WHERE title ILIKE '%q%' OR id IN <author-matched cardIds>`，`SELECT + LIMIT` 完全下推
- 复用 `card-catalog` 的分组逻辑（pageId 分组 + `buildImageVariants`）
- 取前 `limit` 个 page 返回

旧的 `/trade/buy-requests/card-catalog` 保留一版，标 DEPRECATED，下个 PR 删除。

### 前端
- `useGachaTrade`: 新增 `searchCatalogPages(q)`，空 query 时把 `cardCatalog` 清为 `[]`；`refreshCardCatalog` 改为 no-op
- `trade.vue`: 绑定 `@search-catalog="handleSearchCatalog"`
- `GachaTradePanel.vue`:
  - `brTargetSearch` 经 280ms debounce emit `'search-catalog'`
  - `brFilteredCatalog` 从本地 filter 改为直接 `props.pageCatalog`（父组件已填搜索结果）
- `gachaBuyRequest.ts`: 新增 `searchPages(q, limit)` API 方法

## 验证

- `user-backend`: `npm run build` exit=0
- `frontend`: `npm run build` exit=0（Nuxt nitro 输出完整）

## 留给 Bucket F 的项

- `/trade/my-activity` 内存排序 → UNION ALL + keyset
- `fulfillableOnly` 的 3 分支 EXISTS → JOIN 或 Redis 预计算（已被 Bucket D 的 `idx_gacha_card_instance_unlocked` 部分缓解）