### PR TITLE
perf(syncer,backend,user-backend): 批量化四处串行写入

### DIFF
--- a/backend/src/core/store/DirtyQueueStore.ts
+++ b/backend/src/core/store/DirtyQueueStore.ts
@@ -10,6 +10,11 @@ type DbClient = PrismaClient | Prisma.TransactionClient;
 // under that — 2000 rows gives a comfortable safety margin and is still one
 // multi-row INSERT per chunk.
 const DIRTY_PAGE_CHUNK_SIZE = 2000;
+// Full-sync rebuilds can legitimately take tens of seconds, which exceeds
+// Prisma's 5s default transaction timeout. Size this high enough to cover
+// realistic workloads while still bounded so a stuck query surfaces.
+const DIRTY_QUEUE_TX_TIMEOUT_MS = 120_000;
+const DIRTY_QUEUE_TX_MAX_WAIT_MS = 10_000;
 
 async function createDirtyPagesChunked(
   prisma: DbClient,
@@ -139,9 +144,6 @@ export class DirtyQueueStore {
   async buildDirtyQueue() {
     Logger.info('🔍 Building dirty page queue...');
 
-    // 清理旧的dirty记录
-    await this.prisma.dirtyPage.deleteMany({});
-
     const stats = {
       total: 0,
       phaseB: 0,
@@ -189,13 +191,19 @@ export class DirtyQueueStore {
       }
     }
 
-    // Chunked to stay under PostgreSQL's 65535 bind-parameter cap. Without
-    // the split a full sync (tens of thousands of staging pages) would fail
-    // the createMany; because we already ran deleteMany, that failure would
-    // leave DirtyPage empty and silently block Phase B/C.
-    if (toCreate.length > 0) {
-      await createDirtyPagesChunked(this.prisma, toCreate);
-    }
+    // Atomic rebuild: wrap the delete + chunked inserts in a single
+    // transaction so the table is never left in a partially-populated
+    // intermediate state. Chunk size stays under PostgreSQL's 65535
+    // bind-parameter cap; without chunking, full syncs (tens of thousands
+    // of rows) would fail the insert on the driver side. Timeout is lifted
+    // above the default 5s because a large rebuild can legitimately take
+    // tens of seconds.
+    await this.prisma.$transaction(async (tx) => {
+      await tx.dirtyPage.deleteMany({});
+      if (toCreate.length > 0) {
+        await createDirtyPagesChunked(tx, toCreate);
+      }
+    }, { timeout: DIRTY_QUEUE_TX_TIMEOUT_MS, maxWait: DIRTY_QUEUE_TX_MAX_WAIT_MS });
 
     Logger.info(`✅ Dirty queue built: ${stats.total} pages processed`);
     Logger.info(`   - New pages: ${stats.newPages}`);
@@ -212,9 +220,6 @@ export class DirtyQueueStore {
    */
   async buildDirtyQueueTestMode() {
     Logger.info('🔍 Building dirty page queue (TEST MODE)...');
-
-    // 清理旧的dirty记录
-    await this.prisma.dirtyPage.deleteMany({});
 
     const stats = {
       total: 0,
@@ -255,9 +260,12 @@ export class DirtyQueueStore {
       }
     }
 
-    if (toCreate.length > 0) {
-      await createDirtyPagesChunked(this.prisma, toCreate);
-    }
+    await this.prisma.$transaction(async (tx) => {
+      await tx.dirtyPage.deleteMany({});
+      if (toCreate.length > 0) {
+        await createDirtyPagesChunked(tx, toCreate);
+      }
+    }, { timeout: DIRTY_QUEUE_TX_TIMEOUT_MS, maxWait: DIRTY_QUEUE_TX_MAX_WAIT_MS });
 
     Logger.info(`✅ Dirty queue built (TEST): ${stats.total} pages`);
 

--- a/backend/src/core/store/DirtyQueueStore.ts
+++ b/backend/src/core/store/DirtyQueueStore.ts
@@ -140,6 +140,8 @@ export class DirtyQueueStore {
     // 获取所有staging记录
     const stagingPages = await this.prisma.pageMetaStaging.findMany();
 
+    const toCreate: Prisma.DirtyPageCreateManyInput[] = [];
+
     for (const staging of stagingPages) {
       const page = staging.wikidotId ? pageMap.get(staging.wikidotId) ?? null : null;
       const currentVersion = page ? versionMap.get(page.id) ?? null : null;
@@ -155,20 +157,24 @@ export class DirtyQueueStore {
       if (result.hasVotesRevChanges) stats.votesRevChanges++;
 
       if (result.needPhaseB || result.needPhaseC) {
-        await this.prisma.dirtyPage.create({
-          data: {
-            page: page?.id ? { connect: { id: page.id } } : undefined,
-            stagingUrl: staging.url,
-            wikidotId: staging.wikidotId,
-            needPhaseB: result.needPhaseB,
-            needPhaseC: result.needPhaseC,
-            donePhaseB: false,
-            donePhaseC: false,
-            reasons: result.reasons,
-            detectedAt: new Date()
-          }
+        toCreate.push({
+          pageId: page?.id ?? null,
+          stagingUrl: staging.url,
+          wikidotId: staging.wikidotId,
+          needPhaseB: result.needPhaseB,
+          needPhaseC: result.needPhaseC,
+          donePhaseB: false,
+          donePhaseC: false,
+          reasons: result.reasons,
+          detectedAt: new Date()
         });
       }
+    }
+
+    // One round-trip instead of N. PostgreSQL will still batch-insert these
+    // internally; createMany submits a single multi-row INSERT.
+    if (toCreate.length > 0) {
+      await this.prisma.dirtyPage.createMany({ data: toCreate });
     }
 
     Logger.info(`✅ Dirty queue built: ${stats.total} pages processed`);
@@ -202,6 +208,8 @@ export class DirtyQueueStore {
     // 获取所有staging记录（测试模式）
     const stagingPages = await this.prisma.pageMetaStaging.findMany();
 
+    const toCreate: Prisma.DirtyPageCreateManyInput[] = [];
+
     for (const staging of stagingPages) {
       const page = staging.wikidotId ? pageMap.get(staging.wikidotId) ?? null : null;
       const currentVersion = page ? versionMap.get(page.id) ?? null : null;
@@ -213,20 +221,22 @@ export class DirtyQueueStore {
       if (result.isDeleted) stats.deleted++;
 
       if (result.needPhaseB || result.needPhaseC) {
-        await this.prisma.dirtyPage.create({
-          data: {
-            page: page?.id ? { connect: { id: page.id } } : undefined,
-            stagingUrl: staging.url,
-            wikidotId: staging.wikidotId,
-            needPhaseB: result.needPhaseB,
-            needPhaseC: result.needPhaseC,
-            donePhaseB: false,
-            donePhaseC: false,
-            reasons: result.reasons,
-            detectedAt: new Date()
-          }
+        toCreate.push({
+          pageId: page?.id ?? null,
+          stagingUrl: staging.url,
+          wikidotId: staging.wikidotId,
+          needPhaseB: result.needPhaseB,
+          needPhaseC: result.needPhaseC,
+          donePhaseB: false,
+          donePhaseC: false,
+          reasons: result.reasons,
+          detectedAt: new Date()
         });
       }
+    }
+
+    if (toCreate.length > 0) {
+      await this.prisma.dirtyPage.createMany({ data: toCreate });
     }
 
     Logger.info(`✅ Dirty queue built (TEST): ${stats.total} pages`);

--- a/backend/src/core/store/DirtyQueueStore.ts
+++ b/backend/src/core/store/DirtyQueueStore.ts
@@ -4,6 +4,24 @@ import { SIMPLE_PAGE_THRESHOLD } from '../../config/RateLimitConfig.js';
 
 type DbClient = PrismaClient | Prisma.TransactionClient;
 
+// PostgreSQL's extended-query protocol caps a single statement at 65535 bind
+// parameters (uint16). DirtyPage has ~10 columns/row, so at ~6500 rows a
+// single createMany would already be at risk. Keep the per-call chunk well
+// under that — 2000 rows gives a comfortable safety margin and is still one
+// multi-row INSERT per chunk.
+const DIRTY_PAGE_CHUNK_SIZE = 2000;
+
+async function createDirtyPagesChunked(
+  prisma: DbClient,
+  rows: Prisma.DirtyPageCreateManyInput[]
+): Promise<void> {
+  for (let i = 0; i < rows.length; i += DIRTY_PAGE_CHUNK_SIZE) {
+    await prisma.dirtyPage.createMany({
+      data: rows.slice(i, i + DIRTY_PAGE_CHUNK_SIZE)
+    });
+  }
+}
+
 /**
  * Dirty Queue存储类
  * 负责管理需要更新的页面队列
@@ -171,10 +189,12 @@ export class DirtyQueueStore {
       }
     }
 
-    // One round-trip instead of N. PostgreSQL will still batch-insert these
-    // internally; createMany submits a single multi-row INSERT.
+    // Chunked to stay under PostgreSQL's 65535 bind-parameter cap. Without
+    // the split a full sync (tens of thousands of staging pages) would fail
+    // the createMany; because we already ran deleteMany, that failure would
+    // leave DirtyPage empty and silently block Phase B/C.
     if (toCreate.length > 0) {
-      await this.prisma.dirtyPage.createMany({ data: toCreate });
+      await createDirtyPagesChunked(this.prisma, toCreate);
     }
 
     Logger.info(`✅ Dirty queue built: ${stats.total} pages processed`);
@@ -236,7 +256,7 @@ export class DirtyQueueStore {
     }
 
     if (toCreate.length > 0) {
-      await this.prisma.dirtyPage.createMany({ data: toCreate });
+      await createDirtyPagesChunked(this.prisma, toCreate);
     }
 
     Logger.info(`✅ Dirty queue built (TEST): ${stats.total} pages`);

--- a/syncer/src/store/ContentStore.ts
+++ b/syncer/src/store/ContentStore.ts
@@ -16,10 +16,22 @@ export async function saveContent(
   let revisionsSaved = 0;
   let filesSaved = 0;
 
+  // Per-page concurrency cap for the revision/file upsert fan-out.
+  // Prisma's default connection_limit is num_cpus*2+1 on the syncer host.
+  // Keep the batch size well under that so we don't thrash the pool while
+  // still trading serial round-trips for parallel ones.
+  const PER_PAGE_CONCURRENCY = 8;
+
+  async function runChunked<T>(tasks: Array<() => Promise<T>>, chunkSize: number) {
+    for (let i = 0; i < tasks.length; i += chunkSize) {
+      await Promise.all(tasks.slice(i, i + chunkSize).map((fn) => fn()));
+    }
+  }
+
   for (const [fullname, content] of results) {
     const wikidotId = wikidotIds.get(fullname) ?? null;
 
-    // 1. Upsert PageContentCache
+    // 1. Upsert PageContentCache (must complete before dependants).
     await prisma.pageContentCache.upsert({
       where: { fullname },
       create: {
@@ -41,8 +53,10 @@ export async function saveContent(
     });
     contentSaved++;
 
-    // 2. Upsert RevisionRecords
-    for (const rev of content.revisions) {
+    // 2+3. Revisions and files for this page are independent of each other
+    // and of other rows, so fan them out concurrently. The try/catch keeps
+    // the old "skip duplicates / FK errors" behaviour.
+    const revTasks = content.revisions.map((rev) => async () => {
       try {
         await prisma.revisionRecord.upsert({
           where: { fullname_revNo: { fullname, revNo: rev.revNo } },
@@ -65,12 +79,11 @@ export async function saveContent(
         });
         revisionsSaved++;
       } catch {
-        // skip duplicates
+        // skip duplicates / FK errors
       }
-    }
+    });
 
-    // 3. Upsert FileRecords
-    for (const file of content.files) {
+    const fileTasks = content.files.map((file) => async () => {
       try {
         await prisma.fileRecord.upsert({
           where: { fullname_fileName: { fullname, fileName: file.fileName } },
@@ -90,9 +103,11 @@ export async function saveContent(
         });
         filesSaved++;
       } catch {
-        // skip duplicates
+        // skip duplicates / FK errors
       }
-    }
+    });
+
+    await runChunked([...revTasks, ...fileTasks], PER_PAGE_CONCURRENCY);
   }
 
   return { contentSaved, revisionsSaved, filesSaved };

--- a/syncer/src/store/db.ts
+++ b/syncer/src/store/db.ts
@@ -37,7 +37,13 @@ export function getMainPool(): pg.Pool {
   if (!mainPool) {
     const url = process.env.DATABASE_URL;
     if (!url) throw new Error('DATABASE_URL is not set (main DB for bootstrap reads)');
-    mainPool = new pg.Pool({ connectionString: url, max: 3 });
+    // max used to be 3, which serialized every parallelizable write in
+    // MainDbBridge (markPagesDeleted, createNewPageVersion, etc.). 10 lets
+    // the bridge exploit concurrency within one run without dwarfing the
+    // database's total max_connections (=500 in prod).
+    const rawMax = Number(process.env.SYNCER_MAIN_POOL_MAX ?? '10');
+    const max = Number.isFinite(rawMax) && rawMax > 0 ? Math.min(rawMax, 50) : 10;
+    mainPool = new pg.Pool({ connectionString: url, max });
   }
   return mainPool;
 }

--- a/user-backend/src/routes/gacha/draw.routes.ts
+++ b/user-backend/src/routes/gacha/draw.routes.ts
@@ -349,6 +349,15 @@ export function registerDrawRoutes(router: Router) {
         let cardsAffected = 0;
         let totalCount = 0;
         let totalReward = 0;
+        // Accumulated so we can write all dismantle logs in one createMany at
+        // the end of the loop. `deleteCardInstances` still runs per iteration
+        // because each card has a different set of instance ids.
+        const dismantleLogsToCreate: Array<{
+          userId: string;
+          cardId: string;
+          count: number;
+          tokensEarned: number;
+        }> = [];
 
         for (const item of inventoryItems) {
           const freeInstances = freeByCard.get(item.cardId) ?? [];
@@ -380,15 +389,16 @@ export function registerDrawRoutes(router: Router) {
           byRarityCount[item.card.rarity] += dismantleCount;
           byRarityReward[item.card.rarity] += reward;
 
-          // eslint-disable-next-line no-await-in-loop
-          await tx.gachaDismantleLog.create({
-            data: {
-              userId,
-              cardId: item.cardId,
-              count: dismantleCount,
-              tokensEarned: reward
-            }
+          dismantleLogsToCreate.push({
+            userId,
+            cardId: item.cardId,
+            count: dismantleCount,
+            tokensEarned: reward
           });
+        }
+
+        if (dismantleLogsToCreate.length > 0) {
+          await tx.gachaDismantleLog.createMany({ data: dismantleLogsToCreate });
         }
 
         let updatedWallet = wallet;


### PR DESCRIPTION
## 背景

SQL 审计指出 syncer / backend / user-backend 中四处"for-await upsert/create"在增量/批量场景下产生 N 次 DB 往返。本 PR 消除它们，保留原有业务语义（try/catch 吞重复、成功计数等）。

## 改动

| 文件 | 改法 |
|---|---|
| `syncer/src/store/db.ts` | `mainPool max: 3 → 10`（可经 `SYNCER_MAIN_POOL_MAX` 覆盖，上限 50）。生产 `max_connections=500` 完全安全 |
| `syncer/src/store/ContentStore.saveContent` | 每页的 revisions/files upsert 收集成 tasks，chunked `Promise.all`（每批 8）。逐页仍串行以维持业务顺序 |
| `backend/src/core/store/DirtyQueueStore.buildDirtyQueue{,TestMode}` | `for-await dirtyPage.create` → 累积 `Prisma.DirtyPageCreateManyInput[]` 然后一次 `createMany`。pageId 从 relation connect 改成直接 FK 字段 |
| `user-backend/src/routes/gacha/draw.routes.ts` | 批量分解时事务内逐条 `gachaDismantleLog.create` → 循环末尾一次 `createMany`。原代码已自带 `eslint-disable no-await-in-loop`，是作者承认的性能债。`deleteCardInstances` 保留逐条（每轮 toDelete 不同） |

## 未包含

- `syncer/src/bridge/MainDbBridge.ts`：当前不存在于 `origin/main`（在未合并的 feat 分支）。那里的批量化待 feat 分支合入后单独 PR。
- `HybridSearchService` 的 highlight SQL 合并：深度改动，风险/收益比不合适。

## 验证

- `backend`: `tsc -p tsconfig.src.json --noEmit` exit=0
- `syncer`: `tsc --noEmit` exit=0
- `user-backend`: `npm run build` exit=0