### PR TITLE
perf(bff): 降低 stats/analytics/pages 的重复扫表成本

### DIFF
--- a/bff/src/web/routes/analytics.ts
+++ b/bff/src/web/routes/analytics.ts
@@ -397,10 +397,12 @@ export function analyticsRouter(pool: Pool, redis: RedisClientType | null) {
 
       const loversSql = `${baseSelect} ORDER BY ${orderLovers} LIMIT $3 OFFSET $4`;
       const hatersSql = `${baseSelect} ORDER BY ${orderHaters} LIMIT $3 OFFSET $4`;
+      // COUNT 不需要 JOIN "User"：每条 UserTagPreference 有 FK 到 User，且
+      // 查询没有 User 列上的 WHERE 条件，JOIN 仅用于取 displayName/wikidotId
+      // 给 lovers/haters 的行用。剥离 JOIN 让 COUNT 只扫 UserTagPreference。
       const countSql = `
         SELECT COUNT(*)::int AS total
         FROM "UserTagPreference" utp
-        JOIN "User" u ON u.id = utp."userId"
         WHERE utp.tag = $1 AND utp."totalVotes" >= $2
       `;
 
@@ -479,10 +481,12 @@ export function analyticsRouter(pool: Pool, redis: RedisClientType | null) {
       `;
       const loversSql = `${baseSelect} ORDER BY ${orderLovers} LIMIT $3 OFFSET $4`;
       const hatersSql = `${baseSelect} ORDER BY ${orderHaters} LIMIT $3 OFFSET $4`;
+      // COUNT 不需要 JOIN "User"：每条 UserTagPreference 有 FK 到 User，且
+      // 查询没有 User 列上的 WHERE 条件，JOIN 仅用于取 displayName/wikidotId
+      // 给 lovers/haters 的行用。剥离 JOIN 让 COUNT 只扫 UserTagPreference。
       const countSql = `
         SELECT COUNT(*)::int AS total
         FROM "UserTagPreference" utp
-        JOIN "User" u ON u.id = utp."userId"
         WHERE utp.tag = $1 AND utp."totalVotes" >= $2
       `;
 

--- a/bff/src/web/routes/pages.ts
+++ b/bff/src/web/routes/pages.ts
@@ -44,13 +44,22 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
         return res.json({ votes: {} });
       }
 
-      const ids = (Array.isArray(idsParam) ? idsParam : String(idsParam).split(','))
+      // Hard cap on array size so a caller passing thousands of ids can't
+      // push PG's planner to a seq scan on Vote. 200 comfortably covers all
+      // real page-list responses (default page size is 40).
+      const MAX_VOTE_STATUS_IDS = 200;
+      const parsedIds = (Array.isArray(idsParam) ? idsParam : String(idsParam).split(','))
         .map((value) => Number(String(value).trim()))
         .filter((value) => Number.isInteger(value) && value > 0);
 
-      if (ids.length === 0) {
+      if (parsedIds.length === 0) {
         return res.json({ votes: {} });
       }
+
+      if (parsedIds.length > MAX_VOTE_STATUS_IDS) {
+        return res.status(400).json({ error: 'too_many_ids', max: MAX_VOTE_STATUS_IDS });
+      }
+      const ids = parsedIds;
 
       const viewerWikidotId = Number(viewerParam);
       if (!Number.isInteger(viewerWikidotId) || viewerWikidotId <= 0) {

--- a/bff/src/web/routes/stats.ts
+++ b/bff/src/web/routes/stats.ts
@@ -73,12 +73,14 @@ export function statsRouter(pool: Pool, redis: RedisClientType | null) {
 					WHERE "lastActivityAt" IS NOT NULL
 					  AND "lastActivityAt" >= CURRENT_DATE - INTERVAL '90 days'
 				`;
-				const [baseRes, countsRes] = await Promise.all([
-					timedQuery('site.latest base', baseSql, undefined, reqLabel),
-					timedQuery('site.latest activeCounts', activeCountsSql, undefined, reqLabel)
-				]);
+				// Short-circuit before the expensive active-user scan. cache.remember
+				// does not cache null, so if SiteStats is empty (fresh env / first
+				// deploy) every request would otherwise re-run `activeCountsSql`
+				// only to return 404. Do the cheap base query first, bail on miss.
+				const baseRes = await timedQuery('site.latest base', baseSql, undefined, reqLabel);
 				const base = baseRes.rows[0];
 				if (!base) return null;
+				const countsRes = await timedQuery('site.latest activeCounts', activeCountsSql, undefined, reqLabel);
 				const counts = countsRes.rows[0] ?? { activeUsers30: 0, activeUsers60: 0, activeUsers90: 0 };
 				return { ...base, ...counts };
 			});

--- a/bff/src/web/routes/stats.ts
+++ b/bff/src/web/routes/stats.ts
@@ -46,26 +46,41 @@ export function statsRouter(pool: Pool, redis: RedisClientType | null) {
 			// 缓存 1 小时 - 站点统计变化较慢，减少 sync 期间的数据库压力
 		const data = await cache.remember('stats:site:latest', 3600, async () => {
 				const reqLabel = `site.latest:${Date.now().toString(36)}`;
-				const sql = `
-					SELECT 
-						s.date, 
-						s."totalUsers", 
+				// Base stats row is cheap (single-row SELECT from SiteStats).
+				const baseSql = `
+					SELECT
+						s.date,
+						s."totalUsers",
 						s."activeUsers", -- 约定为近60天活跃
-						s."totalPages", 
+						s."totalPages",
 						s."totalVotes",
-						s."newUsersToday", 
-						s."newPagesToday", 
-						s."newVotesToday",
-						-- 参考口径：近30/60/90天活跃用户（基于当前日期）
-						(SELECT COUNT(*) FROM "User" u WHERE u."lastActivityAt" IS NOT NULL AND u."lastActivityAt" >= CURRENT_DATE - INTERVAL '30 days') AS "activeUsers30",
-						(SELECT COUNT(*) FROM "User" u WHERE u."lastActivityAt" IS NOT NULL AND u."lastActivityAt" >= CURRENT_DATE - INTERVAL '60 days') AS "activeUsers60",
-						(SELECT COUNT(*) FROM "User" u WHERE u."lastActivityAt" IS NOT NULL AND u."lastActivityAt" >= CURRENT_DATE - INTERVAL '90 days') AS "activeUsers90"
+						s."newUsersToday",
+						s."newPagesToday",
+						s."newVotesToday"
 					FROM "SiteStats" s
 					ORDER BY s.date DESC
 					LIMIT 1
 				`;
-				const { rows } = await timedQuery('site.latest base', sql, undefined, reqLabel);
-				return rows[0] ?? null;
+				// 近 30/60/90 天活跃用户合并为一次扫描 — 先按索引范围 (>= 90 days)
+				// 收窄行集，再用 COUNT FILTER 一次出三列。原版是三条独立 subquery
+				// 每条扫全表，冷缓存下可达秒级。
+				const activeCountsSql = `
+					SELECT
+						COUNT(*) FILTER (WHERE "lastActivityAt" >= CURRENT_DATE - INTERVAL '30 days')::int AS "activeUsers30",
+						COUNT(*) FILTER (WHERE "lastActivityAt" >= CURRENT_DATE - INTERVAL '60 days')::int AS "activeUsers60",
+						COUNT(*) AS "activeUsers90"
+					FROM "User"
+					WHERE "lastActivityAt" IS NOT NULL
+					  AND "lastActivityAt" >= CURRENT_DATE - INTERVAL '90 days'
+				`;
+				const [baseRes, countsRes] = await Promise.all([
+					timedQuery('site.latest base', baseSql, undefined, reqLabel),
+					timedQuery('site.latest activeCounts', activeCountsSql, undefined, reqLabel)
+				]);
+				const base = baseRes.rows[0];
+				if (!base) return null;
+				const counts = countsRes.rows[0] ?? { activeUsers30: 0, activeUsers60: 0, activeUsers90: 0 };
+				return { ...base, ...counts };
 			});
 			if (!data) return res.status(404).json({ error: 'not_found' });
 			res.json(data);


### PR DESCRIPTION
## 三处小优化

### 1. `stats.ts` `/site/latest` 的 activeUsers30/60/90
- 原：一条 SELECT 里塞三个独立 SCALAR subquery 扫 User 表，缓存 miss 时等于 3 次 seq scan
- 改：拆成两条查询 `Promise.all`。第二条先 `WHERE lastActivityAt >= CURRENT_DATE - INTERVAL '90 days'` 借 `User.lastActivityAt` 索引收窄行集，再用 `COUNT(*) FILTER (...)` 一次算 30/60/90 三列

### 2. `analytics.ts` `/tags/users`、`/tags/users/batch` 的 COUNT
- 原：COUNT 子查询 JOIN `User`，但 WHERE 没有 User 列条件，JOIN 纯浪费
- 改：剥离 JOIN，COUNT 只扫 `UserTagPreference`。热 tag 收益最明显

### 3. `pages.ts` `/vote-status` 的 `ANY($1::int[])` 数组大小 clamp
- 原：只过滤 `>0`，无上限。外部传 1 万+ id 会让规划器退到 `Vote` 的 seq scan
- 改：clamp 到 200（默认页 40，有冗余），超过返回 `400 too_many_ids`

## 未包含（单独 PR）

- LIMIT+OFFSET 深翻页全面改 keyset（审计 M-6，40+ 处）
- `search.ts` 正则执行超时（审计 M-5）

## 验证

`bff` `npm run build` exit=0。