### PR TITLE
feat(bff): 新增 /embed 路由提供 Wikidot 可嵌入徽章与用户卡

### DIFF
--- a/bff/src/web/router.ts
+++ b/bff/src/web/router.ts
@@ -28,6 +28,7 @@ import { forumsRouter } from './routes/forums.js';
 import { cssProxyRouter } from './routes/css-proxy.js';
 import { pagePreviewRouter } from './routes/page-preview.js';
 import { annualSummaryRouter } from './routes/annual-summary.js';
+import { embedRouter } from './routes/embed.js';
 
 export function buildRouter(pool: Pool, redis: RedisClientType | null) {
   const router = Router();
@@ -85,6 +86,7 @@ export function buildRouter(pool: Pool, redis: RedisClientType | null) {
   router.use('/pages', pagePreviewRouter(pool));
   router.use(cssProxyRouter());
   router.use('/annual-summary', annualSummaryRouter());
+  router.use('/embed', embedRouter(pool, redis));
   router.use('/internal', guardInternalRoutes, internalRouter());
   router.use('/', htmlSnippetsRouter);
   router.use(PAGE_IMAGE_ROUTE_PREFIX, pageImagesRouter(pool));

--- a/bff/src/web/routes/embed.ts
+++ b/bff/src/web/routes/embed.ts
@@ -34,6 +34,9 @@ const BADGE_CACHE_SECONDS = 300;
 const USER_CARD_CACHE_SECONDS = 300;
 const USER_HISTORY_CACHE_SECONDS = 600;
 
+const VALID_BADGE_METRICS = new Set(['rating', 'wilson', 'controversy', 'votes', 'trend']);
+const VALID_BADGE_STYLES = new Set(['flat', 'plastic', 'mono']);
+
 function parseFlag(value: unknown, def: boolean): boolean {
   if (value === undefined || value === null) return def;
   const str = String(value).toLowerCase();
@@ -47,6 +50,52 @@ function parseRange(raw: unknown): '90d' | '1y' | 'all' {
   if (s === '1y' || s === '365d' || s === '12m') return '1y';
   if (s === 'all') return 'all';
   return '90d';
+}
+
+/** 仅接受 3/6/8 位 hex，不带 #。其他输入（含 "currentColor" 之类的关键字）一律视为未传。 */
+function normalizeAccentParam(raw: unknown): string {
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim().replace(/^#/, '').toLowerCase();
+  if (/^[0-9a-f]{3}$/.test(trimmed) || /^[0-9a-f]{6}$/.test(trimmed) || /^[0-9a-f]{8}$/.test(trimmed)) {
+    return trimmed;
+  }
+  return '';
+}
+
+/** label 长度/字符收紧，最多 32 个可见 ASCII+中文，用来防御 cache key 轰炸和 SVG 过宽。 */
+function normalizeLabelParam(raw: unknown): string {
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  if (trimmed.length > 32) return trimmed.slice(0, 32);
+  return trimmed;
+}
+
+/** 渲染一个走 sendEmbedHtml 包装的极简 404 页，保留 frame-ancestors / CSP / 缓存控制。 */
+function sendEmbedNotFound(
+  res: import('express').Response,
+  themeOpts: import('../utils/embed/theme.js').ResolvedTheme,
+  message: string
+) {
+  const body = `<div class="e-empty-card">${message
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')}</div>`;
+  const baseCss = `
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; background: transparent; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", Roboto, sans-serif; color: var(--e-text-muted); font-size: 13px; }
+    .e-empty-card { padding: 16px 20px; border: 1px dashed var(--e-border); border-radius: 12px; background: var(--e-surface); text-align: center; }
+  `;
+  sendEmbedHtml(res, {
+    title: 'SCPPER-CN',
+    baseCss,
+    bodyHtml: body,
+    theme: themeOpts,
+    extraImgSrc: "'self' data:",
+    cacheSeconds: 60,
+    statusCode: 404
+  });
 }
 
 function trimSeriesToLastDays(values: number[], days: number): number[] {
@@ -98,20 +147,31 @@ export function embedRouter(pool: Pool, redis: RedisClientType | null) {
   router.get('/badge/page/:wikidotId\\.svg', async (req, res, next) => {
     try {
       const wikidotId = Number((req.params as Record<string, string>).wikidotId);
-      const metric = String(req.query.metric || 'rating').toLowerCase();
-      const style = (String(req.query.style || 'flat').toLowerCase() as 'flat' | 'plastic' | 'mono');
+      const rawMetric = typeof req.query.metric === 'string' ? req.query.metric.toLowerCase() : 'rating';
+      const rawStyle = typeof req.query.style === 'string' ? req.query.style.toLowerCase() : 'flat';
+      if (!VALID_BADGE_METRICS.has(rawMetric)) {
+        return res.status(400).json({ error: 'invalid_metric', allowed: Array.from(VALID_BADGE_METRICS) });
+      }
+      if (!VALID_BADGE_STYLES.has(rawStyle)) {
+        return res.status(400).json({ error: 'invalid_style', allowed: Array.from(VALID_BADGE_STYLES) });
+      }
+      const metric = rawMetric as 'rating' | 'wilson' | 'controversy' | 'votes' | 'trend';
+      const style = rawStyle as 'flat' | 'plastic' | 'mono';
       const themeMono = style === 'mono' || String(req.query.theme || '').toLowerCase() === 'mono';
-      const accent = typeof req.query.accent === 'string' ? req.query.accent : undefined;
-      const labelOverride = typeof req.query.label === 'string' ? req.query.label : undefined;
+      const accentHex = normalizeAccentParam(req.query.accent);
+      // trend 模式下 accent/label 不参与渲染，就不要让它进 cache key，避免
+      // `?metric=trend&accent=1/2/3...` 刷穿 JSONB 读取。
+      const labelOverride = metric === 'trend' ? '' : normalizeLabelParam(req.query.label);
+      const accentForKey = metric === 'trend' ? '' : accentHex;
 
-      const cacheKey = `embed:badge:page:${wikidotId}:${metric}:${style}:${themeMono ? 'm' : 'c'}:${accent || ''}:${labelOverride || ''}`;
+      const cacheKey = `embed:badge:page:${wikidotId}:${metric}:${style}:${themeMono ? 'm' : 'c'}:${accentForKey}:${labelOverride}`;
 
       const svg = await cache.remember(cacheKey, BADGE_CACHE_SECONDS, async () => {
         if (metric === 'trend') {
           const series = await loadPageVotingSeries(readPool, wikidotId);
           if (!series) {
             return renderSvgBadge({
-              label: labelOverride || 'scpper',
+              label: 'scpper',
               value: 'no data',
               style: style === 'mono' ? 'flat' : style,
               themeMono,
@@ -184,14 +244,14 @@ export function embedRouter(pool: Pool, redis: RedisClientType | null) {
           if (colorKey === 'rating_pos') color = '#4c1';
           else if (colorKey === 'rating_neg') color = '#e05d44';
           else color = metricColor(metric, false);
-          if (accent) color = undefined; // 若用户传 accent，优先走 accent
+          if (accentHex) color = undefined; // 若用户传 accent，优先走 accent
         }
         return renderSvgBadge({
           label,
           value,
           style: style === 'mono' ? 'flat' : style,
           themeMono,
-          color: accent ? `#${String(accent).replace(/^#/, '')}` : color,
+          color: accentHex ? `#${accentHex}` : color,
           title: page.title || undefined
         });
       });
@@ -234,8 +294,7 @@ export function embedRouter(pool: Pool, redis: RedisClientType | null) {
       });
 
       if (!data) {
-        res.status(404).setHeader('Cache-Control', 'public, max-age=60');
-        return res.type('text/html').send('<!doctype html><html><body style="font-family:sans-serif;padding:16px;color:#888">用户不存在或无统计数据</body></html>');
+        return sendEmbedNotFound(res, themeOpts, '用户不存在或无统计数据');
       }
 
       const renderOpts: UserCardRenderOptions = {
@@ -251,7 +310,9 @@ export function embedRouter(pool: Pool, redis: RedisClientType | null) {
         userCss: sanitizedCss,
         bodyHtml,
         theme: themeOpts,
-        extraImgSrc: "'self' data: https:",
+        // user-card 不再放开外部 https 图片：作者自定义 CSS 只允许 same-origin 和 data:image，
+        // 防止 url() 被当作访客追踪像素。头像走 /api/avatar（同源）仍能工作。
+        extraImgSrc: "'self' data:",
         cacheSeconds: USER_CARD_CACHE_SECONDS
       });
     } catch (error) {
@@ -285,8 +346,7 @@ export function embedRouter(pool: Pool, redis: RedisClientType | null) {
       });
 
       if (!data) {
-        res.status(404).setHeader('Cache-Control', 'public, max-age=60');
-        return res.type('text/html').send('<!doctype html><html><body style="font-family:sans-serif;padding:16px;color:#888">用户不存在</body></html>');
+        return sendEmbedNotFound(res, themeOpts, '用户不存在');
       }
 
       const renderOpts: UserHistoryRenderOptions = {

--- a/bff/src/web/routes/embed.ts
+++ b/bff/src/web/routes/embed.ts
@@ -1,0 +1,314 @@
+import { Router } from 'express';
+import type { Pool } from 'pg';
+import type { RedisClientType } from 'redis';
+import rateLimit from 'express-rate-limit';
+
+import { createCache } from '../utils/cache.js';
+import { getReadPoolSync } from '../utils/dbPool.js';
+import { parsePositiveInt } from '../utils/helpers.js';
+
+import { renderSvgBadge } from '../utils/embed/svgBadge.js';
+import { renderSparkline } from '../utils/embed/sparkline.js';
+import { resolveTheme } from '../utils/embed/theme.js';
+import { sendEmbedHtml } from '../utils/embed/htmlWrapper.js';
+import { sanitizeInlineCss } from '../utils/embed/inlineCss.js';
+import { loadPageBadgeData, loadPageVotingSeries } from '../utils/embed/pageData.js';
+import {
+  loadUserBasicByWikidotId,
+  loadUserCardStats,
+  loadUserVotingSeries,
+  loadUserActivityHeatmap
+} from '../utils/embed/userData.js';
+import {
+  USER_CARD_BASE_CSS,
+  renderUserCardBody,
+  type UserCardRenderOptions
+} from '../utils/embed/templates/userCard.js';
+import {
+  USER_HISTORY_BASE_CSS,
+  renderUserHistoryBody,
+  type UserHistoryRenderOptions
+} from '../utils/embed/templates/userHistory.js';
+
+const BADGE_CACHE_SECONDS = 300;
+const USER_CARD_CACHE_SECONDS = 300;
+const USER_HISTORY_CACHE_SECONDS = 600;
+
+function parseFlag(value: unknown, def: boolean): boolean {
+  if (value === undefined || value === null) return def;
+  const str = String(value).toLowerCase();
+  if (str === '1' || str === 'true' || str === 'yes' || str === 'on') return true;
+  if (str === '0' || str === 'false' || str === 'no' || str === 'off') return false;
+  return def;
+}
+
+function parseRange(raw: unknown): '90d' | '1y' | 'all' {
+  const s = typeof raw === 'string' ? raw.toLowerCase() : '';
+  if (s === '1y' || s === '365d' || s === '12m') return '1y';
+  if (s === 'all') return 'all';
+  return '90d';
+}
+
+function trimSeriesToLastDays(values: number[], days: number): number[] {
+  if (values.length <= days) return values.slice();
+  return values.slice(values.length - days);
+}
+
+function metricColor(metric: string, themeMono: boolean): string | undefined {
+  if (themeMono) return undefined;
+  switch (metric) {
+    case 'wilson':
+      return '#16a34a';
+    case 'controversy':
+      return '#d97706';
+    case 'votes':
+      return '#6f4ef2';
+    case 'trend':
+      return '#0ea5e9';
+    default:
+      return '#4c1';
+  }
+}
+
+export function embedRouter(pool: Pool, redis: RedisClientType | null) {
+  const router = Router();
+  const cache = createCache(redis);
+  const readPool = getReadPoolSync(pool);
+
+  // 整个 /embed 下统一做一层保守限速，防止单 IP 刷爆缓存层
+  const limiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 120,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'too_many_requests' }
+  });
+  router.use(limiter);
+
+  router.param('wikidotId', (req, res, next, value) => {
+    if (parsePositiveInt(value) === null) {
+      return res.status(400).json({ error: 'invalid_wikidotId' });
+    }
+    return next();
+  });
+
+  // ──────────────────────────────────────
+  // 1) SVG badge: GET /embed/badge/page/:wikidotId.svg
+  // ──────────────────────────────────────
+  router.get('/badge/page/:wikidotId\\.svg', async (req, res, next) => {
+    try {
+      const wikidotId = Number((req.params as Record<string, string>).wikidotId);
+      const metric = String(req.query.metric || 'rating').toLowerCase();
+      const style = (String(req.query.style || 'flat').toLowerCase() as 'flat' | 'plastic' | 'mono');
+      const themeMono = style === 'mono' || String(req.query.theme || '').toLowerCase() === 'mono';
+      const accent = typeof req.query.accent === 'string' ? req.query.accent : undefined;
+      const labelOverride = typeof req.query.label === 'string' ? req.query.label : undefined;
+
+      const cacheKey = `embed:badge:page:${wikidotId}:${metric}:${style}:${themeMono ? 'm' : 'c'}:${accent || ''}:${labelOverride || ''}`;
+
+      const svg = await cache.remember(cacheKey, BADGE_CACHE_SECONDS, async () => {
+        if (metric === 'trend') {
+          const series = await loadPageVotingSeries(readPool, wikidotId);
+          if (!series) {
+            return renderSvgBadge({
+              label: labelOverride || 'scpper',
+              value: 'no data',
+              style: style === 'mono' ? 'flat' : style,
+              themeMono,
+              color: '#9ca3af'
+            });
+          }
+          // 按用户拍板：sparkline 默认 90 天
+          const windowDays = 90;
+          const dailyUp = series.dailyUpvotes.slice(-windowDays);
+          const dailyDown = series.dailyDownvotes.slice(-windowDays);
+          const n = Math.max(dailyUp.length, dailyDown.length);
+          const net: number[] = [];
+          let running = 0;
+          // 用完整缓存末尾的 cumulative 作为初始值
+          const prefixN = Math.max(0, series.upvotes.length - n);
+          if (prefixN > 0) {
+            running = (series.upvotes[prefixN - 1] ?? 0) - (series.downvotes[prefixN - 1] ?? 0);
+          }
+          for (let i = 0; i < n; i += 1) {
+            running += (dailyUp[i] ?? 0) - (dailyDown[i] ?? 0);
+            net.push(running);
+          }
+          const stroke = themeMono ? 'currentColor' : (metricColor('trend', false) as string);
+          return renderSparkline({
+            values: net,
+            width: 140,
+            height: 28,
+            stroke,
+            fill: themeMono ? 'none' : 'color-mix(in srgb, #0ea5e9 20%, transparent)',
+            showZeroAxis: true
+          });
+        }
+
+        const page = await loadPageBadgeData(readPool, wikidotId);
+        if (!page) {
+          return renderSvgBadge({
+            label: labelOverride || 'scpper',
+            value: 'not found',
+            style: style === 'mono' ? 'flat' : style,
+            themeMono,
+            color: '#9ca3af'
+          });
+        }
+
+        let label = labelOverride || 'rating';
+        let value = String(page.rating);
+        switch (metric) {
+          case 'wilson':
+            label = labelOverride || 'wilson 95%';
+            value = page.wilson95 != null ? page.wilson95.toFixed(3) : '—';
+            break;
+          case 'controversy':
+            label = labelOverride || 'controversy';
+            value = page.controversy != null ? page.controversy.toFixed(3) : '—';
+            break;
+          case 'votes':
+            label = labelOverride || 'votes';
+            value = String(page.voteCount);
+            break;
+          case 'rating':
+          default:
+            label = labelOverride || 'rating';
+            value = (page.rating >= 0 ? '+' : '') + String(page.rating);
+            break;
+        }
+
+        const colorKey = metric === 'rating' ? (page.rating >= 0 ? 'rating_pos' : 'rating_neg') : metric;
+        let color: string | undefined;
+        if (!themeMono) {
+          if (colorKey === 'rating_pos') color = '#4c1';
+          else if (colorKey === 'rating_neg') color = '#e05d44';
+          else color = metricColor(metric, false);
+          if (accent) color = undefined; // 若用户传 accent，优先走 accent
+        }
+        return renderSvgBadge({
+          label,
+          value,
+          style: style === 'mono' ? 'flat' : style,
+          themeMono,
+          color: accent ? `#${String(accent).replace(/^#/, '')}` : color,
+          title: page.title || undefined
+        });
+      });
+
+      res.setHeader('Content-Type', 'image/svg+xml; charset=utf-8');
+      res.setHeader('Cache-Control', `public, max-age=${BADGE_CACHE_SECONDS}, s-maxage=${BADGE_CACHE_SECONDS * 3}`);
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.status(200).send(svg);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // ──────────────────────────────────────
+  // 2) User card iframe: GET /embed/user-card/:wikidotId
+  // ──────────────────────────────────────
+  router.get('/user-card/:wikidotId', async (req, res, next) => {
+    try {
+      const wikidotId = Number((req.params as Record<string, string>).wikidotId);
+      const themeOpts = resolveTheme(req.query.theme, req.query.accent);
+      const breakdown = (String(req.query.breakdown || 'list').toLowerCase() === 'radar')
+        ? 'radar'
+        : 'list';
+      const hideActivity = parseFlag(req.query.hideActivity, false);
+      const categoriesParam = typeof req.query.showCategories === 'string' ? req.query.showCategories : '';
+      const showCategories = categoriesParam
+        ? categoriesParam.split(',').map(s => s.trim().toLowerCase()).filter(Boolean)
+        : [];
+
+      const userCss = typeof req.query.css === 'string' ? req.query.css : '';
+      const sanitizedCss = sanitizeInlineCss(userCss);
+
+      const dataCacheKey = `embed:user-card-data:${wikidotId}`;
+      const data = await cache.remember(dataCacheKey, USER_CARD_CACHE_SECONDS, async () => {
+        const user = await loadUserBasicByWikidotId(readPool, wikidotId);
+        if (!user) return null;
+        const stats = await loadUserCardStats(readPool, wikidotId);
+        if (!stats) return null;
+        return { user, stats };
+      });
+
+      if (!data) {
+        res.status(404).setHeader('Cache-Control', 'public, max-age=60');
+        return res.type('text/html').send('<!doctype html><html><body style="font-family:sans-serif;padding:16px;color:#888">用户不存在或无统计数据</body></html>');
+      }
+
+      const renderOpts: UserCardRenderOptions = {
+        breakdown,
+        hideActivity,
+        showCategories
+      };
+
+      const bodyHtml = renderUserCardBody(data.user, data.stats, renderOpts);
+      sendEmbedHtml(res, {
+        title: `${data.user.displayName || 'User'} · SCPPER-CN`,
+        baseCss: USER_CARD_BASE_CSS,
+        userCss: sanitizedCss,
+        bodyHtml,
+        theme: themeOpts,
+        extraImgSrc: "'self' data: https:",
+        cacheSeconds: USER_CARD_CACHE_SECONDS
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // ──────────────────────────────────────
+  // 3) User history iframe: GET /embed/user-history/:wikidotId
+  // ──────────────────────────────────────
+  router.get('/user-history/:wikidotId', async (req, res, next) => {
+    try {
+      const wikidotId = Number((req.params as Record<string, string>).wikidotId);
+      const themeOpts = resolveTheme(req.query.theme, req.query.accent);
+      const range = parseRange(req.query.range);
+      const showTrend = parseFlag(req.query.showTrend, true);
+      const showHeatmap = parseFlag(req.query.showHeatmap, true);
+
+      const userCss = typeof req.query.css === 'string' ? req.query.css : '';
+      const sanitizedCss = sanitizeInlineCss(userCss);
+
+      const dataCacheKey = `embed:user-history-data:${wikidotId}:${range}:${showTrend ? 1 : 0}:${showHeatmap ? 1 : 0}`;
+      const data = await cache.remember(dataCacheKey, USER_HISTORY_CACHE_SECONDS, async () => {
+        const user = await loadUserBasicByWikidotId(readPool, wikidotId);
+        if (!user) return null;
+        const series = showTrend ? await loadUserVotingSeries(readPool, wikidotId) : null;
+        const heatmap = showHeatmap
+          ? await loadUserActivityHeatmap(readPool, user.id, 366)
+          : [];
+        return { user, series, heatmap };
+      });
+
+      if (!data) {
+        res.status(404).setHeader('Cache-Control', 'public, max-age=60');
+        return res.type('text/html').send('<!doctype html><html><body style="font-family:sans-serif;padding:16px;color:#888">用户不存在</body></html>');
+      }
+
+      const renderOpts: UserHistoryRenderOptions = {
+        range,
+        showTrend,
+        showHeatmap
+      };
+
+      const bodyHtml = renderUserHistoryBody(data.user, data.series, data.heatmap, renderOpts);
+      sendEmbedHtml(res, {
+        title: `${data.user.displayName || 'User'} · 历史 · SCPPER-CN`,
+        baseCss: USER_HISTORY_BASE_CSS,
+        userCss: sanitizedCss,
+        bodyHtml,
+        theme: themeOpts,
+        extraImgSrc: "'self' data:",
+        cacheSeconds: USER_HISTORY_CACHE_SECONDS
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/bff/src/web/utils/embed/htmlWrapper.ts
+++ b/bff/src/web/utils/embed/htmlWrapper.ts
@@ -12,6 +12,8 @@ export interface EmbedHtmlOptions {
   extraImgSrc?: string;
   /** 缓存秒数，默认 300 */
   cacheSeconds?: number;
+  /** HTTP 状态码；默认 200。用于把 embed wrapper 复用给 404/410 等错误页。 */
+  statusCode?: number;
 }
 
 function escapeHtml(str: string): string {
@@ -62,5 +64,6 @@ ${cleanUser ? `<style data-origin="user">${cleanUser}</style>` : ''}
 <body class="e-body">${opts.bodyHtml}</body>
 </html>`;
 
-  res.status(200).send(html);
+  const status = Number.isInteger(opts.statusCode) ? opts.statusCode! : 200;
+  res.status(status).send(html);
 }

--- a/bff/src/web/utils/embed/htmlWrapper.ts
+++ b/bff/src/web/utils/embed/htmlWrapper.ts
@@ -1,0 +1,66 @@
+import type { Response } from 'express';
+import { buildThemeCss, type ResolvedTheme } from './theme.js';
+import { sanitizeInlineCss } from './inlineCss.js';
+
+export interface EmbedHtmlOptions {
+  title: string;
+  baseCss: string;              // 模板自带 CSS
+  userCss?: string;             // 已由 sanitizeInlineCss 过的 CSS；若传原始值会再跑一次
+  bodyHtml: string;             // <body> 内容
+  theme: ResolvedTheme;
+  /** 额外 CSP `img-src` 项，例如 "'self' /api/avatar" */
+  extraImgSrc?: string;
+  /** 缓存秒数，默认 300 */
+  cacheSeconds?: number;
+}
+
+function escapeHtml(str: string): string {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function sendEmbedHtml(res: Response, opts: EmbedHtmlOptions): void {
+  const cleanUser = opts.userCss ? sanitizeInlineCss(opts.userCss) : '';
+  const themeVars = buildThemeCss(opts.theme);
+  const cacheSeconds = opts.cacheSeconds ?? 300;
+
+  const imgSrc = opts.extraImgSrc || "data: https:";
+
+  // frame-ancestors '*' 让任何站点都能 iframe；这是嵌入组件的必需品。
+  // 关闭 script-src，所有行为用纯 CSS 实现。
+  const csp = [
+    "default-src 'none'",
+    "base-uri 'none'",
+    "style-src 'unsafe-inline'",
+    `img-src ${imgSrc}`,
+    "font-src data:",
+    "connect-src 'none'",
+    "frame-ancestors *"
+  ].join('; ');
+
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.setHeader('Cache-Control', `public, max-age=${cacheSeconds}`);
+  res.setHeader('Content-Security-Policy', csp);
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Referrer-Policy', 'no-referrer');
+  // 不设 X-Frame-Options: 留白即允许被任意站点 iframe
+  res.removeHeader('X-Frame-Options');
+
+  const html = `<!DOCTYPE html>
+<html lang="zh-CN" data-theme="${opts.theme.theme}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1">
+<title>${escapeHtml(opts.title)}</title>
+<style>${themeVars}</style>
+<style>${opts.baseCss}</style>
+${cleanUser ? `<style data-origin="user">${cleanUser}</style>` : ''}
+</head>
+<body class="e-body">${opts.bodyHtml}</body>
+</html>`;
+
+  res.status(200).send(html);
+}

--- a/bff/src/web/utils/embed/inlineCss.ts
+++ b/bff/src/web/utils/embed/inlineCss.ts
@@ -1,6 +1,52 @@
 export const INLINE_CSS_MAX_BYTES = 4096;
 
 /**
+ * 把 CSS 转义（`\HH ` / `\HHHHHH` / `\X`）展开成真实字符。
+ *
+ * 该函数只用于"检测输入里是否混入了需要被拒绝的关键字"。实际返回给客户端的仍然是
+ * 原始字符串：让浏览器自己按 CSS 规范重新识别转义，这样作者还能用 `\feff` 之类的
+ * 合法写法。参考 CSS Syntax Module Level 3 §4.3.7。
+ */
+function decodeCssEscapes(src: string): string {
+  return src.replace(/\\([0-9a-fA-F]{1,6})[\t\n\f\r ]?|\\([^\n\r\f])/g, (_, hex, other) => {
+    if (hex) {
+      const code = parseInt(hex, 16);
+      if (!Number.isFinite(code) || code === 0 || (code >= 0xd800 && code <= 0xdfff) || code > 0x10ffff) {
+        return '\ufffd';
+      }
+      try {
+        return String.fromCodePoint(code);
+      } catch {
+        return '\ufffd';
+      }
+    }
+    return other || '';
+  });
+}
+
+const FORBIDDEN_DECODED: RegExp[] = [
+  /@import/i,
+  /@charset/i,
+  /@namespace/i,
+  /@document/i,
+  /behavior\s*:/i,
+  /-moz-binding/i,
+  /expression\s*\(/i,
+  /javascript\s*:/i,
+  /vbscript\s*:/i,
+  /data\s*:\s*text\//i,
+  /data\s*:\s*application\/(x-)?javascript/i
+];
+
+// HTML-层 break-out 必须对原始字符串匹配：HTML 解析器看 <style> 里的文本时
+// 只找字面 `</style>` / `</script>`，不过任何 CSS 转义，所以检测必须基于原文。
+const FORBIDDEN_RAW: RegExp[] = [
+  /<\s*\/?\s*style\b/i,
+  /<\s*\/?\s*script\b/i,
+  /<\s*\/?\s*iframe\b/i
+];
+
+/**
  * 结果：safe 版的 CSS 字符串（若被截断或拒绝，会返回空串）。
  *
  * 拒绝而非抛错的理由：CSS 是纯装饰，任何"解析不了"的情况直接回落到默认样式即可，
@@ -22,43 +68,35 @@ export function sanitizeInlineCss(raw: unknown): string {
   }
 
   // 剥离块注释，避免注释里绕过关键字检查；CSS 行注释 (//) 不是标准，不处理。
-  let cleaned = input.replace(/\/\*[\s\S]*?\*\//g, ' ');
+  const commentStripped = input.replace(/\/\*[\s\S]*?\*\//g, ' ');
 
-  // 关键字黑名单：遇到一项直接拒绝整块
-  const forbidden: RegExp[] = [
-    /@import/i,
-    /@charset/i,
-    /@namespace/i,
-    /behavior\s*:/i,
-    /-moz-binding/i,
-    /expression\s*\(/i,
-    /javascript\s*:/i,
-    /vbscript\s*:/i,
-    /<\s*\/?\s*style\b/i,
-    /<\s*\/?\s*script\b/i,
-    /<\s*\/?\s*iframe\b/i
-  ];
-  for (const rule of forbidden) {
-    if (rule.test(cleaned)) return '';
+  // HTML break-out 基于原文匹配
+  for (const rule of FORBIDDEN_RAW) {
+    if (rule.test(commentStripped)) return '';
   }
 
-  // 限制 url(...)：只允许 http/https/相对路径 / data:image/*
-  cleaned = cleaned.replace(/url\(\s*(['"]?)([^'")]+)\1\s*\)/gi, (full, quote, urlRaw) => {
+  // 其他关键字用"CSS 转义展开后"的文本匹配，堵掉 `@\41import` / `ex\70 ression(` 之类绕过
+  const decoded = decodeCssEscapes(commentStripped);
+  for (const rule of FORBIDDEN_DECODED) {
+    if (rule.test(decoded)) return '';
+  }
+
+  // 限制 url(...)：只允许同源（/ 开头）和 data:image/*。
+  // 显式拒绝任意 http(s) 外链，避免作者 CSS 被当作访客追踪像素。
+  const urlCleaned = commentStripped.replace(/url\(\s*(['"]?)([^'")]+)\1\s*\)/gi, (_full, _quote, urlRaw) => {
     const url = String(urlRaw).trim();
     if (!url) return 'none';
-    const lower = url.toLowerCase();
-    if (lower.startsWith('data:')) {
-      // 只允许 data:image/*
-      if (!/^data:image\/(png|jpeg|jpg|gif|webp|svg\+xml);/i.test(url)) return 'none';
-      return `url("${url.replace(/"/g, '')}")`;
+    const decodedUrl = decodeCssEscapes(url).toLowerCase();
+    if (decodedUrl.startsWith('data:')) {
+      if (!/^data:image\/(png|jpeg|jpg|gif|webp|svg\+xml);/i.test(decodedUrl)) return 'none';
+      return `url("${url.replace(/["\\<>]/g, '')}")`;
     }
-    if (lower.startsWith('http://') || lower.startsWith('https://') || lower.startsWith('/') || lower.startsWith('./') || lower.startsWith('../')) {
-      // 去掉引号反斜杠，避免 CSS 字符串注入
-      const safe = url.replace(/["\\<>]/g, '');
-      return `url("${safe}")`;
+    if (decodedUrl.startsWith('/') && !decodedUrl.startsWith('//')) {
+      return `url("${url.replace(/["\\<>]/g, '')}")`;
     }
+    // 其他（含 http:/https:/相对路径/协议相对）一律清洗掉，防止追踪像素
     return 'none';
   });
 
-  return cleaned.trim();
+  return urlCleaned.trim();
 }

--- a/bff/src/web/utils/embed/inlineCss.ts
+++ b/bff/src/web/utils/embed/inlineCss.ts
@@ -87,11 +87,15 @@ export function sanitizeInlineCss(raw: unknown): string {
   }
 
   // 限制 url(...)：
-  //   - `url("...")` / `url('...')` 分支单独匹配，允许 URL 内部包含 `)` 和转义字符
-  //     （`(?:\\.|[^"\\])*` 允许 `\\"`、`\\\\` 这类合法 CSS string escape，否则
-  //     遇到 `url("https://x/a\\""` 这类输入正则会整体不命中，导致原文直接透传）
+  //   - `url("...")` / `url('...')` 分支允许 URL 内部包含 `)` 和 CSS string escape；
+  //     escape 用 `\\(?:\r\n|[\s\S])`：
+  //       - `\<CRLF>` 按 CSS string-continuation 规则被整体吃掉（最长匹配，放最前）
+  //       - `\<任意单字符>` 覆盖 `\"` / `\'` / `\\` / `\<LF>` 等转义形式
+  //     否则遇到 `url("https://x/a\\""` 或 `url("https://x/a\<nl>")` 这类输入
+  //     正则会中途脱轨，导致原文直接透传给浏览器（浏览器会按 CSS 规则把 escape
+  //     吃掉，拿到真实外链）。
   //   - 不带引号的走 URL-token 分支，内部不可出现 `'"()` 和空白
-  const URL_REGEX = /url\(\s*(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'|([^'")\s]+))\s*\)/gi;
+  const URL_REGEX = /url\(\s*(?:"((?:\\(?:\r\n|[\s\S])|[^"\\])*)"|'((?:\\(?:\r\n|[\s\S])|[^'\\])*)'|([^'")\s]+))\s*\)/gi;
   const urlCleaned = commentStripped.replace(URL_REGEX, (_full, dq, sq, bare) => {
     const url = String(dq ?? sq ?? bare ?? '').trim();
     if (!url) return 'none';

--- a/bff/src/web/utils/embed/inlineCss.ts
+++ b/bff/src/web/utils/embed/inlineCss.ts
@@ -88,14 +88,19 @@ export function sanitizeInlineCss(raw: unknown): string {
 
   // 限制 url(...)：
   //   - `url("...")` / `url('...')` 分支允许 URL 内部包含 `)` 和 CSS string escape；
-  //     escape 用 `\\(?:\r\n|[\s\S])`：
-  //       - `\<CRLF>` 按 CSS string-continuation 规则被整体吃掉（最长匹配，放最前）
-  //       - `\<任意单字符>` 覆盖 `\"` / `\'` / `\\` / `\<LF>` 等转义形式
-  //     否则遇到 `url("https://x/a\\""` 或 `url("https://x/a\<nl>")` 这类输入
-  //     正则会中途脱轨，导致原文直接透传给浏览器（浏览器会按 CSS 规则把 escape
-  //     吃掉，拿到真实外链）。
+  //     escape 用 `\\[\s\S]`：`\<任意单字符>` 整体吞掉，覆盖 `\"` / `\'` / `\\` /
+  //     `\<LF>` / `\<CR>` / `\<FF>` 等转义形式，避免上一版 regex 遇到
+  //     `url("https://x/a\\""` 或 `url("https://x/a\<nl>")` 会脱轨放原文透传。
+  //
+  //     为什么不把 `\<CRLF>` 作整体 alternation（`(?:\r\n|[\s\S])`）：那种写法在
+  //     未闭合 quoted-string 上会产生 "\<CR>\<LF>" 两条等价展开路径，`*` 量词叠加
+  //     之后 V8 会指数级回溯（实测 repeat(25) 就要秒级 CPU），构成 ReDoS。这里每
+  //     个位置只有"要么 `\<x>` 2 字符、要么 `[^"\\]` 1 字符"一种走法，线性时间。
+  //     `\<CRLF>` 会被拆成 `\<CR>` + 裸 `<LF>` 两步消费；对我们只做 protocol 判断
+  //     的下游逻辑来说等价（任何含 `\`/`\r`/`\n` 的字符串都不会 startsWith('/')
+  //     或 'data:'，会被统一替换成 none）。
   //   - 不带引号的走 URL-token 分支，内部不可出现 `'"()` 和空白
-  const URL_REGEX = /url\(\s*(?:"((?:\\(?:\r\n|[\s\S])|[^"\\])*)"|'((?:\\(?:\r\n|[\s\S])|[^'\\])*)'|([^'")\s]+))\s*\)/gi;
+  const URL_REGEX = /url\(\s*(?:"((?:\\[\s\S]|[^"\\])*)"|'((?:\\[\s\S]|[^'\\])*)'|([^'")\s]+))\s*\)/gi;
   const urlCleaned = commentStripped.replace(URL_REGEX, (_full, dq, sq, bare) => {
     const url = String(dq ?? sq ?? bare ?? '').trim();
     if (!url) return 'none';

--- a/bff/src/web/utils/embed/inlineCss.ts
+++ b/bff/src/web/utils/embed/inlineCss.ts
@@ -87,9 +87,11 @@ export function sanitizeInlineCss(raw: unknown): string {
   }
 
   // 限制 url(...)：
-  //   - `url("...")` / `url('...')` 分支单独匹配，允许 URL 内部包含 `)`
+  //   - `url("...")` / `url('...')` 分支单独匹配，允许 URL 内部包含 `)` 和转义字符
+  //     （`(?:\\.|[^"\\])*` 允许 `\\"`、`\\\\` 这类合法 CSS string escape，否则
+  //     遇到 `url("https://x/a\\""` 这类输入正则会整体不命中，导致原文直接透传）
   //   - 不带引号的走 URL-token 分支，内部不可出现 `'"()` 和空白
-  const URL_REGEX = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^'")\s]+))\s*\)/gi;
+  const URL_REGEX = /url\(\s*(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'|([^'")\s]+))\s*\)/gi;
   const urlCleaned = commentStripped.replace(URL_REGEX, (_full, dq, sq, bare) => {
     const url = String(dq ?? sq ?? bare ?? '').trim();
     if (!url) return 'none';

--- a/bff/src/web/utils/embed/inlineCss.ts
+++ b/bff/src/web/utils/embed/inlineCss.ts
@@ -6,9 +6,12 @@ export const INLINE_CSS_MAX_BYTES = 4096;
  * 该函数只用于"检测输入里是否混入了需要被拒绝的关键字"。实际返回给客户端的仍然是
  * 原始字符串：让浏览器自己按 CSS 规范重新识别转义，这样作者还能用 `\feff` 之类的
  * 合法写法。参考 CSS Syntax Module Level 3 §4.3.7。
+ *
+ * 尾随的 whitespace 可以是 `[\t\n\f\r ]` 中一项，或 CRLF 作为整体被吞掉；
+ * 单独的 \r\n 也允许。参见 §4.3.7 的 "whitespace" token 定义。
  */
 function decodeCssEscapes(src: string): string {
-  return src.replace(/\\([0-9a-fA-F]{1,6})[\t\n\f\r ]?|\\([^\n\r\f])/g, (_, hex, other) => {
+  return src.replace(/\\([0-9a-fA-F]{1,6})(?:\r\n|[\t\n\f\r ])?|\\([^\n\r\f])/g, (_, hex, other) => {
     if (hex) {
       const code = parseInt(hex, 16);
       if (!Number.isFinite(code) || code === 0 || (code >= 0xd800 && code <= 0xdfff) || code > 0x10ffff) {
@@ -67,13 +70,15 @@ export function sanitizeInlineCss(raw: unknown): string {
     if (!input) return '';
   }
 
-  // 剥离块注释，避免注释里绕过关键字检查；CSS 行注释 (//) 不是标准，不处理。
-  const commentStripped = input.replace(/\/\*[\s\S]*?\*\//g, ' ');
-
-  // HTML break-out 基于原文匹配
+  // HTML break-out 必须基于"原始输入（未剥注释）"匹配：<style> 元素的 HTML raw-text
+  // 解析模式只会扫字面 </style>，根本不理解 CSS 注释，所以 `/* </style> */` 这类写法
+  // 会提前关掉 <style> 并让后续内容逃出。
   for (const rule of FORBIDDEN_RAW) {
-    if (rule.test(commentStripped)) return '';
+    if (rule.test(input)) return '';
   }
+
+  // 剥离块注释后再做关键字与 url() 检查；CSS 行注释 (//) 不是标准，不处理。
+  const commentStripped = input.replace(/\/\*[\s\S]*?\*\//g, ' ');
 
   // 其他关键字用"CSS 转义展开后"的文本匹配，堵掉 `@\41import` / `ex\70 ression(` 之类绕过
   const decoded = decodeCssEscapes(commentStripped);
@@ -81,10 +86,12 @@ export function sanitizeInlineCss(raw: unknown): string {
     if (rule.test(decoded)) return '';
   }
 
-  // 限制 url(...)：只允许同源（/ 开头）和 data:image/*。
-  // 显式拒绝任意 http(s) 外链，避免作者 CSS 被当作访客追踪像素。
-  const urlCleaned = commentStripped.replace(/url\(\s*(['"]?)([^'")]+)\1\s*\)/gi, (_full, _quote, urlRaw) => {
-    const url = String(urlRaw).trim();
+  // 限制 url(...)：
+  //   - `url("...")` / `url('...')` 分支单独匹配，允许 URL 内部包含 `)`
+  //   - 不带引号的走 URL-token 分支，内部不可出现 `'"()` 和空白
+  const URL_REGEX = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^'")\s]+))\s*\)/gi;
+  const urlCleaned = commentStripped.replace(URL_REGEX, (_full, dq, sq, bare) => {
+    const url = String(dq ?? sq ?? bare ?? '').trim();
     if (!url) return 'none';
     const decodedUrl = decodeCssEscapes(url).toLowerCase();
     if (decodedUrl.startsWith('data:')) {

--- a/bff/src/web/utils/embed/inlineCss.ts
+++ b/bff/src/web/utils/embed/inlineCss.ts
@@ -1,0 +1,64 @@
+export const INLINE_CSS_MAX_BYTES = 4096;
+
+/**
+ * 结果：safe 版的 CSS 字符串（若被截断或拒绝，会返回空串）。
+ *
+ * 拒绝而非抛错的理由：CSS 是纯装饰，任何"解析不了"的情况直接回落到默认样式即可，
+ * 不应该让整块嵌入 404。
+ */
+export function sanitizeInlineCss(raw: unknown): string {
+  if (typeof raw !== 'string') return '';
+  let input = raw.trim();
+  if (!input) return '';
+
+  // 超长直接截断，避免 URL 被刻意做长炸带宽
+  const bytes = Buffer.byteLength(input, 'utf8');
+  if (bytes > INLINE_CSS_MAX_BYTES) {
+    // 截到字节上限附近；再找一个 '}' 当做安全边界，保证不会切到半条规则
+    const slice = Buffer.from(input, 'utf8').slice(0, INLINE_CSS_MAX_BYTES).toString('utf8');
+    const lastBrace = slice.lastIndexOf('}');
+    input = lastBrace > 0 ? slice.slice(0, lastBrace + 1) : '';
+    if (!input) return '';
+  }
+
+  // 剥离块注释，避免注释里绕过关键字检查；CSS 行注释 (//) 不是标准，不处理。
+  let cleaned = input.replace(/\/\*[\s\S]*?\*\//g, ' ');
+
+  // 关键字黑名单：遇到一项直接拒绝整块
+  const forbidden: RegExp[] = [
+    /@import/i,
+    /@charset/i,
+    /@namespace/i,
+    /behavior\s*:/i,
+    /-moz-binding/i,
+    /expression\s*\(/i,
+    /javascript\s*:/i,
+    /vbscript\s*:/i,
+    /<\s*\/?\s*style\b/i,
+    /<\s*\/?\s*script\b/i,
+    /<\s*\/?\s*iframe\b/i
+  ];
+  for (const rule of forbidden) {
+    if (rule.test(cleaned)) return '';
+  }
+
+  // 限制 url(...)：只允许 http/https/相对路径 / data:image/*
+  cleaned = cleaned.replace(/url\(\s*(['"]?)([^'")]+)\1\s*\)/gi, (full, quote, urlRaw) => {
+    const url = String(urlRaw).trim();
+    if (!url) return 'none';
+    const lower = url.toLowerCase();
+    if (lower.startsWith('data:')) {
+      // 只允许 data:image/*
+      if (!/^data:image\/(png|jpeg|jpg|gif|webp|svg\+xml);/i.test(url)) return 'none';
+      return `url("${url.replace(/"/g, '')}")`;
+    }
+    if (lower.startsWith('http://') || lower.startsWith('https://') || lower.startsWith('/') || lower.startsWith('./') || lower.startsWith('../')) {
+      // 去掉引号反斜杠，避免 CSS 字符串注入
+      const safe = url.replace(/["\\<>]/g, '');
+      return `url("${safe}")`;
+    }
+    return 'none';
+  });
+
+  return cleaned.trim();
+}

--- a/bff/src/web/utils/embed/pageData.ts
+++ b/bff/src/web/utils/embed/pageData.ts
@@ -1,0 +1,80 @@
+import type { Pool } from 'pg';
+import type { VotingSeries } from './userData.js';
+
+export interface PageBadgeData {
+  pageId: number;
+  wikidotId: number;
+  title: string | null;
+  alternateTitle: string | null;
+  rating: number;
+  voteCount: number;
+  wilson95: number | null;
+  controversy: number | null;
+  isDeleted: boolean;
+  firstPublishedAt: Date | null;
+}
+
+/**
+ * 拿到当前活跃版本（validTo IS NULL）的 PageVersion + PageStats，一次查询。
+ */
+export async function loadPageBadgeData(
+  pool: Pool,
+  wikidotId: number
+): Promise<PageBadgeData | null> {
+  const { rows } = await pool.query(
+    `SELECT
+       p.id AS "pageId",
+       p."wikidotId",
+       p."firstPublishedAt",
+       p."isDeleted",
+       pv.title,
+       pv."alternateTitle",
+       COALESCE(pv.rating, 0)::int AS rating,
+       COALESCE(pv."voteCount", 0)::int AS "voteCount",
+       ps.wilson95,
+       ps.controversy
+     FROM "Page" p
+     JOIN "PageVersion" pv ON pv."pageId" = p.id AND pv."validTo" IS NULL
+     LEFT JOIN "PageStats" ps ON ps."pageVersionId" = pv.id
+     WHERE p."wikidotId" = $1`,
+    [wikidotId]
+  );
+  if (!rows.length) return null;
+  const r = rows[0];
+  return {
+    pageId: Number(r.pageId),
+    wikidotId: Number(r.wikidotId),
+    title: r.title ?? null,
+    alternateTitle: r.alternateTitle ?? null,
+    rating: Number(r.rating ?? 0),
+    voteCount: Number(r.voteCount ?? 0),
+    wilson95: r.wilson95 != null ? Number(r.wilson95) : null,
+    controversy: r.controversy != null ? Number(r.controversy) : null,
+    isDeleted: Boolean(r.isDeleted),
+    firstPublishedAt: r.firstPublishedAt ? new Date(r.firstPublishedAt) : null
+  };
+}
+
+export async function loadPageVotingSeries(
+  pool: Pool,
+  wikidotId: number
+): Promise<VotingSeries | null> {
+  const { rows } = await pool.query(
+    `SELECT "votingTimeSeriesCache" AS cache
+     FROM "Page"
+     WHERE "wikidotId" = $1`,
+    [wikidotId]
+  );
+  const cache = rows[0]?.cache;
+  if (!cache || typeof cache !== 'object') return null;
+  const src = cache as Partial<VotingSeries>;
+  if (!Array.isArray(src.dates) || src.dates.length === 0) return null;
+  return {
+    dates: src.dates.map(String),
+    dailyUpvotes: (src.dailyUpvotes ?? []).map(Number),
+    dailyDownvotes: (src.dailyDownvotes ?? []).map(Number),
+    upvotes: (src.upvotes ?? []).map(Number),
+    downvotes: (src.downvotes ?? []).map(Number),
+    totalVotes: (src.totalVotes ?? []).map(Number)
+  };
+}

--- a/bff/src/web/utils/embed/pageData.ts
+++ b/bff/src/web/utils/embed/pageData.ts
@@ -10,7 +10,10 @@ export interface PageBadgeData {
   voteCount: number;
   wilson95: number | null;
   controversy: number | null;
-  isDeleted: boolean;             // true 当仅能回退到已删除版本
+  /** 返回的 PageVersion 本身是否为 tombstone（isDeleted=true）。常见用途：决定徽章是否加 "deleted" 前缀。 */
+  isDeleted: boolean;
+  /** 当前版本是 tombstone、已回退到最后一个非 deleted 版本时为 true。 */
+  fromDeletedFallback: boolean;
   firstPublishedAt: Date | null;
 }
 
@@ -101,7 +104,8 @@ export async function loadPageBadgeData(
     voteCount: Number(r.voteCount ?? 0),
     wilson95: r.wilson95 != null ? Number(r.wilson95) : null,
     controversy: r.controversy != null ? Number(r.controversy) : null,
-    isDeleted: resolved.fromDeleted || Boolean(r.versionIsDeleted),
+    isDeleted: Boolean(r.versionIsDeleted),
+    fromDeletedFallback: resolved.fromDeleted,
     firstPublishedAt: resolved.firstPublishedAt
   };
 }

--- a/bff/src/web/utils/embed/pageData.ts
+++ b/bff/src/web/utils/embed/pageData.ts
@@ -10,48 +10,99 @@ export interface PageBadgeData {
   voteCount: number;
   wilson95: number | null;
   controversy: number | null;
-  isDeleted: boolean;
+  isDeleted: boolean;             // true 当仅能回退到已删除版本
   firstPublishedAt: Date | null;
 }
 
 /**
- * 拿到当前活跃版本（validTo IS NULL）的 PageVersion + PageStats，一次查询。
+ * Badge 的 effective-version 选择：优先取 `validTo IS NULL` 的当前版本；若当前版本
+ * 本身是 tombstone（isDeleted），回退到最近的非 deleted 版本。保持和
+ * `/stats/pages/:wikidotId` 口径一致（参考 `bff/src/web/routes/stats.ts:442` 附近）。
  */
+async function resolvePageBadgeVersion(
+  pool: Pool,
+  wikidotId: number
+): Promise<{ pageId: number; versionId: number; fromDeleted: boolean; firstPublishedAt: Date | null } | null> {
+  const pageRes = await pool.query(
+    `SELECT id, "firstPublishedAt"
+       FROM "Page"
+      WHERE "wikidotId" = $1
+      LIMIT 1`,
+    [wikidotId]
+  );
+  if (!pageRes.rows.length) return null;
+  const pageId = Number(pageRes.rows[0].id);
+  const firstPublishedAt = pageRes.rows[0].firstPublishedAt
+    ? new Date(pageRes.rows[0].firstPublishedAt)
+    : null;
+
+  const currentRes = await pool.query(
+    `SELECT id, "isDeleted"
+       FROM "PageVersion"
+      WHERE "pageId" = $1 AND "validTo" IS NULL
+      ORDER BY id DESC
+      LIMIT 1`,
+    [pageId]
+  );
+  const current = currentRes.rows[0] ?? null;
+  let versionId: number | null = current?.id ?? null;
+  const currentDeleted = current?.isDeleted === true;
+  let fromDeleted = false;
+
+  if (!versionId || currentDeleted) {
+    const fallbackRes = await pool.query(
+      `SELECT id
+         FROM "PageVersion"
+        WHERE "pageId" = $1 AND "isDeleted" = false
+        ORDER BY "validFrom" DESC NULLS LAST, id DESC
+        LIMIT 1`,
+      [pageId]
+    );
+    if (fallbackRes.rows.length > 0) {
+      versionId = Number(fallbackRes.rows[0].id);
+      fromDeleted = true;
+    }
+  }
+
+  if (!versionId) return null;
+  return { pageId, versionId, fromDeleted, firstPublishedAt };
+}
+
 export async function loadPageBadgeData(
   pool: Pool,
   wikidotId: number
 ): Promise<PageBadgeData | null> {
+  const resolved = await resolvePageBadgeVersion(pool, wikidotId);
+  if (!resolved) return null;
+
   const { rows } = await pool.query(
     `SELECT
-       p.id AS "pageId",
-       p."wikidotId",
-       p."firstPublishedAt",
-       p."isDeleted",
        pv.title,
        pv."alternateTitle",
+       pv."isDeleted" AS "versionIsDeleted",
        COALESCE(pv.rating, 0)::int AS rating,
        COALESCE(pv."voteCount", 0)::int AS "voteCount",
        ps.wilson95,
        ps.controversy
-     FROM "Page" p
-     JOIN "PageVersion" pv ON pv."pageId" = p.id AND pv."validTo" IS NULL
+     FROM "PageVersion" pv
      LEFT JOIN "PageStats" ps ON ps."pageVersionId" = pv.id
-     WHERE p."wikidotId" = $1`,
-    [wikidotId]
+     WHERE pv.id = $1
+     LIMIT 1`,
+    [resolved.versionId]
   );
   if (!rows.length) return null;
   const r = rows[0];
   return {
-    pageId: Number(r.pageId),
-    wikidotId: Number(r.wikidotId),
+    pageId: resolved.pageId,
+    wikidotId,
     title: r.title ?? null,
     alternateTitle: r.alternateTitle ?? null,
     rating: Number(r.rating ?? 0),
     voteCount: Number(r.voteCount ?? 0),
     wilson95: r.wilson95 != null ? Number(r.wilson95) : null,
     controversy: r.controversy != null ? Number(r.controversy) : null,
-    isDeleted: Boolean(r.isDeleted),
-    firstPublishedAt: r.firstPublishedAt ? new Date(r.firstPublishedAt) : null
+    isDeleted: resolved.fromDeleted || Boolean(r.versionIsDeleted),
+    firstPublishedAt: resolved.firstPublishedAt
   };
 }
 

--- a/bff/src/web/utils/embed/sparkline.ts
+++ b/bff/src/web/utils/embed/sparkline.ts
@@ -1,0 +1,77 @@
+export interface SparklineOptions {
+  values: number[];
+  width?: number;
+  height?: number;
+  stroke?: string;            // 线条颜色 (CSS 合法值)
+  fill?: string;              // 面积填充色 (留空关闭)
+  padding?: number;
+  /** 是否把 y 轴 0 作为参考线 */
+  showZeroAxis?: boolean;
+}
+
+function buildPath(values: number[], w: number, h: number, pad: number) {
+  if (values.length === 0) return { line: '', area: '', zeroY: null as number | null };
+  const n = values.length;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const usableW = Math.max(1, w - pad * 2);
+  const usableH = Math.max(1, h - pad * 2);
+  const stepX = n === 1 ? 0 : usableW / (n - 1);
+
+  const pts: Array<[number, number]> = values.map((v, i) => {
+    const x = pad + stepX * i;
+    const y = pad + usableH - ((v - min) / range) * usableH;
+    return [Number(x.toFixed(2)), Number(y.toFixed(2))];
+  });
+
+  const line = pts
+    .map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x} ${y}`)
+    .join(' ');
+  const area = `${line} L${pts[pts.length - 1][0]} ${pad + usableH} L${pts[0][0]} ${pad + usableH} Z`;
+
+  const zeroY =
+    min <= 0 && max >= 0
+      ? Number((pad + usableH - ((0 - min) / range) * usableH).toFixed(2))
+      : null;
+
+  return { line, area, zeroY };
+}
+
+/**
+ * 渲染一条窄幅 sparkline SVG，尺寸默认 120x28。
+ * stroke/fill 接受 currentColor 或任何 CSS 颜色。
+ */
+export function renderSparkline(opts: SparklineOptions): string {
+  const width = opts.width ?? 120;
+  const height = opts.height ?? 28;
+  const padding = opts.padding ?? 2;
+  const stroke = opts.stroke || 'currentColor';
+  const fill = opts.fill || 'none';
+
+  const values = Array.isArray(opts.values) ? opts.values : [];
+  if (values.length < 2) {
+    // 退化：空或只有一个点时渲染一条水平基线
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">
+      <line x1="${padding}" y1="${height / 2}" x2="${width - padding}" y2="${height / 2}" stroke="${stroke}" stroke-opacity="0.4" stroke-dasharray="2 2"/>
+    </svg>`;
+  }
+
+  const { line, area, zeroY } = buildPath(values, width, height, padding);
+
+  const zeroAxis =
+    opts.showZeroAxis && zeroY != null
+      ? `<line x1="${padding}" x2="${width - padding}" y1="${zeroY}" y2="${zeroY}" stroke="${stroke}" stroke-opacity="0.25" stroke-dasharray="2 2"/>`
+      : '';
+
+  const areaEl =
+    fill && fill !== 'none'
+      ? `<path d="${area}" fill="${fill}" stroke="none"/>`
+      : '';
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">
+    ${zeroAxis}
+    ${areaEl}
+    <path d="${line}" fill="none" stroke="${stroke}" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>
+  </svg>`;
+}

--- a/bff/src/web/utils/embed/svgBadge.ts
+++ b/bff/src/web/utils/embed/svgBadge.ts
@@ -1,0 +1,117 @@
+import { estimateTextWidth } from './textMetrics.js';
+
+export type BadgeStyle = 'flat' | 'plastic' | 'mono';
+
+export interface BadgeOptions {
+  label: string;
+  value: string;
+  color?: string;             // 右侧底色 (hex without #, or full CSS color)
+  labelColor?: string;        // 左侧底色
+  style?: BadgeStyle;
+  /** 若 true，则使用 currentColor，供父级主题着色 */
+  themeMono?: boolean;
+  /** title 属性，会渲染成 <title> 供屏幕阅读器 / 悬停提示 */
+  title?: string;
+}
+
+const DEFAULT_LABEL_BG = '#555';
+const DEFAULT_VALUE_BG = '#4c1';
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function normalizeColor(raw: string | undefined, fallback: string): string {
+  if (!raw) return fallback;
+  const trimmed = String(raw).trim();
+  if (!trimmed) return fallback;
+  // 仅接受 currentColor / 3-8 位 hex / 6-10 位带 # 的 hex / CSS 命名色白名单
+  if (/^currentColor$/i.test(trimmed)) return 'currentColor';
+  if (/^#?[0-9a-fA-F]{3,8}$/.test(trimmed)) {
+    return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+  }
+  // 允许一些常见的主题关键字
+  if (/^(transparent|black|white|gray|grey|red|green|blue|yellow|orange)$/i.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+  return fallback;
+}
+
+/**
+ * 生成一个 shields.io 风格的 SVG 徽章。
+ *
+ * 输出使用内联 SVG，字体 Verdana，宽度通过 estimateTextWidth 近似。
+ * 文本使用 transform="scale(.1)" + font-size=110 的标准技巧规避 Verdana 子像素漂移。
+ */
+export function renderSvgBadge(opts: BadgeOptions): string {
+  const style: BadgeStyle = opts.style || 'flat';
+  const themeMono = Boolean(opts.themeMono);
+
+  const label = String(opts.label ?? '').trim();
+  const value = String(opts.value ?? '').trim();
+
+  const labelBg = themeMono
+    ? 'rgba(127,127,127,0.35)'
+    : normalizeColor(opts.labelColor, DEFAULT_LABEL_BG);
+  const valueBg = themeMono
+    ? 'currentColor'
+    : normalizeColor(opts.color, DEFAULT_VALUE_BG);
+  const textFill = themeMono ? 'currentColor' : '#fff';
+  const labelTextFill = themeMono ? 'currentColor' : '#fff';
+
+  const labelTextWidth = estimateTextWidth(label);
+  const valueTextWidth = estimateTextWidth(value);
+  const padding = 6;
+  const labelWidth = label ? labelTextWidth + padding * 2 : 0;
+  const valueWidth = valueTextWidth + padding * 2;
+  const totalWidth = labelWidth + valueWidth;
+  const height = style === 'plastic' ? 18 : 20;
+  const radius = style === 'plastic' ? 4 : 3;
+
+  // 文本基线：Verdana 在 110pt 时上移到 140 看起来居中，并再加一条阴影文字实现轻微深度
+  const labelCenterX = (labelWidth / 2) * 10;
+  const valueCenterX = (labelWidth + valueWidth / 2) * 10;
+  const textY = style === 'plastic' ? 130 : 140;
+  const shadowY = textY + 10;
+
+  const title = opts.title ? `<title>${escapeXml(opts.title)}</title>` : '';
+
+  // 只有左侧标签非空时才渲染左侧块
+  const labelRect = label
+    ? `<rect width="${labelWidth}" height="${height}" fill="${labelBg}"/>`
+    : '';
+  const labelText = label
+    ? `<text aria-hidden="true" x="${labelCenterX}" y="${shadowY}" transform="scale(.1)" fill="#010101" fill-opacity=".3">${escapeXml(label)}</text>
+       <text x="${labelCenterX}" y="${textY}" transform="scale(.1)" fill="${labelTextFill}">${escapeXml(label)}</text>`
+    : '';
+
+  const gradient = style === 'flat' || themeMono
+    ? ''
+    : `<linearGradient id="g" x2="0" y2="100%">
+         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+         <stop offset="1" stop-opacity=".1"/>
+       </linearGradient>
+       <rect width="${totalWidth}" height="${height}" fill="url(#g)"/>`;
+
+  const ariaLabel = label ? `${label}: ${value}` : value;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="${height}" role="img" aria-label="${escapeXml(ariaLabel)}">
+  ${title}
+  <clipPath id="r"><rect width="${totalWidth}" height="${height}" rx="${radius}" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    ${labelRect}
+    <rect x="${labelWidth}" width="${valueWidth}" height="${height}" fill="${valueBg}"/>
+    ${gradient}
+  </g>
+  <g fill="${textFill}" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+    ${labelText}
+    <text aria-hidden="true" x="${valueCenterX}" y="${shadowY}" transform="scale(.1)" fill="#010101" fill-opacity=".3">${escapeXml(value)}</text>
+    <text x="${valueCenterX}" y="${textY}" transform="scale(.1)">${escapeXml(value)}</text>
+  </g>
+</svg>`;
+}

--- a/bff/src/web/utils/embed/templates/userCard.ts
+++ b/bff/src/web/utils/embed/templates/userCard.ts
@@ -1,0 +1,202 @@
+import type { UserBasic, UserCardStats } from '../userData.js';
+
+export interface UserCardRenderOptions {
+  breakdown: 'list' | 'radar';
+  hideActivity: boolean;
+  showCategories: string[];          // 要展示的 category key 列表；空数组=全部有数据的
+}
+
+function esc(str: string | null | undefined): string {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function formatInt(n: number): string {
+  return Number.isFinite(n) ? Math.round(n).toLocaleString('zh-CN') : '—';
+}
+
+function formatFloat(n: number, digits = 1): string {
+  return Number.isFinite(n) ? n.toFixed(digits) : '—';
+}
+
+function formatDate(d: Date | null): string {
+  if (!d) return '—';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+}
+
+/**
+ * 6 边雷达图。用用户自身各分类评分中的最大值作为满格，避免无作品的用户看到空图。
+ * 每个顶点上再绘一个小点，突出非零分类。
+ */
+function renderRadar(categories: UserCardStats['categories']): string {
+  const size = 220;
+  const cx = size / 2;
+  const cy = size / 2;
+  const radius = 78;
+  const n = categories.length;
+  if (n < 3) return '';
+
+  const maxRating = Math.max(...categories.map(c => c.rating), 1);
+  const angles = categories.map((_, i) => (-Math.PI / 2) + (i * 2 * Math.PI) / n);
+
+  const axisPoints = angles.map(a => {
+    const x = cx + radius * Math.cos(a);
+    const y = cy + radius * Math.sin(a);
+    return { x, y };
+  });
+
+  const rings = [0.25, 0.5, 0.75, 1].map(frac => {
+    const points = angles.map(a => {
+      const x = cx + radius * frac * Math.cos(a);
+      const y = cy + radius * frac * Math.sin(a);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    }).join(' ');
+    return `<polygon points="${points}" fill="none" stroke="var(--e-border)" stroke-width="1"/>`;
+  }).join('');
+
+  const axisLines = axisPoints.map(({ x, y }) =>
+    `<line x1="${cx}" y1="${cy}" x2="${x.toFixed(1)}" y2="${y.toFixed(1)}" stroke="var(--e-border)" stroke-width="1"/>`
+  ).join('');
+
+  const dataPoints = categories.map((c, i) => {
+    const r = (Math.max(0, c.rating) / maxRating) * radius;
+    const a = angles[i];
+    return {
+      x: cx + r * Math.cos(a),
+      y: cy + r * Math.sin(a),
+      hasData: c.rating > 0
+    };
+  });
+
+  const dataPolygon = dataPoints.map(p => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+
+  const markers = dataPoints.map((p, i) =>
+    p.hasData
+      ? `<circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="3" fill="var(--e-accent)"/>`
+      : ''
+  ).join('');
+
+  const labels = categories.map((c, i) => {
+    const a = angles[i];
+    const lx = cx + (radius + 16) * Math.cos(a);
+    const ly = cy + (radius + 16) * Math.sin(a);
+    const anchor = Math.abs(Math.cos(a)) < 0.25 ? 'middle' : (Math.cos(a) > 0 ? 'start' : 'end');
+    const dy = Math.sin(a) > 0.5 ? 10 : (Math.sin(a) < -0.5 ? -2 : 4);
+    return `<text x="${lx.toFixed(1)}" y="${(ly + dy).toFixed(1)}" text-anchor="${anchor}" class="radar-label">${esc(c.label)}</text>`;
+  }).join('');
+
+  return `<svg viewBox="0 0 ${size} ${size}" class="radar-svg" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+    <g class="radar-grid">${rings}${axisLines}</g>
+    <polygon class="radar-data" points="${dataPolygon}" />
+    ${markers}
+    ${labels}
+  </svg>`;
+}
+
+function renderCategoryList(categories: UserCardStats['categories'], keep: Set<string>): string {
+  const visible = categories.filter(c => keep.size === 0 ? c.pageCount > 0 || c.rating > 0 : keep.has(c.key));
+  if (visible.length === 0) {
+    return `<div class="e-empty">暂无分类数据</div>`;
+  }
+  return `<ul class="cat-list">${visible.map(c => `
+    <li class="cat-row">
+      <span class="cat-label">${esc(c.label)}</span>
+      <span class="cat-rank">${c.rank != null ? `#${formatInt(c.rank)}` : '—'}</span>
+      <span class="cat-rating">${formatInt(c.rating)} pts</span>
+      <span class="cat-count">${formatInt(c.pageCount)} 作</span>
+    </li>`).join('')}</ul>`;
+}
+
+export const USER_CARD_BASE_CSS = `
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: transparent; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", Roboto, sans-serif; color: var(--e-text); font-size: 13px; line-height: 1.45; -webkit-font-smoothing: antialiased; }
+  .e-card { background: var(--e-bg); border: 1px solid var(--e-border); border-radius: 14px; padding: 18px 20px; box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.02); display: flex; flex-direction: column; gap: 16px; }
+  .e-header { display: flex; align-items: center; gap: 14px; position: relative; }
+  .e-avatar { width: 56px; height: 56px; border-radius: 50%; overflow: hidden; background: var(--e-surface); flex-shrink: 0; ring: 1px solid var(--e-border); position: relative; }
+  .e-avatar img { display: block; width: 100%; height: 100%; object-fit: cover; }
+  .e-name-block { min-width: 0; flex: 1; }
+  .e-name { font-size: 16px; font-weight: 600; color: var(--e-accent); display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .e-subtitle { font-size: 11px; color: var(--e-text-subtle); margin-top: 2px; display: flex; gap: 6px; flex-wrap: wrap; }
+  .e-subtitle span:not(:last-child)::after { content: '·'; margin-left: 6px; color: var(--e-text-subtle); }
+  .e-rank { position: absolute; top: 0; right: 0; color: var(--e-accent); font-weight: 700; font-size: 15px; font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
+  .stat-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; }
+  .stat-tile { background: var(--e-surface); border: 1px solid var(--e-border); border-radius: 8px; padding: 8px 10px; text-align: center; }
+  .stat-tile .lbl { font-size: 10px; color: var(--e-text-muted); margin-bottom: 2px; letter-spacing: 0.02em; }
+  .stat-tile .val { font-size: 14px; font-weight: 600; color: var(--e-text); font-variant-numeric: tabular-nums; }
+  .section-title { font-size: 11px; color: var(--e-text-muted); font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 6px; }
+  .cat-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
+  .cat-row { display: grid; grid-template-columns: 4em 3em 1fr auto; gap: 10px; align-items: baseline; padding: 6px 10px; background: var(--e-surface); border: 1px solid var(--e-border); border-radius: 6px; font-size: 12px; }
+  .cat-label { color: var(--e-text); font-weight: 500; }
+  .cat-rank { color: var(--e-accent); font-weight: 600; font-variant-numeric: tabular-nums; }
+  .cat-rating { color: var(--e-text-muted); font-variant-numeric: tabular-nums; }
+  .cat-count { color: var(--e-text-subtle); font-variant-numeric: tabular-nums; font-size: 11px; }
+  .radar-wrap { display: flex; justify-content: center; align-items: center; height: 230px; }
+  .radar-svg { max-width: 280px; }
+  .radar-grid { stroke: var(--e-border); fill: none; }
+  .radar-data { fill: var(--e-accent-soft); stroke: var(--e-accent); stroke-width: 1.5; }
+  .radar-label { fill: var(--e-text-muted); font-size: 10px; font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif; }
+  .e-empty { color: var(--e-text-subtle); font-size: 11px; text-align: center; padding: 12px 0; }
+`;
+
+export function renderUserCardBody(
+  user: UserBasic,
+  stats: UserCardStats,
+  opts: UserCardRenderOptions
+): string {
+  const wikidotId = user.wikidotId;
+  const displayName = user.displayName || `User ${wikidotId}`;
+
+  const activityLine = opts.hideActivity
+    ? ''
+    : `<span>首次 ${esc(formatDate(user.firstActivityAt))}</span><span>最近 ${esc(formatDate(user.lastActivityAt))}</span>`;
+
+  const subtitleParts = [`<span>ID ${wikidotId}</span>`];
+  if (activityLine) subtitleParts.push(activityLine);
+
+  const meanRating = Number.isFinite(stats.meanRating) && stats.meanRating > 0
+    ? stats.meanRating
+    : (stats.pageCount > 0 ? stats.totalRating / stats.pageCount : 0);
+
+  const rank = stats.rank != null
+    ? `<div class="e-rank">#${formatInt(stats.rank)}</div>`
+    : '';
+
+  const keep = new Set(opts.showCategories.filter(Boolean));
+  const breakdownHtml = opts.breakdown === 'radar'
+    ? `<div class="radar-wrap">${renderRadar(stats.categories.filter(c => keep.size === 0 ? true : keep.has(c.key)))}</div>`
+    : renderCategoryList(stats.categories, keep);
+
+  return `<div class="e-card">
+    <header class="e-header">
+      <div class="e-avatar">
+        <img src="/api/avatar/${wikidotId}" alt="${esc(displayName)}" width="56" height="56"
+             onerror="this.style.visibility='hidden'"/>
+      </div>
+      <div class="e-name-block">
+        <span class="e-name">${esc(displayName)}</span>
+        <div class="e-subtitle">${subtitleParts.join('')}</div>
+      </div>
+      ${rank}
+    </header>
+
+    <section class="stat-grid">
+      <div class="stat-tile"><div class="lbl">总评分</div><div class="val">${formatInt(stats.totalRating)}</div></div>
+      <div class="stat-tile"><div class="lbl">平均分</div><div class="val">${formatFloat(meanRating, 1)}</div></div>
+      <div class="stat-tile"><div class="lbl">作品</div><div class="val">${formatInt(stats.pageCount)}</div></div>
+      <div class="stat-tile"><div class="lbl">支持</div><div class="val">${formatInt(stats.votesUp)}</div></div>
+      <div class="stat-tile"><div class="lbl">反对</div><div class="val">${formatInt(stats.votesDown)}</div></div>
+    </section>
+
+    <section>
+      <div class="section-title">分类表现</div>
+      ${breakdownHtml}
+    </section>
+  </div>`;
+}

--- a/bff/src/web/utils/embed/templates/userCard.ts
+++ b/bff/src/web/utils/embed/templates/userCard.ts
@@ -119,8 +119,7 @@ export const USER_CARD_BASE_CSS = `
   body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", Roboto, sans-serif; color: var(--e-text); font-size: 13px; line-height: 1.45; -webkit-font-smoothing: antialiased; }
   .e-card { background: var(--e-bg); border: 1px solid var(--e-border); border-radius: 14px; padding: 18px 20px; box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.02); display: flex; flex-direction: column; gap: 16px; }
   .e-header { display: flex; align-items: center; gap: 14px; position: relative; }
-  .e-avatar { width: 56px; height: 56px; border-radius: 50%; overflow: hidden; background: var(--e-surface); flex-shrink: 0; ring: 1px solid var(--e-border); position: relative; }
-  .e-avatar img { display: block; width: 100%; height: 100%; object-fit: cover; }
+  .e-avatar { width: 56px; height: 56px; border-radius: 50%; overflow: hidden; background: var(--e-surface) center/cover no-repeat; flex-shrink: 0; box-shadow: inset 0 0 0 1px var(--e-border); position: relative; }
   .e-name-block { min-width: 0; flex: 1; }
   .e-name { font-size: 16px; font-weight: 600; color: var(--e-accent); display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .e-subtitle { font-size: 11px; color: var(--e-text-subtle); margin-top: 2px; display: flex; gap: 6px; flex-wrap: wrap; }
@@ -169,16 +168,20 @@ export function renderUserCardBody(
     : '';
 
   const keep = new Set(opts.showCategories.filter(Boolean));
-  const breakdownHtml = opts.breakdown === 'radar'
-    ? `<div class="radar-wrap">${renderRadar(stats.categories.filter(c => keep.size === 0 ? true : keep.has(c.key)))}</div>`
+  const radarCategories = stats.categories.filter(c => keep.size === 0 ? true : keep.has(c.key));
+  // 雷达图最少需要 3 个顶点才有意义；过滤后不足时退回列表渲染，避免出现空白区
+  const effectiveBreakdown: 'list' | 'radar' =
+    opts.breakdown === 'radar' && radarCategories.length >= 3 ? 'radar' : 'list';
+  const breakdownHtml = effectiveBreakdown === 'radar'
+    ? `<div class="radar-wrap">${renderRadar(radarCategories)}</div>`
     : renderCategoryList(stats.categories, keep);
 
+  // 用 background-image 承载头像；img 元素加载失败会显示浏览器默认的 broken-image 图标，
+  // 而 CSP `script-src 'none'` 下 <img onerror> 不生效，因此直接用背景图 + aria-label 承担语义。
+  const avatarStyle = `background-image: url(/api/avatar/${wikidotId})`;
   return `<div class="e-card">
     <header class="e-header">
-      <div class="e-avatar">
-        <img src="/api/avatar/${wikidotId}" alt="${esc(displayName)}" width="56" height="56"
-             onerror="this.style.visibility='hidden'"/>
-      </div>
+      <div class="e-avatar" role="img" aria-label="${esc(displayName)}" style="${avatarStyle}"></div>
       <div class="e-name-block">
         <span class="e-name">${esc(displayName)}</span>
         <div class="e-subtitle">${subtitleParts.join('')}</div>

--- a/bff/src/web/utils/embed/templates/userHistory.ts
+++ b/bff/src/web/utils/embed/templates/userHistory.ts
@@ -1,0 +1,264 @@
+import type { UserBasic, VotingSeries } from '../userData.js';
+
+export interface UserHistoryRenderOptions {
+  range: '90d' | '1y' | 'all';
+  showTrend: boolean;
+  showHeatmap: boolean;
+}
+
+function esc(str: string | null | undefined): string {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function formatInt(n: number): string {
+  return Number.isFinite(n) ? Math.round(n).toLocaleString('zh-CN') : '—';
+}
+
+/**
+ * 从 VotingSeries 生成累计评分序列（upvotes[i] - downvotes[i]）。
+ */
+function buildCumulativeRating(series: VotingSeries): Array<{ date: string; rating: number }> {
+  const out: Array<{ date: string; rating: number }> = [];
+  const n = series.dates.length;
+  for (let i = 0; i < n; i += 1) {
+    const up = series.upvotes[i] ?? 0;
+    const down = series.downvotes[i] ?? 0;
+    out.push({ date: series.dates[i], rating: up - down });
+  }
+  return out;
+}
+
+function trimToRange(points: Array<{ date: string; rating: number }>, range: UserHistoryRenderOptions['range']): Array<{ date: string; rating: number }> {
+  if (range === 'all' || points.length === 0) return points;
+  const days = range === '90d' ? 90 : 365;
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  return points.filter(p => p.date >= cutoffStr);
+}
+
+/**
+ * 一条带 y 轴坐标的评分曲线。大致视觉：左下 padding 留 Y 轴，底部留 X 轴文本。
+ */
+function renderRatingChart(points: Array<{ date: string; rating: number }>): string {
+  const width = 560;
+  const height = 220;
+  const padL = 42;
+  const padR = 12;
+  const padT = 12;
+  const padB = 24;
+
+  if (points.length < 2) {
+    return `<div class="e-empty chart-empty">数据不足以绘制曲线</div>`;
+  }
+
+  const ratings = points.map(p => p.rating);
+  const minY = Math.min(...ratings, 0);
+  const maxY = Math.max(...ratings, minY + 1);
+  const rangeY = maxY - minY;
+
+  const usableW = width - padL - padR;
+  const usableH = height - padT - padB;
+  const n = points.length;
+
+  const x = (i: number) => padL + (usableW * i) / (n - 1);
+  const y = (v: number) => padT + usableH - ((v - minY) / rangeY) * usableH;
+
+  const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${x(i).toFixed(1)} ${y(p.rating).toFixed(1)}`).join(' ');
+  const areaPath = `${linePath} L${x(n - 1).toFixed(1)} ${(padT + usableH).toFixed(1)} L${x(0).toFixed(1)} ${(padT + usableH).toFixed(1)} Z`;
+
+  // Y 轴刻度：选 4 档
+  const yTicks = [0, 0.33, 0.66, 1].map(frac => {
+    const val = minY + frac * rangeY;
+    return {
+      y: y(val),
+      label: formatInt(val)
+    };
+  });
+
+  // X 轴三个时间标签：首 / 中 / 末
+  const xTicks = [0, Math.floor((n - 1) / 2), n - 1].map(i => ({
+    x: x(i),
+    label: points[i].date
+  }));
+
+  return `<svg class="chart-svg" viewBox="0 0 ${width} ${height}" width="100%" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+    <g class="chart-grid">
+      ${yTicks.map(t => `<line x1="${padL}" x2="${width - padR}" y1="${t.y.toFixed(1)}" y2="${t.y.toFixed(1)}" />`).join('')}
+    </g>
+    <path class="chart-area" d="${areaPath}" />
+    <path class="chart-line" d="${linePath}" />
+    <g class="chart-axis-y">
+      ${yTicks.map(t => `<text x="${padL - 6}" y="${(t.y + 3).toFixed(1)}" text-anchor="end">${esc(t.label)}</text>`).join('')}
+    </g>
+    <g class="chart-axis-x">
+      ${xTicks.map(t => `<text x="${t.x.toFixed(1)}" y="${height - 6}" text-anchor="middle">${esc(t.label)}</text>`).join('')}
+    </g>
+  </svg>`;
+}
+
+/**
+ * GitHub 风格的活动热力图：12 个月 / 53 周 / 7 天。
+ * dayMap 的 key 是 YYYY-MM-DD。
+ */
+function renderHeatmap(dayMap: Map<string, number>): string {
+  const cellSize = 11;
+  const gap = 2;
+  const today = new Date();
+  // 以今天为最后一格的日子，算出 52×7 网格左上角需要对齐的起点（让最后一列包含今天）
+  const weeks = 52;
+  const totalDays = weeks * 7;
+
+  // 起点：totalDays-1 天前，再往前推到那天所在的"周一"
+  const start = new Date(today);
+  start.setDate(today.getDate() - (totalDays - 1));
+  // 把 start 对齐到周一（getDay: 0=Sun,1=Mon...）
+  const dow = start.getDay();
+  const daysToMonday = (dow + 6) % 7;
+  start.setDate(start.getDate() - daysToMonday);
+
+  // 收集非零值以便分档
+  const allValues = Array.from(dayMap.values()).filter(v => v > 0);
+  const sorted = allValues.slice().sort((a, b) => a - b);
+  const q = (frac: number) => sorted.length === 0 ? 0 : sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * frac))];
+  const thresholds = [q(0.25), q(0.5), q(0.75), q(1)];
+
+  function levelFor(v: number): number {
+    if (v <= 0) return 0;
+    for (let i = 0; i < thresholds.length; i += 1) {
+      if (v <= thresholds[i]) return i + 1;
+    }
+    return 4;
+  }
+
+  // 构造格子
+  const cellsPerWeek = 7;
+  const totalWeeks = Math.ceil((totalDays + daysToMonday) / 7);
+  const cells: string[] = [];
+  const monthLabels: string[] = [];
+  let lastMonth = -1;
+
+  for (let w = 0; w < totalWeeks; w += 1) {
+    for (let d = 0; d < cellsPerWeek; d += 1) {
+      const cur = new Date(start);
+      cur.setDate(start.getDate() + w * 7 + d);
+      if (cur > today) continue;
+      const y = d * (cellSize + gap);
+      const x = w * (cellSize + gap);
+      const iso = cur.toISOString().slice(0, 10);
+      const v = dayMap.get(iso) ?? 0;
+      const lvl = levelFor(v);
+      const title = v > 0 ? `${iso}: ${v}` : iso;
+      cells.push(`<rect x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" rx="2" ry="2" class="hm-cell lvl-${lvl}"><title>${esc(title)}</title></rect>`);
+
+      if (d === 0) {
+        const month = cur.getMonth();
+        if (month !== lastMonth) {
+          monthLabels.push(`<text x="${x}" y="-4" class="hm-month">${cur.getMonth() + 1}月</text>`);
+          lastMonth = month;
+        }
+      }
+    }
+  }
+
+  const svgWidth = totalWeeks * (cellSize + gap);
+  const svgHeight = 7 * (cellSize + gap) + 14;
+
+  return `<div class="hm-wrap">
+    <svg class="hm-svg" viewBox="0 -14 ${svgWidth} ${svgHeight}" width="100%" preserveAspectRatio="xMinYMid meet" xmlns="http://www.w3.org/2000/svg">
+      <g class="hm-months">${monthLabels.join('')}</g>
+      <g class="hm-cells">${cells.join('')}</g>
+    </svg>
+    <div class="hm-legend">
+      <span>活跃度</span>
+      <span class="hm-chip lvl-0"></span>
+      <span class="hm-chip lvl-1"></span>
+      <span class="hm-chip lvl-2"></span>
+      <span class="hm-chip lvl-3"></span>
+      <span class="hm-chip lvl-4"></span>
+    </div>
+  </div>`;
+}
+
+export const USER_HISTORY_BASE_CSS = `
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: transparent; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", Roboto, sans-serif; color: var(--e-text); font-size: 13px; line-height: 1.45; -webkit-font-smoothing: antialiased; }
+  .e-card { background: var(--e-bg); border: 1px solid var(--e-border); border-radius: 14px; padding: 18px 20px; box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.02); display: flex; flex-direction: column; gap: 18px; }
+  .e-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+  .e-title { font-size: 15px; font-weight: 600; color: var(--e-text); }
+  .e-name-inline { color: var(--e-accent); font-weight: 600; }
+  .e-sub { color: var(--e-text-subtle); font-size: 11px; }
+  .section-title { font-size: 11px; color: var(--e-text-muted); font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 8px; }
+  .chart-wrap { background: var(--e-surface); border: 1px solid var(--e-border); border-radius: 8px; padding: 10px; }
+  .chart-svg { display: block; width: 100%; height: auto; }
+  .chart-grid line { stroke: var(--e-border); stroke-dasharray: 2 3; }
+  .chart-area { fill: var(--e-accent-soft); }
+  .chart-line { fill: none; stroke: var(--e-accent); stroke-width: 1.8; stroke-linejoin: round; }
+  .chart-axis-y text, .chart-axis-x text { fill: var(--e-text-muted); font-size: 10px; font-family: inherit; font-variant-numeric: tabular-nums; }
+  .chart-empty { color: var(--e-text-subtle); text-align: center; padding: 24px 0; }
+  .hm-wrap { background: var(--e-surface); border: 1px solid var(--e-border); border-radius: 8px; padding: 16px 12px 12px; }
+  .hm-svg { display: block; }
+  .hm-months text { fill: var(--e-text-subtle); font-size: 9px; font-family: inherit; }
+  .hm-cell { fill: var(--e-border); }
+  .hm-cell.lvl-0 { fill: var(--e-border); fill-opacity: 0.5; }
+  .hm-cell.lvl-1 { fill: color-mix(in srgb, var(--e-accent) 28%, var(--e-border)); }
+  .hm-cell.lvl-2 { fill: color-mix(in srgb, var(--e-accent) 52%, var(--e-border)); }
+  .hm-cell.lvl-3 { fill: color-mix(in srgb, var(--e-accent) 76%, var(--e-border)); }
+  .hm-cell.lvl-4 { fill: var(--e-accent); }
+  .hm-legend { display: flex; align-items: center; gap: 6px; color: var(--e-text-muted); font-size: 10px; margin-top: 8px; justify-content: flex-end; }
+  .hm-chip { display: inline-block; width: 10px; height: 10px; border-radius: 2px; }
+  .hm-chip.lvl-0 { background: var(--e-border); opacity: 0.5; }
+  .hm-chip.lvl-1 { background: color-mix(in srgb, var(--e-accent) 28%, var(--e-border)); }
+  .hm-chip.lvl-2 { background: color-mix(in srgb, var(--e-accent) 52%, var(--e-border)); }
+  .hm-chip.lvl-3 { background: color-mix(in srgb, var(--e-accent) 76%, var(--e-border)); }
+  .hm-chip.lvl-4 { background: var(--e-accent); }
+  .e-empty { color: var(--e-text-subtle); font-size: 11px; text-align: center; padding: 12px 0; }
+`;
+
+export function renderUserHistoryBody(
+  user: UserBasic,
+  series: VotingSeries | null,
+  heatmapDaily: Array<{ date: string; votes: number; pages: number }>,
+  opts: UserHistoryRenderOptions
+): string {
+  const displayName = user.displayName || `User ${user.wikidotId}`;
+
+  const chartHtml = opts.showTrend
+    ? (series
+      ? `<div class="chart-wrap">${renderRatingChart(trimToRange(buildCumulativeRating(series), opts.range))}</div>`
+      : `<div class="chart-wrap"><div class="e-empty chart-empty">暂无评分历史缓存</div></div>`)
+    : '';
+
+  const dayMap = new Map<string, number>();
+  for (const row of heatmapDaily) {
+    dayMap.set(row.date, row.votes + row.pages * 3);
+  }
+
+  const heatmapHtml = opts.showHeatmap
+    ? renderHeatmap(dayMap)
+    : '';
+
+  return `<div class="e-card">
+    <header class="e-header">
+      <div class="e-title">
+        <span class="e-name-inline">${esc(displayName)}</span>
+        <span class="e-sub">ID ${user.wikidotId}</span>
+      </div>
+    </header>
+
+    ${opts.showTrend ? `<section>
+      <div class="section-title">评分曲线 · ${esc(opts.range === '90d' ? '近 90 天' : opts.range === '1y' ? '近 1 年' : '全部历史')}</div>
+      ${chartHtml}
+    </section>` : ''}
+
+    ${opts.showHeatmap ? `<section>
+      <div class="section-title">近一年活动</div>
+      ${heatmapHtml}
+    </section>` : ''}
+  </div>`;
+}

--- a/bff/src/web/utils/embed/templates/userHistory.ts
+++ b/bff/src/web/utils/embed/templates/userHistory.ts
@@ -19,6 +19,35 @@ function formatInt(n: number): string {
 }
 
 /**
+ * 本地（Asia/Shanghai）YYYY-MM-DD 格式化。传入 `Date` 或 UNIX ms。
+ * `toISOString().slice(0,10)` 会用 UTC 日，凌晨时段会错切到前一天，所以这里统一显式走站点时区。
+ */
+const SH_DATE = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Shanghai',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit'
+});
+
+function shanghaiDate(input: Date | number): string {
+  const d = typeof input === 'number' ? new Date(input) : input;
+  return SH_DATE.format(d);
+}
+
+/**
+ * 按"本地日期"后退 N 天：在 UTC 基础上加时区偏移得到 Shanghai 当日的午夜时刻，再减天数。
+ * Shanghai 无 DST，偏移固定 +08:00，这样处理比拼字符串更稳。
+ */
+function shanghaiDateNDaysAgo(days: number): string {
+  const todayStr = shanghaiDate(Date.now());
+  const [y, m, d] = todayStr.split('-').map(Number);
+  // 构造 Shanghai 当日 00:00 UTC 等价时间戳（-8h）
+  const shanghaiMidnightUtcMs = Date.UTC(y, m - 1, d) - 8 * 3600 * 1000;
+  const cutoffMs = shanghaiMidnightUtcMs - days * 24 * 3600 * 1000;
+  return shanghaiDate(cutoffMs);
+}
+
+/**
  * 从 VotingSeries 生成累计评分序列（upvotes[i] - downvotes[i]）。
  */
 function buildCumulativeRating(series: VotingSeries): Array<{ date: string; rating: number }> {
@@ -35,9 +64,7 @@ function buildCumulativeRating(series: VotingSeries): Array<{ date: string; rati
 function trimToRange(points: Array<{ date: string; rating: number }>, range: UserHistoryRenderOptions['range']): Array<{ date: string; rating: number }> {
   if (range === 'all' || points.length === 0) return points;
   const days = range === '90d' ? 90 : 365;
-  const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - days);
-  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  const cutoffStr = shanghaiDateNDaysAgo(days);
   return points.filter(p => p.date >= cutoffStr);
 }
 
@@ -103,23 +130,28 @@ function renderRatingChart(points: Array<{ date: string; rating: number }>): str
 
 /**
  * GitHub 风格的活动热力图：12 个月 / 53 周 / 7 天。
- * dayMap 的 key 是 YYYY-MM-DD。
+ * dayMap 的 key 是 Asia/Shanghai 下的 YYYY-MM-DD。
+ *
+ * 内部完全在"Shanghai 本地日"坐标系下推进：把每一天的 UTC 偏移算一次，后续都用
+ * 天数偏移累加，避免受 JS `Date` 方法的本地时区影响（服务器可能在 UTC 运行）。
  */
 function renderHeatmap(dayMap: Map<string, number>): string {
   const cellSize = 11;
   const gap = 2;
-  const today = new Date();
-  // 以今天为最后一格的日子，算出 52×7 网格左上角需要对齐的起点（让最后一列包含今天）
   const weeks = 52;
   const totalDays = weeks * 7;
+  const MS_PER_DAY = 24 * 3600 * 1000;
 
-  // 起点：totalDays-1 天前，再往前推到那天所在的"周一"
-  const start = new Date(today);
-  start.setDate(today.getDate() - (totalDays - 1));
-  // 把 start 对齐到周一（getDay: 0=Sun,1=Mon...）
-  const dow = start.getDay();
-  const daysToMonday = (dow + 6) % 7;
-  start.setDate(start.getDate() - daysToMonday);
+  const todayStr = shanghaiDate(Date.now());
+  const [ty, tm, td] = todayStr.split('-').map(Number);
+  // Shanghai 无 DST，直接用 +08:00 偏移；UTC 时刻 = 本地午夜 - 8h
+  const todayMidnightUtcMs = Date.UTC(ty, tm - 1, td) - 8 * 3600 * 1000;
+  // Shanghai 当日是周几（0=Sun），把它转成 Monday=0 的坐标系
+  const todayDow = new Date(todayMidnightUtcMs + 8 * 3600 * 1000).getUTCDay();
+  const todayDowMon = (todayDow + 6) % 7;
+
+  // 网格左上角：往前 totalDays-1 天到 "N 天前"，再补齐到那天所在周的周一
+  const gridStartMs = todayMidnightUtcMs - (totalDays - 1 + todayDowMon) * MS_PER_DAY;
 
   // 收集非零值以便分档
   const allValues = Array.from(dayMap.values()).filter(v => v > 0);
@@ -137,28 +169,29 @@ function renderHeatmap(dayMap: Map<string, number>): string {
 
   // 构造格子
   const cellsPerWeek = 7;
-  const totalWeeks = Math.ceil((totalDays + daysToMonday) / 7);
+  // 从 gridStart 到今天需要多少周
+  const daysSpan = Math.round((todayMidnightUtcMs - gridStartMs) / MS_PER_DAY) + 1;
+  const totalWeeks = Math.ceil(daysSpan / 7);
   const cells: string[] = [];
   const monthLabels: string[] = [];
   let lastMonth = -1;
 
   for (let w = 0; w < totalWeeks; w += 1) {
     for (let d = 0; d < cellsPerWeek; d += 1) {
-      const cur = new Date(start);
-      cur.setDate(start.getDate() + w * 7 + d);
-      if (cur > today) continue;
-      const y = d * (cellSize + gap);
-      const x = w * (cellSize + gap);
-      const iso = cur.toISOString().slice(0, 10);
+      const cellMs = gridStartMs + (w * 7 + d) * MS_PER_DAY;
+      if (cellMs > todayMidnightUtcMs) continue;
+      const yPos = d * (cellSize + gap);
+      const xPos = w * (cellSize + gap);
+      const iso = shanghaiDate(cellMs);
       const v = dayMap.get(iso) ?? 0;
       const lvl = levelFor(v);
       const title = v > 0 ? `${iso}: ${v}` : iso;
-      cells.push(`<rect x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" rx="2" ry="2" class="hm-cell lvl-${lvl}"><title>${esc(title)}</title></rect>`);
+      cells.push(`<rect x="${xPos}" y="${yPos}" width="${cellSize}" height="${cellSize}" rx="2" ry="2" class="hm-cell lvl-${lvl}"><title>${esc(title)}</title></rect>`);
 
       if (d === 0) {
-        const month = cur.getMonth();
+        const month = Number(iso.slice(5, 7));
         if (month !== lastMonth) {
-          monthLabels.push(`<text x="${x}" y="-4" class="hm-month">${cur.getMonth() + 1}月</text>`);
+          monthLabels.push(`<text x="${xPos}" y="-4" class="hm-month">${month}月</text>`);
           lastMonth = month;
         }
       }

--- a/bff/src/web/utils/embed/textMetrics.ts
+++ b/bff/src/web/utils/embed/textMetrics.ts
@@ -1,0 +1,38 @@
+/**
+ * Rough text-width estimation for shields-style SVG badges.
+ *
+ * Shields.io ships a full Verdana glyph-width table; we only need a cheap
+ * approximation that keeps Latin / digit / CJK / symbol labels aligned.
+ */
+
+const LATIN_NARROW = new Set('ijlI.,:;!|\'`"'.split(''));
+const LATIN_WIDE = new Set('MWmw@#%&'.split(''));
+
+function codeUnitWidth(ch: string): number {
+  const code = ch.charCodeAt(0);
+  // CJK Unified Ideographs, Hangul, Hiragana, Katakana, full-width
+  if (
+    (code >= 0x2e80 && code <= 0x9fff) ||
+    (code >= 0xac00 && code <= 0xd7a3) ||
+    (code >= 0x3040 && code <= 0x30ff) ||
+    (code >= 0xff00 && code <= 0xffef)
+  ) {
+    return 12;
+  }
+  if (code < 0x20) return 0;
+  if (LATIN_NARROW.has(ch)) return 4;
+  if (LATIN_WIDE.has(ch)) return 9;
+  if (ch >= '0' && ch <= '9') return 6.5;
+  if (ch >= 'A' && ch <= 'Z') return 7.5;
+  if (ch >= 'a' && ch <= 'z') return 6.5;
+  return 6;
+}
+
+export function estimateTextWidth(text: string): number {
+  if (!text) return 0;
+  let width = 0;
+  for (const ch of text) {
+    width += codeUnitWidth(ch);
+  }
+  return Math.ceil(width);
+}

--- a/bff/src/web/utils/embed/theme.ts
+++ b/bff/src/web/utils/embed/theme.ts
@@ -1,0 +1,66 @@
+export type EmbedTheme = 'auto' | 'light' | 'dark';
+
+export interface ResolvedTheme {
+  theme: EmbedTheme;
+  accent: string;
+}
+
+/**
+ * 把 theme / accent 参数标准化。accent 接受 3/6/8 位 hex（可带或不带 #），fallback 到 SCPPER
+ * 默认强调色。非法输入一律回退，不抛错，与 inlineCss 的"装饰失败即沉默"保持一致。
+ */
+export function resolveTheme(rawTheme: unknown, rawAccent: unknown): ResolvedTheme {
+  const t = typeof rawTheme === 'string' ? rawTheme.toLowerCase() : 'auto';
+  const theme: EmbedTheme = t === 'dark' || t === 'light' ? t : 'auto';
+
+  const defaultAccent = '#6f4ef2';
+  let accent = defaultAccent;
+  if (typeof rawAccent === 'string') {
+    const trimmed = rawAccent.trim().replace(/^#/, '');
+    if (/^[0-9a-fA-F]{3}$/.test(trimmed) || /^[0-9a-fA-F]{6}$/.test(trimmed) || /^[0-9a-fA-F]{8}$/.test(trimmed)) {
+      accent = `#${trimmed}`;
+    }
+  }
+
+  return { theme, accent };
+}
+
+/**
+ * 注：light / dark 变量名和前端 `:root` / `.dark` 上定义的设计系统同源，
+ * 方便用户的自定义 CSS 用同一套变量覆写。
+ */
+export function buildThemeCss({ theme, accent }: ResolvedTheme): string {
+  const lightVars = `
+    --e-bg: #ffffff;
+    --e-surface: #f7f7f8;
+    --e-border: #e5e7eb;
+    --e-text: #111827;
+    --e-text-muted: #6b7280;
+    --e-text-subtle: #9ca3af;
+    --e-accent: ${accent};
+    --e-accent-soft: color-mix(in srgb, ${accent} 16%, transparent);
+    --e-good: #059669;
+    --e-warn: #d97706;
+    --e-bad: #dc2626;
+  `;
+  const darkVars = `
+    --e-bg: #0b0b0f;
+    --e-surface: #16161c;
+    --e-border: #26262e;
+    --e-text: #f5f5f5;
+    --e-text-muted: #a1a1aa;
+    --e-text-subtle: #71717a;
+    --e-accent: ${accent};
+    --e-accent-soft: color-mix(in srgb, ${accent} 22%, transparent);
+    --e-good: #34d399;
+    --e-warn: #fbbf24;
+    --e-bad: #f87171;
+  `;
+
+  if (theme === 'light') return `:root { ${lightVars} }`;
+  if (theme === 'dark') return `:root { ${darkVars} }`;
+  return `:root { ${lightVars} }
+    @media (prefers-color-scheme: dark) {
+      :root { ${darkVars} }
+    }`;
+}

--- a/bff/src/web/utils/embed/userData.ts
+++ b/bff/src/web/utils/embed/userData.ts
@@ -146,6 +146,8 @@ export async function loadUserActivityHeatmap(
   userId: number,
   days: number
 ): Promise<Array<{ date: string; votes: number; pages: number }>> {
+  // 显式用 Asia/Shanghai 的当天做锚点：若 DB session 的 TimeZone 是 UTC，
+  // 直接用 CURRENT_DATE 会在本地 00:00-08:00 这段时间漏掉"今天"的行。
   const { rows } = await pool.query(
     `SELECT
        to_char(date::date, 'YYYY-MM-DD') AS date,
@@ -153,7 +155,8 @@ export async function loadUserActivityHeatmap(
        COALESCE("pages_created", 0)::int AS pages
      FROM "UserDailyStats"
      WHERE "userId" = $1
-       AND date >= CURRENT_DATE - ($2::int - 1) * INTERVAL '1 day'
+       AND date >= (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Shanghai')::date
+                   - ($2::int - 1) * INTERVAL '1 day'
      ORDER BY date ASC`,
     [userId, Math.max(1, Math.min(days, 366))]
   );

--- a/bff/src/web/utils/embed/userData.ts
+++ b/bff/src/web/utils/embed/userData.ts
@@ -1,0 +1,165 @@
+import type { Pool } from 'pg';
+
+export interface UserBasic {
+  id: number;
+  wikidotId: number;
+  displayName: string | null;
+  firstActivityAt: Date | null;
+  lastActivityAt: Date | null;
+}
+
+export interface UserCardStats {
+  rank: number | null;
+  totalRating: number;
+  meanRating: number;
+  pageCount: number;
+  votesUp: number;
+  votesDown: number;
+  totalUp: number;
+  totalDown: number;
+  favTag: string | null;
+  categories: Array<{
+    key: string;
+    label: string;
+    rank: number | null;
+    rating: number;
+    pageCount: number;
+  }>;
+}
+
+export interface VotingSeries {
+  dates: string[];
+  dailyUpvotes: number[];
+  dailyDownvotes: number[];
+  upvotes: number[];
+  downvotes: number[];
+  totalVotes: number[];
+}
+
+const CATEGORY_MAP: Array<{ key: string; label: string; rankField: string; ratingField: string; countField: string }> = [
+  { key: 'scp', label: 'SCP', rankField: 'scpRank', ratingField: 'scpRating', countField: 'scpPageCount' },
+  { key: 'story', label: '故事', rankField: 'storyRank', ratingField: 'storyRating', countField: 'storyPageCount' },
+  { key: 'translation', label: '翻译', rankField: 'translationRank', ratingField: 'translationRating', countField: 'translationPageCount' },
+  { key: 'goi', label: 'GoI', rankField: 'goiRank', ratingField: 'goiRating', countField: 'goiPageCount' },
+  { key: 'wanderers', label: '漫游者', rankField: 'wanderersRank', ratingField: 'wanderersRating', countField: 'wanderersPageCount' },
+  { key: 'art', label: '艺术', rankField: 'artRank', ratingField: 'artRating', countField: 'artPageCount' }
+];
+
+export async function loadUserBasicByWikidotId(
+  pool: Pool,
+  wikidotId: number
+): Promise<UserBasic | null> {
+  const { rows } = await pool.query(
+    `SELECT id, "wikidotId", "displayName", "firstActivityAt", "lastActivityAt"
+     FROM "User"
+     WHERE "wikidotId" = $1`,
+    [wikidotId]
+  );
+  if (!rows.length) return null;
+  const r = rows[0];
+  return {
+    id: Number(r.id),
+    wikidotId: Number(r.wikidotId),
+    displayName: r.displayName ?? null,
+    firstActivityAt: r.firstActivityAt ? new Date(r.firstActivityAt) : null,
+    lastActivityAt: r.lastActivityAt ? new Date(r.lastActivityAt) : null
+  };
+}
+
+export async function loadUserCardStats(
+  pool: Pool,
+  wikidotId: number
+): Promise<UserCardStats | null> {
+  const { rows } = await pool.query(
+    `SELECT
+       us."overallRank" AS rank,
+       COALESCE(us."totalRating", 0)::int AS "totalRating",
+       COALESCE(us."overallRating", 0)::float AS "meanRating",
+       COALESCE(us."pageCount", 0)::int AS "pageCount",
+       COALESCE(us."votesCastUp", 0)::int AS "votesUp",
+       COALESCE(us."votesCastDown", 0)::int AS "votesDown",
+       COALESCE(us."totalUp", 0)::int AS "totalUp",
+       COALESCE(us."totalDown", 0)::int AS "totalDown",
+       us."favTag",
+       us."scpRank", COALESCE(us."scpRating", 0)::float AS "scpRating", COALESCE(us."scpPageCount", 0)::int AS "scpPageCount",
+       us."storyRank", COALESCE(us."storyRating", 0)::float AS "storyRating", COALESCE(us."storyPageCount", 0)::int AS "storyPageCount",
+       us."translationRank", COALESCE(us."translationRating", 0)::float AS "translationRating", COALESCE(us."translationPageCount", 0)::int AS "translationPageCount",
+       us."goiRank", COALESCE(us."goiRating", 0)::float AS "goiRating", COALESCE(us."goiPageCount", 0)::int AS "goiPageCount",
+       us."wanderersRank", COALESCE(us."wanderersRating", 0)::float AS "wanderersRating", COALESCE(us."wanderersPageCount", 0)::int AS "wanderersPageCount",
+       us."artRank", COALESCE(us."artRating", 0)::float AS "artRating", COALESCE(us."artPageCount", 0)::int AS "artPageCount"
+     FROM "UserStats" us
+     JOIN "User" u ON us."userId" = u.id
+     WHERE u."wikidotId" = $1`,
+    [wikidotId]
+  );
+  if (!rows.length) return null;
+  const r = rows[0] as any;
+
+  const categories = CATEGORY_MAP.map(({ key, label, rankField, ratingField, countField }) => ({
+    key,
+    label,
+    rank: r[rankField] != null ? Number(r[rankField]) : null,
+    rating: Number(r[ratingField] ?? 0),
+    pageCount: Number(r[countField] ?? 0)
+  }));
+
+  return {
+    rank: r.rank != null ? Number(r.rank) : null,
+    totalRating: Number(r.totalRating ?? 0),
+    meanRating: Number(r.meanRating ?? 0),
+    pageCount: Number(r.pageCount ?? 0),
+    votesUp: Number(r.votesUp ?? 0),
+    votesDown: Number(r.votesDown ?? 0),
+    totalUp: Number(r.totalUp ?? 0),
+    totalDown: Number(r.totalDown ?? 0),
+    favTag: r.favTag ?? null,
+    categories
+  };
+}
+
+export async function loadUserVotingSeries(
+  pool: Pool,
+  wikidotId: number
+): Promise<VotingSeries | null> {
+  const { rows } = await pool.query(
+    `SELECT "attributionVotingTimeSeriesCache" AS cache
+     FROM "User"
+     WHERE "wikidotId" = $1`,
+    [wikidotId]
+  );
+  const cache = rows[0]?.cache;
+  if (!cache || typeof cache !== 'object') return null;
+  const src = cache as Partial<VotingSeries>;
+  if (!Array.isArray(src.dates) || src.dates.length === 0) return null;
+  return {
+    dates: src.dates.map(String),
+    dailyUpvotes: (src.dailyUpvotes ?? []).map(Number),
+    dailyDownvotes: (src.dailyDownvotes ?? []).map(Number),
+    upvotes: (src.upvotes ?? []).map(Number),
+    downvotes: (src.downvotes ?? []).map(Number),
+    totalVotes: (src.totalVotes ?? []).map(Number)
+  };
+}
+
+export async function loadUserActivityHeatmap(
+  pool: Pool,
+  userId: number,
+  days: number
+): Promise<Array<{ date: string; votes: number; pages: number }>> {
+  const { rows } = await pool.query(
+    `SELECT
+       to_char(date::date, 'YYYY-MM-DD') AS date,
+       COALESCE("votes_cast", 0)::int AS votes,
+       COALESCE("pages_created", 0)::int AS pages
+     FROM "UserDailyStats"
+     WHERE "userId" = $1
+       AND date >= CURRENT_DATE - ($2::int - 1) * INTERVAL '1 day'
+     ORDER BY date ASC`,
+    [userId, Math.max(1, Math.min(days, 366))]
+  );
+  return rows.map(r => ({
+    date: String(r.date),
+    votes: Number(r.votes),
+    pages: Number(r.pages)
+  }));
+}

--- a/docs/wikidot-embeds.md
+++ b/docs/wikidot-embeds.md
@@ -1,0 +1,243 @@
+# SCPPER-CN Wikidot 嵌入组件
+
+本文档描述 scpper.mer.run 提供的三类可嵌入组件，以及它们对应的 Wikidot 组件源代码写法。所有端点挂在 `/api/embed/*`（BFF 路由模块：[`bff/src/web/routes/embed.ts`](../bff/src/web/routes/embed.ts)）。
+
+## 设计取舍
+
+| 维度 | 选择 | 理由 |
+| --- | --- | --- |
+| SVG 徽章 vs iframe | 徽章走 SVG（`[[image]]`） | 无需 Wikidot iframe allowlist，支持 `currentColor` 跟随分部主题 |
+| 数据 | 全部复用现有 `PageStats` / `UserStats` / `votingTimeSeriesCache` | 无需新表；日常同步已经覆盖 |
+| 自定义 CSS | 通过 URL `?css=<编码后的 CSS>` 直接注入 | 不上传文件、不服务端缓存，满足"输入即应用"的定位 |
+| CSS 安全 | 拒绝 `@import` / `javascript:` / `expression(` / `</style>` 等危险片段 | 关键字黑名单 + url() 限制，不通过的 CSS 静默丢弃 |
+| CSP | `default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data: https:; frame-ancestors *` | 不允许任何 `<script>`，所有交互靠纯 CSS |
+| X-Frame-Options | 显式不设 | 允许被任意站点 iframe |
+| Cache | badge 300s；user-card 300s；user-history 600s | 与数据实际刷新节奏一致，避免高 QPS 打爆 DB |
+
+## 端点规格
+
+### 1. Page Badge — SVG
+
+```
+GET /api/embed/badge/page/:wikidotId.svg
+  metric = rating (默认) | wilson | controversy | votes | trend
+  label  = 自定义左侧文本；省略则按 metric 派生默认值
+  style  = flat (默认) | plastic | mono
+  theme  = mono  (等同于 style=mono，令徽章用 currentColor 跟随父级主题)
+  accent = 6/3/8 位 hex，不含 #；仅对非 trend 生效
+```
+
+- `metric=trend` 走 [`Page.votingTimeSeriesCache`](../backend/prisma/schema.prisma)，渲染**最近 90 天**累计评分 sparkline。
+- 其他 metric 读 `PageStats.wilson95` / `PageStats.controversy` / `PageVersion.rating` / `PageVersion.voteCount`。
+- 返回 `Content-Type: image/svg+xml`，可直接被 Wikidot `[[image]]` 引用。
+
+### 2. User Card — iframe (HTML)
+
+```
+GET /api/embed/user-card/:wikidotId
+  theme           = auto (默认) | light | dark
+  accent          = hex (可带或不带 #)
+  breakdown       = list (默认) | radar
+  hideActivity    = 0 (默认) | 1      → 隐藏"首次活动 / 最近活动"
+  showCategories  = scp,story,translation,goi,wanderers,art (任意子集)
+  css             = URL-encoded 后的自定义 CSS，最大 4KB，超过会尝试截到最近的 `}`
+```
+
+显示：头像、displayName、wikidotId、`#overallRank`、总评分、平均分、作品、支持/反对票、分类表现（列表或雷达）。与前端的用户页头部字段一一对应（[`frontend/components/UserCard.vue`](../frontend/components/UserCard.vue)）。
+
+### 3. User History — iframe (HTML)
+
+```
+GET /api/embed/user-history/:wikidotId
+  theme        = auto | light | dark
+  accent       = hex
+  range        = 90d (默认) | 1y | all      → 评分曲线显示区间
+  showTrend    = 0 | 1 (默认)               → 评分曲线
+  showHeatmap  = 0 | 1 (默认)               → 近一年活动热力图
+  css          = URL-encoded 自定义 CSS
+```
+
+- 评分曲线：累计 `upvotes - downvotes`，SVG 折线 + 面积。
+- 活动热力图：52 周 × 7 天，`UserDailyStats.votes_cast + pages_created*3` 分 4 档。
+
+## 用户可覆写的 CSS 变量
+
+模板 CSS 在 `:root` 下声明以下变量，可以被 `?css=` 参数传入的 CSS 覆盖：
+
+```css
+:root {
+  --e-bg: #ffffff;          /* 卡片背景 */
+  --e-surface: #f7f7f8;     /* 次级面 */
+  --e-border: #e5e7eb;      /* 边框 */
+  --e-text: #111827;
+  --e-text-muted: #6b7280;
+  --e-text-subtle: #9ca3af;
+  --e-accent: #6f4ef2;      /* 可被 accent= 覆盖；也可被自定义 CSS 覆盖 */
+  --e-accent-soft: ...;     /* accent 的半透明软色 */
+}
+```
+
+只改颜色时最稳妥的写法是只覆盖变量，而不是动 CSS 规则本身：
+
+```css
+:root { --e-accent: #ff3b30; --e-bg: #fff8f4; }
+.e-card { border-radius: 6px; box-shadow: 0 0 0 2px rgba(0,0,0,.06); }
+```
+
+## Wikidot 组件源代码
+
+### component:scpper-badge
+
+SVG 徽章 — 用 `[[image]]` 不需要 iframe allowlist。
+
+```
+[[div_ class="scpper-badge-wrap"]]
+[[image https://scpper.mer.run/api/embed/badge/page/{$page_id}.svg?metric={$metric}
+  alt="SCPPER 统计徽章"
+  class="scpper-badge"
+  style="vertical-align:middle"
+  link="https://scpper.mer.run/page/{$page_id}"]]
+[[/div]]
+
+[[module CSS]]
+.scpper-badge { height: 20px; vertical-align: middle; }
+.scpper-badge-wrap { display: inline-block; }
+[[/module]]
+```
+
+Hub/目录页可以在每个 SCP 后缀徽章，批量用法：
+
+```
+||~ 编号 ||~ 名称 ||~ 评分 ||~ Wilson ||
+|| [[[scp-cn-2000]]] || 不死鸟计划 || [[image https://scpper.mer.run/api/embed/badge/page/1306943399.svg?metric=rating]] || [[image https://scpper.mer.run/api/embed/badge/page/1306943399.svg?metric=wilson&theme=mono]] ||
+```
+
+`theme=mono` 让徽章用 `currentColor`，SCP-CN 白夜模式切换时徽章会跟着变色。
+
+### component:scpper-user-card
+
+iframe 方案，需要分部把 `scpper.mer.run` 加入 `_meta:iframe-security` 的允许列表（或站点 CSS 的 `iframe-src` 白名单）。
+
+```
+[[module CSS]]
+.scpper-embed-frame {
+  width: 100%;
+  min-height: 320px;
+  border: none;
+  display: block;
+}
+[[/module]]
+
+[[iframe https://scpper.mer.run/api/embed/user-card/%%created_by_unix%%?theme=auto&breakdown=list
+  class="scpper-embed-frame"
+  frameborder="0"
+  scrolling="no"]]
+```
+
+> `%%created_by_unix%%` 是 Wikidot 占位符，渲染时替换为当前页作者的 wikidotId；也可以写死一个数字。
+
+**传入自定义 CSS（整版红色主题示例）：**
+
+```
+[[iframe https://scpper.mer.run/api/embed/user-card/1546989?theme=dark&accent=ff3b30&css=%3Aroot%7B--e-bg%3A%23150606%3B--e-surface%3A%23240a0a%3B--e-border%3A%23421717%3B%7D%0A.e-card%7Bborder-radius%3A4px%3B%7D%0A.e-rank%7Btext-shadow%3A0%200%200%20%23ff3b30%7D
+  class="scpper-embed-frame"
+  frameborder="0"
+  scrolling="no"]]
+```
+
+对应的原始 CSS 是：
+
+```css
+:root {
+  --e-bg: #150606;
+  --e-surface: #240a0a;
+  --e-border: #421717;
+}
+.e-card { border-radius: 4px; }
+.e-rank { text-shadow: 0 0 0 #ff3b30 }
+```
+
+用任意 URL-encoder 处理后拼到 `css=` 后面即可；URL 超过 4KB 时服务端会把超出部分安全截断。
+
+### component:scpper-user-history
+
+```
+[[module CSS]]
+.scpper-embed-frame-tall {
+  width: 100%;
+  min-height: 460px;
+  border: none;
+  display: block;
+}
+[[/module]]
+
+[[iframe https://scpper.mer.run/api/embed/user-history/%%created_by_unix%%?range=1y&theme=auto
+  class="scpper-embed-frame-tall"
+  frameborder="0"
+  scrolling="no"]]
+```
+
+典型使用场景：作者自己的 `user:info` 页底部、作者列表页。
+
+### Fallback：通过分部 wdfiles 做 frame-shell
+
+如果分部管理员短期内不愿意把 `scpper.mer.run` 加到 iframe allowlist，可以学 `scpwiki/interwiki` 的做法：把下面这个薄 HTML 传到 `component:scpper-frame` 的 `wdfiles`，用 `[[iframe]]` 指向自家 wdfiles，由 wdfiles 里的页面再 iframe 到 scpper.mer.run。
+
+`frame.html`（传到 wdfiles）：
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>html,body{margin:0;padding:0;background:transparent}iframe{border:none;width:100%;display:block}</style>
+</head>
+<body>
+<script>
+  const p = new URLSearchParams(location.search);
+  const kind = (p.get('kind') || '').replace(/[^a-z\-]/g, '');
+  const wid  = (p.get('wid')  || '').replace(/[^0-9]/g, '');
+  if (!/^(user-card|user-history)$/.test(kind) || !wid) {
+    document.body.textContent = 'invalid params';
+  } else {
+    p.delete('kind'); p.delete('wid');
+    const q = p.toString();
+    const iframe = document.createElement('iframe');
+    iframe.src = 'https://scpper.mer.run/api/embed/' + kind + '/' + wid + (q ? '?' + q : '');
+    iframe.width = '100%';
+    iframe.setAttribute('scrolling', 'no');
+    // 静态高度；若需要自适应，可以在这里加一个 postMessage 监听
+    iframe.height = kind === 'user-history' ? 520 : 360;
+    document.body.appendChild(iframe);
+  }
+</script>
+</body>
+</html>
+```
+
+Wikidot 组件里 iframe 到自家 wdfiles：
+
+```
+[[iframe http://scp-wiki-cn.wdfiles.com/local--files/component%3Ascpper-frame/frame.html?kind=user-card&wid=%%created_by_unix%%&theme=auto
+  frameborder="0" width="100%" height="360" scrolling="no"]]
+```
+
+## 常见坑
+
+1. **Wikidot `[[iframe]]` 的 allowlist**：管理员需要在 `_meta:iframe-security` 或 `.w-site-css` 里放行 `scpper.mer.run`。不放行时浏览器会静默拒绝加载 iframe（控制台有 CSP 报错）。
+2. **CSS URL-encoding 失误**：Wikidot `[[iframe]]` 对 URL 不做二次转码；`?` `&` `#` 本身不需要编码，但 CSS 内容里的 `{`、`:`、空白、换行必须编码。推荐用脚本/浏览器控制台 `encodeURIComponent(css)` 先处理一次。
+3. **自定义 CSS 被整块丢弃**：只要 CSS 里命中任意一条黑名单（`@import` / `javascript:` / `expression(` / `</style>` 等），整段 `css=` 就会被忽略而非只剥离那一条。这是刻意为之——解析一半的 CSS 反而更难排错。
+4. **头像 404 不是 bug**：一些用户在 Wikidot 上没头像，avatar-agent 会回落到默认图或 404；模板里 `<img onerror>` 会把占位藏掉。
+5. **Wilson 95% 对低样本敏感**：页面票数 < 30 时 `wilson95` 可能会显著低于直觉，徽章会照实显示。如果想过滤低票页面，在源码里自己判断 `voteCount` 再渲染徽章即可。
+
+## 数据来源对照表
+
+| 组件字段 | 来源 |
+| --- | --- |
+| `metric=rating` / `votes` | `PageVersion.rating` / `.voteCount`（`validTo IS NULL` 版本） |
+| `metric=wilson` / `controversy` | `PageStats.wilson95` / `.controversy` |
+| `metric=trend` sparkline | `Page.votingTimeSeriesCache.upvotes/downvotes` 末尾 90 天 |
+| User card 评分 / 作品 / 分类 | `UserStats.*`（与 `/api/users/:id/stats` 同源） |
+| User history 评分曲线 | `User.attributionVotingTimeSeriesCache` |
+| User history 热力图 | `UserDailyStats.votes_cast + pages_created`（近 366 天） |
+| 头像 | `/api/avatar/:wikidotId`（走现有 avatar-agent 代理） |


### PR DESCRIPTION
## Summary
- 新增 `/api/embed/*` 路由，提供三类面向 Wikidot 分部的嵌入形式：page badge (SVG)、user-card (iframe HTML)、user-history (iframe HTML)
- 全部数据复用现有 `PageStats` / `UserStats` / `Page.votingTimeSeriesCache` / `User.attributionVotingTimeSeriesCache` / `UserDailyStats`，无新表、无新依赖
- 自定义 CSS 走 `?css=<URL 编码 CSS>` 直接注入（最大 4KB），不上传文件、不服务端缓存；含 `@import` / `javascript:` / `expression(` / `</style>` 等片段时整段静默丢弃

## 端点
| 路径 | 类型 | 说明 |
| --- | --- | --- |
| `GET /embed/badge/page/:wikidotId.svg?metric=rating\|wilson\|controversy\|votes\|trend` | SVG | Shields-style 徽章；`metric=trend` 读 `votingTimeSeriesCache` 末 90 天画 sparkline；`theme=mono` 使用 `currentColor` |
| `GET /embed/user-card/:wikidotId` | HTML | 对齐 `UserCard.vue` 字段；`breakdown=list\|radar`、`hideActivity`、`showCategories`、`css` |
| `GET /embed/user-history/:wikidotId` | HTML | 评分曲线 + 近 366 天活动热力图；`range=90d\|1y\|all`、`showTrend`、`showHeatmap`、`css` |

## 安全
- CSP: `default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data: https:; frame-ancestors *`
- 无脚本、无外部资源加载
- 内嵌 CSS 走关键字黑名单 + `url()` 协议白名单；不通过的整段丢弃（而非半拒绝）
- `/embed/*` 统一 120/min 每 IP rate limit

## Test plan
- [x] `npx tsc --noEmit` 通过；`npm run build` 产物完整
- [x] 真实数据库验证：
  - SCP-CN-2000 (`wikidotId=1306943399`) → rating badge `+4970`、wilson `0.977`、controversy `0.075`、trend sparkline 2.5KB
  - `theme=mono` 下 SVG 填色切换为 `currentColor`
  - User `ashausesall` (`wikidotId=1546989`) → user-card list/radar 两种模式、`hideActivity=1` 生效、`accent=ff6600` 写入 `--e-accent`
  - 合法 `?css=` 被 `<style data-origin="user">` 注入；含 `@import` 的 CSS 整段丢弃
  - user-history 渲染曲线 + 热力图；未知 wikidotId 返回 404
- [x] 响应头验证：CSP、`Content-Type`、`Cache-Control`、无 `X-Frame-Options`、rate-limit 头全部正确
- [ ] 上线后在测试分部站点实测 Wikidot `[[image]]` / `[[iframe]]` 嵌入渲染

## Wikidot 组件源码
使用示例与 `component:scpper-badge` / `component:scpper-user-card` / `component:scpper-user-history` 的完整 Wikidot 源码、以及分部 iframe allowlist 未放通时的 wdfiles frame.html 回退方案，见 `docs/wikidot-embeds.md`。