### PR TITLE
fix(embed): user-card formatDate 兼容 Redis 缓存反序列化

### DIFF
--- a/bff/src/web/utils/embed/templates/userCard.ts
+++ b/bff/src/web/utils/embed/templates/userCard.ts
@@ -22,11 +22,18 @@ function formatFloat(n: number, digits = 1): string {
   return Number.isFinite(n) ? n.toFixed(digits) : '—';
 }
 
-function formatDate(d: Date | null): string {
-  if (!d) return '—';
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const dd = String(d.getDate()).padStart(2, '0');
+/**
+ * Redis 缓存反序列化后 Date 会退化成 ISO 字符串，原版 `d.getFullYear` 直接抛
+ * `TypeError: d.getFullYear is not a function`，导致 /embed/user-card 在生产 500。
+ * 这里同时接受 Date / string / number / null，并对无效日期兜底到 '—'。
+ */
+function formatDate(d: Date | string | number | null | undefined): string {
+  if (d == null || d === '') return '—';
+  const date = d instanceof Date ? d : new Date(d);
+  if (Number.isNaN(date.getTime())) return '—';
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
   return `${y}-${m}-${dd}`;
 }
 


### PR DESCRIPTION
## Hotfix

#66 上线后 `/embed/user-card` 所有生产请求 500。

根因：Redis `cache.remember()` 把 `loadUserBasicByWikidotId` 返回的 Date 字段 JSON.stringify 到 Redis，后续 cache hit 时反序列化成 ISO 字符串，但 `formatDate(d: Date | null)` 直接调 `d.getFullYear()` 抛 `TypeError: d.getFullYear is not a function`。

## Summary

- `formatDate` 同时接受 `Date | string | number | null | undefined`，内部统一 `new Date()` 再取字段；`NaN` 直接回 `—`
- 其它模板（userHistory / badge）目前没有同类 Date 使用，已 grep 过

## Test plan
- [x] 本地用 `ENABLE_CACHE=true` 起 Redis-backed BFF，miss 首请和 hit 二请均 200，输出一致（`首次 2013-08-18`、`最近 2026-04-20`）
- [x] `npx tsc --noEmit` / `npm run build` 通过
- [ ] 部署后 curl `/embed/user-card/1546989` 返回 200