### PR TITLE
feat(embed): user-card 多视图重排与全站分位归一化

### DIFF
--- a/bff/src/web/routes/embed.ts
+++ b/bff/src/web/routes/embed.ts
@@ -17,7 +17,8 @@ import {
   loadUserBasicByWikidotId,
   loadUserCardStats,
   loadUserVotingSeries,
-  loadUserActivityHeatmap
+  loadUserActivityHeatmap,
+  loadCategoryBenchmarks
 } from '../utils/embed/userData.js';
 import {
   USER_CARD_BASE_CSS,
@@ -84,7 +85,7 @@ function sendEmbedNotFound(
   const baseCss = `
     * { box-sizing: border-box; }
     html, body { margin: 0; padding: 0; background: transparent; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", Roboto, sans-serif; color: var(--e-text-muted); font-size: 13px; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", Roboto, sans-serif; color: var(--e-fg-muted); font-size: 13px; }
     .e-empty-card { padding: 16px 20px; border: 1px dashed var(--e-border); border-radius: 12px; background: var(--e-surface); text-align: center; }
   `;
   sendEmbedHtml(res, {
@@ -297,10 +298,19 @@ export function embedRouter(pool: Pool, redis: RedisClientType | null) {
         return sendEmbedNotFound(res, themeOpts, '用户不存在或无统计数据');
       }
 
+      // 全站分类基准（用于雷达图归一化）；单独缓存 30 分钟避免每次读 LeaderboardCache
+      // 没有基准时传 null，renderRadar 会降级到"自身最高值"归一化
+      const benchmarks = await cache.remember(
+        'embed:category-benchmarks',
+        1800,
+        () => loadCategoryBenchmarks(readPool)
+      );
+
       const renderOpts: UserCardRenderOptions = {
         breakdown,
         hideActivity,
-        showCategories
+        showCategories,
+        benchmarks
       };
 
       const bodyHtml = renderUserCardBody(data.user, data.stats, renderOpts);

--- a/bff/src/web/utils/embed/templates/userCard.ts
+++ b/bff/src/web/utils/embed/templates/userCard.ts
@@ -1,9 +1,11 @@
-import type { UserBasic, UserCardStats } from '../userData.js';
+import type { UserBasic, UserCardStats, CategoryBenchmarksPayload, CategoryBenchmark } from '../userData.js';
 
 export interface UserCardRenderOptions {
   breakdown: 'list' | 'radar';
   hideActivity: boolean;
-  showCategories: string[];          // 要展示的 category key 列表；空数组=全部有数据的
+  showCategories: string[];
+  /** 全站分类基准（由 backend UserCategoryBenchmarksJob 预计算）。无则降级到自身最高值归一化。 */
+  benchmarks: CategoryBenchmarksPayload | null;
 }
 
 function esc(str: string | null | undefined): string {
@@ -18,15 +20,15 @@ function formatInt(n: number): string {
   return Number.isFinite(n) ? Math.round(n).toLocaleString('zh-CN') : '—';
 }
 
-function formatFloat(n: number, digits = 1): string {
-  return Number.isFinite(n) ? n.toFixed(digits) : '—';
+function avatarLetter(displayName: string, wikidotId: number): string {
+  const trimmed = (displayName ?? '').trim();
+  if (trimmed.length > 0) {
+    return Array.from(trimmed)[0].toUpperCase();
+  }
+  const s = String(wikidotId);
+  return s[s.length - 1] ?? '·';
 }
 
-/**
- * Redis 缓存反序列化后 Date 会退化成 ISO 字符串，原版 `d.getFullYear` 直接抛
- * `TypeError: d.getFullYear is not a function`，导致 /embed/user-card 在生产 500。
- * 这里同时接受 Date / string / number / null，并对无效日期兜底到 '—'。
- */
 function formatDate(d: Date | string | number | null | undefined): string {
   if (d == null || d === '') return '—';
   const date = d instanceof Date ? d : new Date(d);
@@ -37,118 +39,264 @@ function formatDate(d: Date | string | number | null | undefined): string {
   return `${y}-${m}-${dd}`;
 }
 
+// ─────────────────────────────────────────────────────────────────
+// 归一化：与前端 UserCategoryRadarChart.vue 一致的三档算法（v3 分段 asinh /
+// v2 asinh / v1 线性），始终把 rating 映射到 0-100 的"全站百分位"分数。
+// 语义锚点：p50 = 50 分（站点中位）、p95 = 90 分、p99 = 100 分。
+// 把"雷达顶到外圈"=  全站 p99 水平；"圆心"=  低于 p05 或未参与。
+// ─────────────────────────────────────────────────────────────────
+
+function piecewiseAsinhMap(v: number, b: CategoryBenchmark): number {
+  const clamp = (x: number) => Math.max(0, Math.min(100, x));
+  const t = Math.max(1e-6, Number(b.tau) || 1);
+  const g = (x: number) => Math.asinh(Number(x || 0) / t);
+  const y = g(v);
+  const y05 = g(b.p05Rating || 0);
+  const y50 = g(b.p50Rating || 0);
+  const y95 = g(b.p95Rating || 1);
+  const y99 = g(b.p99Rating || (b.p95Rating || 1) + 1e-6);
+  const safe = (a: number, c: number) => Math.abs(c - a) < 1e-6 ? 1e-6 : (c - a);
+  if (v <= b.p50Rating) return clamp(50 * (y - y05) / safe(y05, y50));
+  if (v <= b.p95Rating) return clamp(50 + 40 * (y - y50) / safe(y50, y95));
+  const beta = 0.7;
+  const tail = Math.pow((y - y95) / safe(y95, y99), beta);
+  return clamp(90 + 10 * tail);
+}
+
+function asinhMap(v: number, p50: number, p95: number, tau: number): number {
+  const t = Math.max(1e-6, Number(tau) || 0);
+  const g = (x: number) => Math.asinh(Number(x || 0) / t);
+  const denom = g(p95) - g(p50);
+  if (!Number.isFinite(denom) || Math.abs(denom) < 1e-6) return 50;
+  return Math.min(100, Math.max(0, 50 + 50 * (g(v) - g(p50)) / denom));
+}
+
+function linearMap(v: number, p50: number, p95: number): number {
+  const denom = p95 - p50;
+  if (!Number.isFinite(denom) || Math.abs(denom) < 1e-6) return 50;
+  return Math.min(100, Math.max(0, 50 + 50 * (v - p50) / denom));
+}
+
+function scoreFromBenchmark(
+  rating: number,
+  b: CategoryBenchmark | undefined,
+  method: CategoryBenchmarksPayload['method']
+): number {
+  if (!b) return 0;
+  if (method === 'asinh_piecewise_p50_p95_p99_v3') return piecewiseAsinhMap(rating, b);
+  if (method === 'asinh_p50_p95_v2') return asinhMap(rating, b.p50Rating || 0, b.p95Rating || 1, b.tau || 1);
+  return linearMap(rating, b.p50Rating || 0, b.p95Rating || 1);
+}
+
 /**
- * 6 边雷达图。用用户自身各分类评分中的最大值作为满格，避免无作品的用户看到空图。
- * 每个顶点上再绘一个小点，突出非零分类。
+ * 雷达图。归一化口径：
+ *   - 若提供 benchmarks → 用 piecewiseAsinh 把每分类 rating 映射到 0-100 分（全站百分位），
+ *     半径 = score/100 × radius。跨用户可比，"顶到外圈"恒等于全站 p99 水平。
+ *   - 若无 benchmarks → 降级到自身最高值 sqrt 归一化（仅用于开发环境或 benchmarks job 未运行时）。
+ *
+ * 零值/未参与（rating==0 或 rank==null）：不算"做得差"。轴线画虚线弱化，
+ * 数据 polygon 跳过此顶点直接连到相邻有效点。
  */
-function renderRadar(categories: UserCardStats['categories']): string {
+function renderRadar(
+  categories: UserCardStats['categories'],
+  benchmarks: CategoryBenchmarksPayload | null
+): string {
   const size = 220;
   const cx = size / 2;
   const cy = size / 2;
-  const radius = 78;
+  const radius = 66;
   const n = categories.length;
   if (n < 3) return '';
 
-  const maxRating = Math.max(...categories.map(c => c.rating), 1);
   const angles = categories.map((_, i) => (-Math.PI / 2) + (i * 2 * Math.PI) / n);
+  const isActive = (c: UserCardStats['categories'][number]) => c.rating > 0 && c.rank != null;
 
-  const axisPoints = angles.map(a => {
-    const x = cx + radius * Math.cos(a);
-    const y = cy + radius * Math.sin(a);
-    return { x, y };
+  const useBenchmark = !!benchmarks;
+  const method = benchmarks?.method ?? 'asinh_piecewise_p50_p95_p99_v3';
+
+  // 计算每顶点的归一化 score（0-1）
+  const normalized = categories.map(c => {
+    if (!isActive(c)) return 0;
+    if (useBenchmark) {
+      const b = benchmarks!.benchmarks[c.key];
+      return scoreFromBenchmark(c.rating, b, method) / 100;
+    }
+    // fallback：自身最高值 sqrt 归一化
+    const selfMax = Math.max(...categories.map(x => x.rating), 1);
+    return Math.sqrt(c.rating) / Math.sqrt(selfMax);
   });
 
+  // 网格圈
   const rings = [0.25, 0.5, 0.75, 1].map(frac => {
-    const points = angles.map(a => {
+    const pts = angles.map(a => {
       const x = cx + radius * frac * Math.cos(a);
       const y = cy + radius * frac * Math.sin(a);
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     }).join(' ');
-    return `<polygon points="${points}" fill="none" stroke="var(--e-border)" stroke-width="1"/>`;
+    const klass = frac === 0.5 && useBenchmark ? 'radar-ring ref-p50' : 'radar-ring';
+    return `<polygon class="${klass}" points="${pts}" />`;
   }).join('');
 
-  const axisLines = axisPoints.map(({ x, y }) =>
-    `<line x1="${cx}" y1="${cy}" x2="${x.toFixed(1)}" y2="${y.toFixed(1)}" stroke="var(--e-border)" stroke-width="1"/>`
-  ).join('');
+  // 轴线
+  const axisLines = angles.map((a, i) => {
+    const x = cx + radius * Math.cos(a);
+    const y = cy + radius * Math.sin(a);
+    const klass = isActive(categories[i]) ? 'radar-axis' : 'radar-axis inactive';
+    return `<line class="${klass}" x1="${cx}" y1="${cy}" x2="${x.toFixed(1)}" y2="${y.toFixed(1)}"/>`;
+  }).join('');
 
-  const dataPoints = categories.map((c, i) => {
-    const r = (Math.max(0, c.rating) / maxRating) * radius;
-    const a = angles[i];
-    return {
-      x: cx + r * Math.cos(a),
-      y: cy + r * Math.sin(a),
-      hasData: c.rating > 0
-    };
-  });
+  // 有效顶点集合（跳过未参与）
+  const activePoints = categories
+    .map((c, i) => ({ c, i, angle: angles[i], r: normalized[i] * radius }))
+    .filter(({ c }) => isActive(c))
+    .map(({ angle, r }) => ({ x: cx + r * Math.cos(angle), y: cy + r * Math.sin(angle) }));
 
-  const dataPolygon = dataPoints.map(p => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+  let dataShape = '';
+  if (activePoints.length >= 3) {
+    const pts = activePoints.map(p => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+    dataShape = `<polygon class="radar-data" points="${pts}" />`;
+  } else if (activePoints.length === 2) {
+    const [a, b] = activePoints;
+    dataShape = `<line class="radar-data-edge" x1="${a.x.toFixed(1)}" y1="${a.y.toFixed(1)}" x2="${b.x.toFixed(1)}" y2="${b.y.toFixed(1)}" />`;
+  } else if (activePoints.length === 1) {
+    const a = activePoints[0];
+    dataShape = `<circle class="radar-data-dot" cx="${a.x.toFixed(1)}" cy="${a.y.toFixed(1)}" r="3" />`;
+  }
 
-  const markers = dataPoints.map((p, i) =>
-    p.hasData
-      ? `<circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="3" fill="var(--e-accent)"/>`
-      : ''
-  ).join('');
+  const markers = categories.map((c, i) => {
+    if (!isActive(c)) return '';
+    const r = normalized[i] * radius;
+    const x = cx + r * Math.cos(angles[i]);
+    const y = cy + r * Math.sin(angles[i]);
+    return `<circle class="radar-dot" cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="2.5"/>`;
+  }).join('');
 
   const labels = categories.map((c, i) => {
     const a = angles[i];
-    const lx = cx + (radius + 16) * Math.cos(a);
-    const ly = cy + (radius + 16) * Math.sin(a);
+    const lx = cx + (radius + 13) * Math.cos(a);
+    const ly = cy + (radius + 13) * Math.sin(a);
     const anchor = Math.abs(Math.cos(a)) < 0.25 ? 'middle' : (Math.cos(a) > 0 ? 'start' : 'end');
-    const dy = Math.sin(a) > 0.5 ? 10 : (Math.sin(a) < -0.5 ? -2 : 4);
-    return `<text x="${lx.toFixed(1)}" y="${(ly + dy).toFixed(1)}" text-anchor="${anchor}" class="radar-label">${esc(c.label)}</text>`;
+    const dy = Math.sin(a) > 0.5 ? 9 : (Math.sin(a) < -0.5 ? -2 : 4);
+    const inactive = !isActive(c);
+    const labelClass = inactive ? 'radar-label inactive' : 'radar-label';
+    return `<text class="${labelClass}" x="${lx.toFixed(1)}" y="${(ly + dy).toFixed(1)}" text-anchor="${anchor}">${esc(c.label)}</text>`;
   }).join('');
 
-  return `<svg viewBox="0 0 ${size} ${size}" class="radar-svg" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+  // p50/p99 参考标注，只在用 benchmark 时显示
+  const refNotes = useBenchmark ? `
+    <text class="radar-ref" x="${cx}" y="${(cy - radius * 0.5 - 3).toFixed(1)}" text-anchor="middle">p50</text>
+    <text class="radar-ref radar-ref-outer" x="${cx}" y="${(cy - radius - 5).toFixed(1)}" text-anchor="middle">p99</text>
+  ` : '';
+
+  return `<svg viewBox="0 0 ${size} ${size}" class="radar-svg" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
     <g class="radar-grid">${rings}${axisLines}</g>
-    <polygon class="radar-data" points="${dataPolygon}" />
+    ${dataShape}
     ${markers}
     ${labels}
+    ${refNotes}
   </svg>`;
 }
 
-function renderCategoryList(categories: UserCardStats['categories'], keep: Set<string>): string {
-  const visible = categories.filter(c => keep.size === 0 ? c.pageCount > 0 || c.rating > 0 : keep.has(c.key));
-  if (visible.length === 0) {
+function renderCategoryList(categories: UserCardStats['categories']): string {
+  if (categories.length === 0) {
     return `<div class="e-empty">暂无分类数据</div>`;
   }
-  return `<ul class="cat-list">${visible.map(c => `
-    <li class="cat-row">
+  return `<ul class="cat-list">${categories.map(c => {
+    const inactiveClass = (c.rating <= 0 || c.rank == null) ? ' is-inactive' : '';
+    return `
+    <li class="cat-row${inactiveClass}">
       <span class="cat-label">${esc(c.label)}</span>
       <span class="cat-rank">${c.rank != null ? `#${formatInt(c.rank)}` : '—'}</span>
-      <span class="cat-rating">${formatInt(c.rating)} pts</span>
-      <span class="cat-count">${formatInt(c.pageCount)} 作</span>
-    </li>`).join('')}</ul>`;
+      <span class="cat-meta">${formatInt(c.rating)} · ${formatInt(c.pageCount)} 作品</span>
+    </li>`;
+  }).join('')}</ul>`;
 }
 
 export const USER_CARD_BASE_CSS = `
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; background: transparent; }
-  body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", Roboto, sans-serif; color: var(--e-text); font-size: 13px; line-height: 1.45; -webkit-font-smoothing: antialiased; }
-  .e-card { background: var(--e-bg); border: 1px solid var(--e-border); border-radius: 14px; padding: 18px 20px; box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.02); display: flex; flex-direction: column; gap: 16px; }
-  .e-header { display: flex; align-items: center; gap: 14px; position: relative; }
-  .e-avatar { width: 56px; height: 56px; border-radius: 50%; overflow: hidden; background: var(--e-surface) center/cover no-repeat; flex-shrink: 0; box-shadow: inset 0 0 0 1px var(--e-border); position: relative; }
-  .e-name-block { min-width: 0; flex: 1; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", Roboto, sans-serif; color: var(--e-fg); font-size: 13px; line-height: 1.45; -webkit-font-smoothing: antialiased; }
+
+  .e-card { background: var(--e-bg); border: 1px solid var(--e-border); border-radius: 14px; padding: 18px 20px; box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.02); display: flex; flex-direction: column; gap: 14px; }
+
+  .breakdown-mode { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; overflow: hidden; clip-path: inset(50%); white-space: nowrap; border: 0; }
+
+  /* Header —— capsule 搬到 rank 正下方、subtitle 右侧（header 右端纵向堆叠）。
+     这样 body 里的两列（stat-grid / breakdown）都从 y=0 开始，总评分 tile 顶边和
+     SCP 列表行顶边天然对齐。 */
+  .e-header { display: flex; align-items: flex-start; gap: 14px; }
+  .e-avatar { position: relative; width: 56px; height: 56px; border-radius: 50%; overflow: hidden; flex-shrink: 0; border: 1px solid var(--e-border); background: var(--e-accent-soft); display: flex; align-items: center; justify-content: center; }
+  .e-avatar-letter { font-size: 22px; font-weight: 700; color: var(--e-accent); line-height: 1; user-select: none; }
+  .e-avatar-image { position: absolute; inset: 0; background-position: center; background-size: cover; background-repeat: no-repeat; }
+  .e-name-block { min-width: 0; flex: 1; padding-top: 2px; }
   .e-name { font-size: 16px; font-weight: 600; color: var(--e-accent); display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .e-subtitle { font-size: 11px; color: var(--e-text-subtle); margin-top: 2px; display: flex; gap: 6px; flex-wrap: wrap; }
-  .e-subtitle span:not(:last-child)::after { content: '·'; margin-left: 6px; color: var(--e-text-subtle); }
-  .e-rank { position: absolute; top: 0; right: 0; color: var(--e-accent); font-weight: 700; font-size: 15px; font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
-  .stat-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; }
-  .stat-tile { background: var(--e-surface); border: 1px solid var(--e-border); border-radius: 8px; padding: 8px 10px; text-align: center; }
-  .stat-tile .lbl { font-size: 10px; color: var(--e-text-muted); margin-bottom: 2px; letter-spacing: 0.02em; }
-  .stat-tile .val { font-size: 14px; font-weight: 600; color: var(--e-text); font-variant-numeric: tabular-nums; }
-  .section-title { font-size: 11px; color: var(--e-text-muted); font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 6px; }
-  .cat-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
-  .cat-row { display: grid; grid-template-columns: 4em 3em 1fr auto; gap: 10px; align-items: baseline; padding: 6px 10px; background: var(--e-surface); border: 1px solid var(--e-border); border-radius: 6px; font-size: 12px; }
-  .cat-label { color: var(--e-text); font-weight: 500; }
-  .cat-rank { color: var(--e-accent); font-weight: 600; font-variant-numeric: tabular-nums; }
-  .cat-rating { color: var(--e-text-muted); font-variant-numeric: tabular-nums; }
-  .cat-count { color: var(--e-text-subtle); font-variant-numeric: tabular-nums; font-size: 11px; }
-  .radar-wrap { display: flex; justify-content: center; align-items: center; height: 230px; }
-  .radar-svg { max-width: 280px; }
-  .radar-grid { stroke: var(--e-border); fill: none; }
+  .e-subtitle { font-size: 11px; color: var(--e-fg-subtle); margin-top: 3px; display: flex; gap: 12px; flex-wrap: wrap; }
+
+  .e-header-side { display: flex; flex-direction: column; align-items: flex-end; gap: 8px; flex-shrink: 0; min-height: 56px; justify-content: space-between; }
+  .e-rank { color: var(--e-accent); font-weight: 700; font-variant-numeric: tabular-nums; line-height: 1; display: inline-flex; align-items: baseline; gap: 3px; }
+  .e-rank-prefix { font-size: 10px; color: var(--e-fg-muted); font-weight: 500; letter-spacing: 0.02em; }
+  .e-rank-num { font-size: 15px; letter-spacing: -0.01em; }
+
+  /* 两列主体：stretch 让两列等高；两列第一行 y=0 对齐（capsule 已搬走） */
+  .e-body { display: grid; grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.15fr); gap: 16px; align-items: stretch; }
+  @media (max-width: 480px) {
+    .e-body { grid-template-columns: minmax(0, 1fr); gap: 14px; }
+  }
+
+  /* stat-grid 4 tile 2×2 等大方阵：总评分 | 作品 / 投出 UpVote | 投出 DownVote。
+     align-content: stretch + grid-template-rows: 1fr 1fr 让每行被拉伸到 stat-grid
+     总高（总高 = breakdown 列高度 via e-body align-items: stretch）。 */
+  .stat-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-rows: 1fr 1fr; gap: 8px; align-content: stretch; }
+  .stat-tile { background: var(--e-surface); border: 1px solid var(--e-border); border-radius: 8px; padding: 8px 10px; text-align: center; display: flex; flex-direction: column; justify-content: center; gap: 2px; min-height: 0; }
+  .stat-tile .lbl { font-size: 10px; color: var(--e-fg-muted); letter-spacing: 0.04em; }
+  .stat-tile .val { font-size: 15px; font-weight: 600; color: var(--e-fg); font-variant-numeric: tabular-nums; }
+
+  /* Breakdown：capsule 搬到 header 后，这里只剩 stage */
+  .breakdown { display: flex; flex-direction: column; min-width: 0; height: 100%; }
+  .mode-tabs { display: inline-flex; background: var(--e-surface); border: 1px solid var(--e-border); border-radius: 999px; padding: 2px; gap: 2px; }
+  .mode-tab { font-size: 10.5px; line-height: 1; padding: 4px 10px; border-radius: 999px; color: var(--e-fg-muted); cursor: pointer; user-select: none; letter-spacing: 0.02em; transition: color 120ms ease, background-color 120ms ease; }
+  .mode-tab:hover { color: var(--e-fg); }
+  .mode-tab.disabled { color: var(--e-fg-subtle); cursor: not-allowed; opacity: 0.6; }
+
+  /* Stage：list 走正常流决定 stage 高度；radar absolute 覆盖在 stage 上，不参与 layout。
+     这样 stage 高度 = list 自然高度，切换不抖动，radar SVG 被 stage 反向约束不会自撑成大方块。 */
+  .breakdown-stage { position: relative; flex: 1; min-height: 0; }
+  .panel-list { position: relative; visibility: hidden; }
+  .panel-radar { position: absolute; inset: 0; visibility: hidden; }
+  /* radio 在 .e-card 直接子，选择器穿过 .e-body / .e-header 触达 panel 与 tab */
+  #bk-mode-list:checked ~ .e-body .panel-list { visibility: visible; }
+  #bk-mode-radar:checked ~ .e-body .panel-radar { visibility: visible; }
+  #bk-mode-list:checked ~ .e-header .mode-tab[for="bk-mode-list"],
+  #bk-mode-radar:checked ~ .e-header .mode-tab[for="bk-mode-radar"] {
+    background: var(--e-bg); color: var(--e-accent); box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+  }
+
+  /* 列表 */
+  .cat-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 5px; }
+  .cat-row { display: grid; grid-template-columns: 5em 3em 1fr; gap: 10px; align-items: baseline; padding: 6px 10px; background: var(--e-surface); border: 1px solid var(--e-border); border-radius: 6px; font-size: 12px; }
+  .cat-row.is-inactive { opacity: 0.55; }
+  .cat-label { color: var(--e-fg); font-weight: 500; }
+  .cat-rank { color: var(--e-accent); font-weight: 600; font-variant-numeric: tabular-nums; text-align: right; }
+  .cat-row.is-inactive .cat-rank { color: var(--e-fg-subtle); }
+  .cat-meta { color: var(--e-fg-muted); font-variant-numeric: tabular-nums; text-align: right; font-size: 11px; }
+
+  /* 雷达 —— SVG 随 stage 高度缩放，而不是按 viewBox 1:1 自撑；这样 stage 高度由
+     list panel 的自然高决定，radar 跟随，切换不抖动、也不出现下部留白。 */
+  .panel-radar { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; }
+  .radar-svg { width: auto; height: 100%; max-width: 100%; max-height: 100%; overflow: visible; }
+  .radar-ring { fill: none; stroke: var(--e-border); stroke-width: 1; }
+  .radar-ring.ref-p50 { stroke-dasharray: 3 3; stroke: var(--e-border-strong); }
+  .radar-axis { stroke: var(--e-border); stroke-width: 1; }
+  .radar-axis.inactive { stroke-dasharray: 3 3; opacity: 0.55; }
   .radar-data { fill: var(--e-accent-soft); stroke: var(--e-accent); stroke-width: 1.5; }
-  .radar-label { fill: var(--e-text-muted); font-size: 10px; font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif; }
-  .e-empty { color: var(--e-text-subtle); font-size: 11px; text-align: center; padding: 12px 0; }
+  .radar-data-edge { stroke: var(--e-accent); stroke-width: 1.5; fill: none; }
+  .radar-data-dot { fill: var(--e-accent); }
+  .radar-dot { fill: var(--e-accent); }
+  .radar-label { fill: var(--e-fg-muted); font-size: 9px; font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif; }
+  .radar-label.inactive { fill: var(--e-fg-subtle); opacity: 0.55; }
+  .radar-ref { fill: var(--e-fg-subtle); font-size: 7.5px; font-family: inherit; font-variant-numeric: tabular-nums; letter-spacing: 0.02em; }
+
+  .e-empty { color: var(--e-fg-subtle); font-size: 11px; text-align: center; padding: 12px 0; }
 `;
 
 export function renderUserCardBody(
@@ -159,54 +307,74 @@ export function renderUserCardBody(
   const wikidotId = user.wikidotId;
   const displayName = user.displayName || `User ${wikidotId}`;
 
-  const activityLine = opts.hideActivity
-    ? ''
-    : `<span>首次 ${esc(formatDate(user.firstActivityAt))}</span><span>最近 ${esc(formatDate(user.lastActivityAt))}</span>`;
+  const activityParts = opts.hideActivity
+    ? []
+    : [`首次 ${formatDate(user.firstActivityAt)}`, `最近 ${formatDate(user.lastActivityAt)}`];
 
-  const subtitleParts = [`<span>ID ${wikidotId}</span>`];
-  if (activityLine) subtitleParts.push(activityLine);
-
-  const meanRating = Number.isFinite(stats.meanRating) && stats.meanRating > 0
-    ? stats.meanRating
-    : (stats.pageCount > 0 ? stats.totalRating / stats.pageCount : 0);
+  const subtitleParts = [`ID ${wikidotId}`, ...activityParts];
 
   const rank = stats.rank != null
-    ? `<div class="e-rank">#${formatInt(stats.rank)}</div>`
+    ? `<div class="e-rank"><span class="e-rank-prefix">全站</span><span class="e-rank-num">#${formatInt(stats.rank)}</span></div>`
     : '';
 
   const keep = new Set(opts.showCategories.filter(Boolean));
-  const radarCategories = stats.categories.filter(c => keep.size === 0 ? true : keep.has(c.key));
-  // 雷达图最少需要 3 个顶点才有意义；过滤后不足时退回列表渲染，避免出现空白区
-  const effectiveBreakdown: 'list' | 'radar' =
-    opts.breakdown === 'radar' && radarCategories.length >= 3 ? 'radar' : 'list';
-  const breakdownHtml = effectiveBreakdown === 'radar'
-    ? `<div class="radar-wrap">${renderRadar(radarCategories)}</div>`
-    : renderCategoryList(stats.categories, keep);
+  const sharedCategories = keep.size === 0
+    ? stats.categories
+    : stats.categories.filter(c => keep.has(c.key));
 
-  // 用 background-image 承载头像；img 元素加载失败会显示浏览器默认的 broken-image 图标，
-  // 而 CSP `script-src 'none'` 下 <img onerror> 不生效，因此直接用背景图 + aria-label 承担语义。
+  const radarAvailable = sharedCategories.length >= 3;
+  const initialMode: 'list' | 'radar' =
+    opts.breakdown === 'radar' && radarAvailable ? 'radar' : 'list';
+
+  const listHtml = renderCategoryList(sharedCategories);
+  const radarHtml = radarAvailable ? renderRadar(sharedCategories, opts.benchmarks) : '';
+
+  const letter = esc(avatarLetter(displayName, wikidotId));
   const avatarStyle = `background-image: url(/api/avatar/${wikidotId})`;
+
+  const listChecked = initialMode === 'list' ? 'checked' : '';
+  const radarChecked = initialMode === 'radar' ? 'checked' : '';
+
+  const radarTab = radarAvailable
+    ? `<label class="mode-tab" for="bk-mode-radar">雷达</label>`
+    : `<span class="mode-tab disabled" title="分类不足，无法绘制雷达图">雷达</span>`;
+
   return `<div class="e-card">
+    <input type="radio" name="bk-mode" id="bk-mode-list" class="breakdown-mode" ${listChecked}>
+    <input type="radio" name="bk-mode" id="bk-mode-radar" class="breakdown-mode" ${radarChecked} ${radarAvailable ? '' : 'disabled'}>
+
     <header class="e-header">
-      <div class="e-avatar" role="img" aria-label="${esc(displayName)}" style="${avatarStyle}"></div>
+      <div class="e-avatar" role="img" aria-label="${esc(displayName)}">
+        <span class="e-avatar-letter" aria-hidden="true">${letter}</span>
+        <div class="e-avatar-image" style="${avatarStyle}"></div>
+      </div>
       <div class="e-name-block">
         <span class="e-name">${esc(displayName)}</span>
-        <div class="e-subtitle">${subtitleParts.join('')}</div>
+        <div class="e-subtitle">${subtitleParts.map(p => `<span>${esc(p)}</span>`).join('')}</div>
       </div>
-      ${rank}
+      <div class="e-header-side">
+        ${rank}
+        <div class="mode-tabs" role="group" aria-label="分类表现视图">
+          <label class="mode-tab" for="bk-mode-list">列表</label>
+          ${radarTab}
+        </div>
+      </div>
     </header>
 
-    <section class="stat-grid">
-      <div class="stat-tile"><div class="lbl">总评分</div><div class="val">${formatInt(stats.totalRating)}</div></div>
-      <div class="stat-tile"><div class="lbl">平均分</div><div class="val">${formatFloat(meanRating, 1)}</div></div>
-      <div class="stat-tile"><div class="lbl">作品</div><div class="val">${formatInt(stats.pageCount)}</div></div>
-      <div class="stat-tile"><div class="lbl">支持</div><div class="val">${formatInt(stats.votesUp)}</div></div>
-      <div class="stat-tile"><div class="lbl">反对</div><div class="val">${formatInt(stats.votesDown)}</div></div>
-    </section>
+    <div class="e-body">
+      <section class="stat-grid" aria-label="数值概览">
+        <div class="stat-tile"><div class="lbl">总评分</div><div class="val">${formatInt(stats.totalRating)}</div></div>
+        <div class="stat-tile"><div class="lbl">作品</div><div class="val">${formatInt(stats.pageCount)}</div></div>
+        <div class="stat-tile"><div class="lbl">投出 UpVote</div><div class="val">${formatInt(stats.votesUp)}</div></div>
+        <div class="stat-tile"><div class="lbl">投出 DownVote</div><div class="val">${formatInt(stats.votesDown)}</div></div>
+      </section>
 
-    <section>
-      <div class="section-title">分类表现</div>
-      ${breakdownHtml}
-    </section>
+      <section class="breakdown" aria-label="分类表现">
+        <div class="breakdown-stage">
+          <div class="breakdown-panel panel-list">${listHtml}</div>
+          ${radarAvailable ? `<div class="breakdown-panel panel-radar">${radarHtml}</div>` : ''}
+        </div>
+      </section>
+    </div>
   </div>`;
 }

--- a/bff/src/web/utils/embed/templates/userHistory.ts
+++ b/bff/src/web/utils/embed/templates/userHistory.ts
@@ -220,37 +220,37 @@ function renderHeatmap(dayMap: Map<string, number>): string {
 export const USER_HISTORY_BASE_CSS = `
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; background: transparent; }
-  body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", Roboto, sans-serif; color: var(--e-text); font-size: 13px; line-height: 1.45; -webkit-font-smoothing: antialiased; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", Roboto, sans-serif; color: var(--e-fg); font-size: 13px; line-height: 1.45; -webkit-font-smoothing: antialiased; }
   .e-card { background: var(--e-bg); border: 1px solid var(--e-border); border-radius: 14px; padding: 18px 20px; box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.02); display: flex; flex-direction: column; gap: 18px; }
   .e-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-  .e-title { font-size: 15px; font-weight: 600; color: var(--e-text); }
+  .e-title { font-size: 15px; font-weight: 600; color: var(--e-fg); }
   .e-name-inline { color: var(--e-accent); font-weight: 600; }
-  .e-sub { color: var(--e-text-subtle); font-size: 11px; }
-  .section-title { font-size: 11px; color: var(--e-text-muted); font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 8px; }
+  .e-sub { color: var(--e-fg-subtle); font-size: 11px; }
+  .section-title { font-size: 11px; color: var(--e-fg-muted); font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 8px; }
   .chart-wrap { background: var(--e-surface); border: 1px solid var(--e-border); border-radius: 8px; padding: 10px; }
   .chart-svg { display: block; width: 100%; height: auto; }
   .chart-grid line { stroke: var(--e-border); stroke-dasharray: 2 3; }
   .chart-area { fill: var(--e-accent-soft); }
   .chart-line { fill: none; stroke: var(--e-accent); stroke-width: 1.8; stroke-linejoin: round; }
-  .chart-axis-y text, .chart-axis-x text { fill: var(--e-text-muted); font-size: 10px; font-family: inherit; font-variant-numeric: tabular-nums; }
-  .chart-empty { color: var(--e-text-subtle); text-align: center; padding: 24px 0; }
+  .chart-axis-y text, .chart-axis-x text { fill: var(--e-fg-muted); font-size: 10px; font-family: inherit; font-variant-numeric: tabular-nums; }
+  .chart-empty { color: var(--e-fg-subtle); text-align: center; padding: 24px 0; }
   .hm-wrap { background: var(--e-surface); border: 1px solid var(--e-border); border-radius: 8px; padding: 16px 12px 12px; }
   .hm-svg { display: block; }
-  .hm-months text { fill: var(--e-text-subtle); font-size: 9px; font-family: inherit; }
+  .hm-months text { fill: var(--e-fg-subtle); font-size: 9px; font-family: inherit; }
   .hm-cell { fill: var(--e-border); }
   .hm-cell.lvl-0 { fill: var(--e-border); fill-opacity: 0.5; }
   .hm-cell.lvl-1 { fill: color-mix(in srgb, var(--e-accent) 28%, var(--e-border)); }
   .hm-cell.lvl-2 { fill: color-mix(in srgb, var(--e-accent) 52%, var(--e-border)); }
   .hm-cell.lvl-3 { fill: color-mix(in srgb, var(--e-accent) 76%, var(--e-border)); }
   .hm-cell.lvl-4 { fill: var(--e-accent); }
-  .hm-legend { display: flex; align-items: center; gap: 6px; color: var(--e-text-muted); font-size: 10px; margin-top: 8px; justify-content: flex-end; }
+  .hm-legend { display: flex; align-items: center; gap: 6px; color: var(--e-fg-muted); font-size: 10px; margin-top: 8px; justify-content: flex-end; }
   .hm-chip { display: inline-block; width: 10px; height: 10px; border-radius: 2px; }
   .hm-chip.lvl-0 { background: var(--e-border); opacity: 0.5; }
   .hm-chip.lvl-1 { background: color-mix(in srgb, var(--e-accent) 28%, var(--e-border)); }
   .hm-chip.lvl-2 { background: color-mix(in srgb, var(--e-accent) 52%, var(--e-border)); }
   .hm-chip.lvl-3 { background: color-mix(in srgb, var(--e-accent) 76%, var(--e-border)); }
   .hm-chip.lvl-4 { background: var(--e-accent); }
-  .e-empty { color: var(--e-text-subtle); font-size: 11px; text-align: center; padding: 12px 0; }
+  .e-empty { color: var(--e-fg-subtle); font-size: 11px; text-align: center; padding: 12px 0; }
 `;
 
 export function renderUserHistoryBody(

--- a/bff/src/web/utils/embed/theme.ts
+++ b/bff/src/web/utils/embed/theme.ts
@@ -26,35 +26,54 @@ export function resolveTheme(rawTheme: unknown, rawAccent: unknown): ResolvedThe
 }
 
 /**
- * 注：light / dark 变量名和前端 `:root` / `.dark` 上定义的设计系统同源，
- * 方便用户的自定义 CSS 用同一套变量覆写。
+ * 设计 token 统一命名规则：
+ *   表面：--e-bg / --e-surface / --e-surface-raised
+ *   边框：--e-border / --e-border-strong
+ *   文字：--e-fg / --e-fg-muted / --e-fg-subtle
+ *   品牌：--e-accent / --e-accent-soft / --e-accent-strong
+ *   语义：--e-good / --e-warn / --e-bad
+ *
+ * 旧命名（--e-text / --e-text-muted / --e-text-subtle）作为向后兼容 alias 保留，
+ * 方便历史 CSS 覆写仍然生效；新模板请只使用新命名。
  */
 export function buildThemeCss({ theme, accent }: ResolvedTheme): string {
   const lightVars = `
     --e-bg: #ffffff;
     --e-surface: #f7f7f8;
+    --e-surface-raised: #eef0f4;
     --e-border: #e5e7eb;
-    --e-text: #111827;
-    --e-text-muted: #6b7280;
-    --e-text-subtle: #9ca3af;
+    --e-border-strong: #d1d5db;
+    --e-fg: #111827;
+    --e-fg-muted: #6b7280;
+    --e-fg-subtle: #9ca3af;
     --e-accent: ${accent};
     --e-accent-soft: color-mix(in srgb, ${accent} 16%, transparent);
+    --e-accent-strong: color-mix(in srgb, ${accent} 75%, #000);
     --e-good: #059669;
     --e-warn: #d97706;
     --e-bad: #dc2626;
+    --e-text: var(--e-fg);
+    --e-text-muted: var(--e-fg-muted);
+    --e-text-subtle: var(--e-fg-subtle);
   `;
   const darkVars = `
     --e-bg: #0b0b0f;
     --e-surface: #16161c;
+    --e-surface-raised: #1e1e26;
     --e-border: #26262e;
-    --e-text: #f5f5f5;
-    --e-text-muted: #a1a1aa;
-    --e-text-subtle: #71717a;
+    --e-border-strong: #353540;
+    --e-fg: #f5f5f5;
+    --e-fg-muted: #a1a1aa;
+    --e-fg-subtle: #71717a;
     --e-accent: ${accent};
     --e-accent-soft: color-mix(in srgb, ${accent} 22%, transparent);
+    --e-accent-strong: color-mix(in srgb, ${accent} 80%, #ffffff);
     --e-good: #34d399;
     --e-warn: #fbbf24;
     --e-bad: #f87171;
+    --e-text: var(--e-fg);
+    --e-text-muted: var(--e-fg-muted);
+    --e-text-subtle: var(--e-fg-subtle);
   `;
 
   if (theme === 'light') return `:root { ${lightVars} }`;

--- a/bff/src/web/utils/embed/userData.ts
+++ b/bff/src/web/utils/embed/userData.ts
@@ -27,6 +27,22 @@ export interface UserCardStats {
   }>;
 }
 
+export interface CategoryBenchmark {
+  p05Rating: number;
+  p50Rating: number;
+  p95Rating: number;
+  p99Rating: number;
+  avgRating: number;
+  tau?: number;
+  nAuthors: number;
+}
+
+export interface CategoryBenchmarksPayload {
+  asOf: string;
+  method: 'asinh_piecewise_p50_p95_p99_v3' | 'asinh_p50_p95_v2' | 'legacy_linear_p50_p95';
+  benchmarks: Record<string, CategoryBenchmark>;
+}
+
 export interface VotingSeries {
   dates: string[];
   dailyUpvotes: number[];
@@ -41,7 +57,7 @@ const CATEGORY_MAP: Array<{ key: string; label: string; rankField: string; ratin
   { key: 'story', label: '故事', rankField: 'storyRank', ratingField: 'storyRating', countField: 'storyPageCount' },
   { key: 'translation', label: '翻译', rankField: 'translationRank', ratingField: 'translationRating', countField: 'translationPageCount' },
   { key: 'goi', label: 'GoI', rankField: 'goiRank', ratingField: 'goiRating', countField: 'goiPageCount' },
-  { key: 'wanderers', label: '漫游者', rankField: 'wanderersRank', ratingField: 'wanderersRating', countField: 'wanderersPageCount' },
+  { key: 'wanderers', label: '图书馆', rankField: 'wanderersRank', ratingField: 'wanderersRating', countField: 'wanderersPageCount' },
   { key: 'art', label: '艺术', rankField: 'artRank', ratingField: 'artRating', countField: 'artPageCount' }
 ];
 
@@ -115,6 +131,32 @@ export async function loadUserCardStats(
     favTag: r.favTag ?? null,
     categories
   };
+}
+
+/**
+ * 读取由 backend UserCategoryBenchmarksJob 写入 LeaderboardCache 的全站分类基准。
+ * 用 v3 → v2 → v1 的顺序回退，和 /stats/category-benchmarks 的行为一致。
+ * 未运行过该 job 时返回 null，调用方需要自己做降级（例如退回到自身最高值归一化）。
+ */
+export async function loadCategoryBenchmarks(
+  pool: Pool
+): Promise<CategoryBenchmarksPayload | null> {
+  const keys = [
+    'category_benchmarks_author_rating_v3',
+    'category_benchmarks_author_rating_v2',
+    'category_benchmarks_author_rating'
+  ];
+  for (const key of keys) {
+    const { rows } = await pool.query(
+      `SELECT payload FROM "LeaderboardCache" WHERE key = $1 AND period = 'daily' LIMIT 1`,
+      [key]
+    );
+    const payload = rows[0]?.payload;
+    if (payload && typeof payload === 'object' && payload.benchmarks) {
+      return payload as CategoryBenchmarksPayload;
+    }
+  }
+  return null;
 }
 
 export async function loadUserVotingSeries(


### PR DESCRIPTION
## Summary
- `/embed/user-card/:wikidotId` 右侧"分类表现"支持 **列表 / 雷达** 两种视图，纯 CSS radio 实现切换（`<input type=radio>` + `:checked ~`，兼容 CSP `script-src 'none'`）。
- **雷达归一化改走全站分位数**：新增 `loadCategoryBenchmarks(pool)` 从 `LeaderboardCache` 的 `category_benchmarks_author_rating_v3` 读取 backend `UserCategoryBenchmarksJob` 预计算的全站 p05/p50/p95/p99/avg/tau；用 `piecewise asinh` 把 rating 映射到 0-100，口径与前端 `UserCategoryRadarChart.vue` 完全一致。无 benchmark 时静默降级到自身 sqrt 归一化（只在开发环境触发）。
- **数据区 4 tile 2×2**：总评分 / 作品 / 投出 UpVote / 投出 DownVote，等宽等高；`align-items: stretch` 让左列追齐右列 list 自然高度。
- **capsule 位置**：搬到 header 右端 rank 正下方，body 两列 `y=0` 天然对齐。
- **Stage 高度稳定**：`panel-list` relative 决定 stage 高度、`panel-radar absolute inset 0` 脱离 layout，radar SVG `height: 100%` 随父缩放，切换不抖动也不留白。
- **语义修复**：零值分类（`rating == 0 || rank == null`）=  "未参与" 而非 "做得差" —— 列表行 `is-inactive` 弱化、雷达虚线轴 + polygon 跳过顶点连相邻有效点。
- **其他**：头像双层 letter/image CSS-only fallback；rank 加 `全站 #42` 前缀消歧；subtitle 去掉伪元素分隔符；theme 变量升级到 `--e-fg/--e-surface-raised/--e-border-strong`（旧 `--e-text-*` 保留为 alias 兼容历史自定义 CSS）。

## Test plan
- [x] 本地 smoke test：22/22 通过（结构、文案、选择器、雷达归一化、head 布局、Scope 切换）
- [x] 端到端真实数据验证：用全站 #4 用户 `breaddddd` 手算 piecewise-asinh score 与 SVG polygon 顶点半径逐项吻合（SCP 100.0/100.0、故事 84.7/84.7、翻译 74.8/74.9、GoI 100.0/100.0、图书馆 97.6/97.6、艺术 100.0/100.1）
- [x] 生产 DB `category_benchmarks_author_rating_v3` 已存在（`2026-04-20 21:42` asOf），6 个分类 benchmark 齐全
- [x] `bff` 构建通过（tsc clean）
- [ ] 部署后访问 `https://<host>/embed/user-card/<wikidotId>?breakdown=list` 和 `?breakdown=radar` 确认渲染与 Chart.js 同用户雷达一致
- [ ] 确认被 Wikidot iframe 嵌入时 CSP/frame-ancestors 仍然正常

## Files
- `bff/src/web/routes/embed.ts` — 加载 benchmarks 并传入 render
- `bff/src/web/utils/embed/userData.ts` — 新增 `loadCategoryBenchmarks` + `CategoryBenchmark(s)Payload` 类型；`wanderers.label` → `图书馆`
- `bff/src/web/utils/embed/templates/userCard.ts` — 整体重写模板（66% 重写率）
- `bff/src/web/utils/embed/templates/userHistory.ts` — 变量名同步切到 `--e-fg*`
- `bff/src/web/utils/embed/theme.ts` — 新增 `--e-fg/-muted/-subtle`、`--e-surface-raised`、`--e-border-strong`、`--e-accent-strong`；旧 `--e-text-*` 作为 alias 保留