### PR TITLE
fix(embed): user-card 窄 iframe 双列→单列回退阈值 480→560

### DIFF
--- a/bff/src/web/utils/embed/templates/userCard.ts
+++ b/bff/src/web/utils/embed/templates/userCard.ts
@@ -237,10 +237,24 @@ export const USER_CARD_BASE_CSS = `
   .e-rank-prefix { font-size: 10px; color: var(--e-fg-muted); font-weight: 500; letter-spacing: 0.02em; }
   .e-rank-num { font-size: 15px; letter-spacing: -0.01em; }
 
-  /* 两列主体：stretch 让两列等高；两列第一行 y=0 对齐（capsule 已搬走） */
+  /* 两列主体：stretch 让两列等高；两列第一行 y=0 对齐（capsule 已搬走）。
+     窄 iframe（wikidot [[iframe]] 常见宽度 400-560px）下回退单列纵排，恢复"宽大"视觉；
+     阈值选 560 是因为 wikidot 默认正文列宽 ~620-760，iframe 通常被 wrap 到 550 以下。 */
   .e-body { display: grid; grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.15fr); gap: 16px; align-items: stretch; }
-  @media (max-width: 480px) {
-    .e-body { grid-template-columns: minmax(0, 1fr); gap: 14px; }
+  @media (max-width: 560px) {
+    .e-body { grid-template-columns: minmax(0, 1fr); gap: 12px; }
+    /* 单列下 stat-grid 横排 4 tile，每个 tile 仍有足够宽度展示数字 */
+    .stat-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); grid-template-rows: auto; }
+    /* 窄屏下 header 允许 capsule wrap 到下一行，不挤压 name-block */
+    .e-header { flex-wrap: wrap; }
+    .e-header-side { flex-direction: row; width: 100%; min-height: 0; justify-content: space-between; align-items: center; order: 2; gap: 12px; }
+  }
+  /* 极窄 iframe（< 380px）下进一步压缩：stat-grid 2×2 回到紧凑方阵，
+     cat-row 去掉固定 rank 列宽让 label 吃掉空间 */
+  @media (max-width: 380px) {
+    .stat-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-rows: auto; }
+    .cat-row { grid-template-columns: 1fr auto auto; gap: 8px; padding: 6px 10px; }
+    .cat-meta { font-size: 10.5px; }
   }
 
   /* stat-grid 4 tile 2×2 等大方阵：总评分 | 作品 / 投出 UpVote | 投出 DownVote。


### PR DESCRIPTION
## 问题

#68 把 user-card 改成 \`.e-body\` 两列 grid（stat-grid | breakdown）之后，在 wikidot 嵌入的 iframe 里出现"整个变窄"——实际是 card 宽度不变，但**每个视觉单元只占 iframe 的 ~45-55%**。wikidot \`[[iframe]]\` 常见嵌入宽度 **400-560px**，卡在老阈值 480 之外被强制双列，挤压效果明显。

## 原因

| 版本 | layout | 400-560px iframe 下每段视觉宽度 |
|---|---|---|
| #68 之前（单列） | 纵排，stat-grid 5 列横铺 + list 在下 | 段宽 ≈ iframe 宽度（~500px）|
| #68 之后（双列） | `grid-template-columns: minmax(0,0.95fr) minmax(0,1.15fr)` | 段宽 ≈ iframe 的 45-55%（~200-300px）|

## 修法

纯 CSS 改动：提高 fallback 阈值 480 → 560，并在窄断点下给更紧凑的 layout。

- **`@media (max-width: 560px)`**：回退单列；stat-grid 改 4 列横排（沿用老版宽大 tile 视觉）；header `flex-wrap: wrap` 让 capsule 换行到下一行水平排开，不再挤压 name-block
- **`@media (max-width: 380px)`**：极窄断点，stat-grid 回 2×2、cat-row 压到 `1fr auto auto` 让 label 伸缩吃空间

## 为什么选 media query 而非 container query

`.e-card` 直接是 `<body>` 子节点，body = iframe viewport → card width ≡ viewport width。在这个拓扑下 media/container 数值等价。选 media 是因为：

- **兼容性**：media query 99.9% vs container query 95%（Chrome 105+/Safari 16+/Firefox 110+，2022-09 之后）。wikidot 长尾用户包含老 Safari/企业版本，不值得承担兼容性风险换零收益
- **无 containment 副作用**：`container-type: inline-size` 会自动加 `contain: layout inline-size`，老浏览器早期实现里偶发 min-content 计算 bug
- wikidot **sandbox** 对两者无区别——CSS parsing 和 layout 不受 sandbox 限制

## Test plan
- [x] smoke test 10/10 通过：断点边界正确、旧阈值移除、默认双列保留
- [x] build EXIT=0
- [ ] 部署后在 wikidot 实际嵌入验证 400-560 范围 iframe 显示为单列宽大视觉
- [ ] ≥ 560 iframe 保持双列（桌面大 iframe 场景不回退）