### PR TITLE
fix(embed): user-card .e-body class 冲突 — 重命名为 .uc-body

### DIFF
--- a/bff/src/web/utils/embed/templates/userCard.ts
+++ b/bff/src/web/utils/embed/templates/userCard.ts
@@ -240,9 +240,9 @@ export const USER_CARD_BASE_CSS = `
   /* 两列主体：stretch 让两列等高；两列第一行 y=0 对齐（capsule 已搬走）。
      窄 iframe（wikidot [[iframe]] 常见宽度 400-560px）下回退单列纵排，恢复"宽大"视觉；
      阈值选 560 是因为 wikidot 默认正文列宽 ~620-760，iframe 通常被 wrap 到 550 以下。 */
-  .e-body { display: grid; grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.15fr); gap: 16px; align-items: stretch; }
+  .uc-body { display: grid; grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.15fr); gap: 16px; align-items: stretch; }
   @media (max-width: 560px) {
-    .e-body { grid-template-columns: minmax(0, 1fr); gap: 12px; }
+    .uc-body { grid-template-columns: minmax(0, 1fr); gap: 12px; }
     /* 单列下 stat-grid 横排 4 tile，每个 tile 仍有足够宽度展示数字 */
     .stat-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); grid-template-rows: auto; }
     /* 窄屏下 header 允许 capsule wrap 到下一行，不挤压 name-block */
@@ -277,9 +277,9 @@ export const USER_CARD_BASE_CSS = `
   .breakdown-stage { position: relative; flex: 1; min-height: 0; }
   .panel-list { position: relative; visibility: hidden; }
   .panel-radar { position: absolute; inset: 0; visibility: hidden; }
-  /* radio 在 .e-card 直接子，选择器穿过 .e-body / .e-header 触达 panel 与 tab */
-  #bk-mode-list:checked ~ .e-body .panel-list { visibility: visible; }
-  #bk-mode-radar:checked ~ .e-body .panel-radar { visibility: visible; }
+  /* radio 在 .e-card 直接子，选择器穿过 .uc-body / .e-header 触达 panel 与 tab */
+  #bk-mode-list:checked ~ .uc-body .panel-list { visibility: visible; }
+  #bk-mode-radar:checked ~ .uc-body .panel-radar { visibility: visible; }
   #bk-mode-list:checked ~ .e-header .mode-tab[for="bk-mode-list"],
   #bk-mode-radar:checked ~ .e-header .mode-tab[for="bk-mode-radar"] {
     background: var(--e-bg); color: var(--e-accent); box-shadow: 0 1px 2px rgba(0,0,0,0.06);
@@ -375,7 +375,7 @@ export function renderUserCardBody(
       </div>
     </header>
 
-    <div class="e-body">
+    <div class="uc-body">
       <section class="stat-grid" aria-label="数值概览">
         <div class="stat-tile"><div class="lbl">总评分</div><div class="val">${formatInt(stats.totalRating)}</div></div>
         <div class="stat-tile"><div class="lbl">作品</div><div class="val">${formatInt(stats.pageCount)}</div></div>


### PR DESCRIPTION
## 真正的问题

**\`htmlWrapper.ts\` 给所有 embed 的 \`<body>\` 元素加了 \`class=\"e-body\"\`**（wrapper 作者保留的通用 hook）。#68 把 card 内部两列 grid container 命名为同名的 \`.e-body\`——CSS 规则 \`.e-body { display: grid; grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.15fr); }\` **同时应用到了 \`<body>\` 和我自己模板里的 \`<div>\`**。

后果：\`<body>\` 变成 2 列 grid 布局，body 里唯一的 child \`.e-card\` 被放到第一列，**占 viewport 的 45%**，右边 55% 是空白 cell。用户看到的就是"card 整个变窄"——card 实际渲染宽度只有 iframe viewport 的 45%。

## #69 为什么完全没救到

#69 调了 \`@media (max-width: 560px)\` 让 card **内部** \`.e-body\` 切单列。但问题在外层 body——body 永远把 card 压到左 45%，不管 viewport 多宽。media query fallback 永远够不到这个问题。

## Fix

纯重命名，无 layout 语义变化：card 内部 \`.e-body\` → \`.uc-body\`（user-card 私有前缀）。wrapper 的 \`<body class=\"e-body\">\` 保持不动（其他模板也挂这个类，不碰避免连锁）。

- CSS: \`.e-body { ... }\` → \`.uc-body { ... }\`（包括默认规则 + 2 处 @media 断点）
- HTML: \`<div class=\"e-body\">\` → \`<div class=\"uc-body\">\`
- 选择器: \`#bk-mode-xxx:checked ~ .e-body ...\` → \`~ .uc-body ...\`

## Test plan
- [x] smoke 5/5：CSS 无 \`.e-body\` 残留、CSS 有 \`.uc-body { display: grid }\`、HTML 改名正确、:checked ~ 选择器同步
- [x] build EXIT=0
- [ ] 部署后在 wikidot iframe 嵌入看 card 是否正常占满 iframe 宽度

## 教训

embed 模板以后新增 class 应该强制加前缀（\`uc-\` user-card / \`uh-\` user-history / \`ba-\` badge），避免和 wrapper 的通用 class 撞名。这是 schema 层的技术债——改名是止血，根治要给 wrapper 的 hook class 加更特异的前缀（如 \`e-wrapper-body\`）。