### PR TITLE
feat(embed): 为语义检索建立 PageEmbedding 全流程 (BGE-M3 + pgvector)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,12 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
+    "embed:health": "node --import tsx/esm src/cli/index.ts embed health",
+    "embed:backfill": "node --import tsx/esm src/cli/index.ts embed backfill",
+    "embed:incremental": "node --import tsx/esm src/cli/index.ts embed incremental",
+    "embed:search": "node --import tsx/esm src/cli/index.ts embed search",
+    "embed:server": "bash services/embedding-server/start.sh",
+    "embed:server:install": "bash -c 'cd services/embedding-server && python3 -m virtualenv .venv && .venv/bin/pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt && .venv/bin/python download_model.py'",
     "sync": "node --import tsx/esm src/cli/index.ts sync",
     "sync:full": "node --import tsx/esm src/cli/index.ts sync --full",
     "sync:test": "node --import tsx/esm src/cli/index.ts sync --test",

--- a/backend/prisma/migrations/20260421000000_add_page_embeddings/migration.sql
+++ b/backend/prisma/migrations/20260421000000_add_page_embeddings/migration.sql
@@ -1,0 +1,35 @@
+-- Ensure pgvector extension is present. Creating it requires SUPERUSER;
+-- if this migration fails here, a DB admin must run
+--   CREATE EXTENSION IF NOT EXISTS vector;
+-- once and re-deploy. Prisma's `postgresqlExtensions` preview feature will
+-- keep the extension declared in schema.prisma, but cannot install it.
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Main table: one row = one embedding of one PageVersion under one model.
+-- `embedding` is halfvec(1024) (FP16) — BGE-M3 dim. Future models can add
+-- rows alongside with a different `model` key without disturbing old data.
+CREATE TABLE "PageEmbedding" (
+  "id" SERIAL PRIMARY KEY,
+  "pageVersionId" INTEGER NOT NULL REFERENCES "PageVersion"("id") ON DELETE CASCADE,
+  "model" VARCHAR(64) NOT NULL,
+  "dim" INTEGER NOT NULL,
+  "embedding" halfvec(1024) NOT NULL,
+  "sourceCharLen" INTEGER NOT NULL,
+  "sourceTruncated" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX "PageEmbedding_pageVersionId_model_key"
+  ON "PageEmbedding" ("pageVersionId", "model");
+
+CREATE INDEX "PageEmbedding_model_idx"
+  ON "PageEmbedding" ("model");
+
+-- HNSW index on the cosine distance for ANN search.
+-- `m=16, ef_construction=64` are standard defaults; build time on ~34K vectors
+-- is typically under a minute. Query-time `ef_search` can be tuned per-session
+-- via `SET hnsw.ef_search = <n>;` (default 40).
+CREATE INDEX "PageEmbedding_embedding_hnsw"
+  ON "PageEmbedding"
+  USING hnsw ("embedding" halfvec_cosine_ops)
+  WITH (m = 16, ef_construction = 64);

--- a/backend/prisma/migrations/20260421010000_chunk_embeddings/migration.sql
+++ b/backend/prisma/migrations/20260421010000_chunk_embeddings/migration.sql
@@ -1,0 +1,26 @@
+-- Chunk-level embeddings: one PageVersion -> N rows.
+--
+-- 为长文（p95 约 15K char，hub 类到 85K char）提供尾部可搜能力：之前的 doc-level
+-- 方案把 > 8000 char 的内容直接 slice 掉，dense 索引里有 ~16% 页面的尾段是空白。
+-- 改成按 ~1500 char 滚动窗口 + 200 char overlap 切段，每段独立 embedding；
+-- 搜索时以 `GROUP BY pageVersionId MAX(score)` 聚合到 PV。
+--
+-- 改动会作废之前写入的少量样本（~800 行 doc-level embedding 不再兼容新 unique key），
+-- 这里在 ALTER 前主动清一下。因为 (pageVersionId, model) -> (pageVersionId, model,
+-- chunkIndex) 的键语义变了，不能无损迁移。
+
+DELETE FROM "PageEmbedding";
+
+ALTER TABLE "PageEmbedding"
+  ADD COLUMN "chunkIndex" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "chunkTotal" INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN "chunkCharStart" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "chunkCharEnd" INTEGER NOT NULL DEFAULT 0;
+
+-- 旧 unique key 作废：允许一个 PV 在同模型下有多行（每 chunk 一行）
+-- 注意：原先是 CREATE UNIQUE INDEX（不是 table constraint），所以用 DROP INDEX。
+DROP INDEX IF EXISTS "PageEmbedding_pageVersionId_model_key";
+
+-- 新 unique index：一个 PV 在同一模型下，每个 chunkIndex 唯一
+CREATE UNIQUE INDEX "PageEmbedding_pageVersionId_model_chunkIndex_key"
+  ON "PageEmbedding" ("pageVersionId", "model", "chunkIndex");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -214,7 +214,8 @@ model PageVersion {
   @@index([voteCount])
 }
 
-/// 一段 text 生成的语义向量。以 PageVersion 为单位绑定：一次 revision 一个嵌入。
+/// 一段 text 生成的语义向量。Chunk 粒度：一个 PageVersion 在同一模型下可以有多行
+/// （每 chunk 一行），`chunkIndex` 从 0 开始。对短文（<= 1 chunk）仍然只有一行。
 /// 支持多模型并存（`model` 区分），以后迁移模型不用砸掉旧数据。
 /// `embedding` 是 pgvector 的 halfvec(1024)（FP16），因为 Prisma 不原生支持，
 /// 这里用 Unsupported；具体类型在 migration SQL 里声明，HNSW 索引也在 migration 里建。
@@ -226,10 +227,14 @@ model PageEmbedding {
   embedding       Unsupported("halfvec(1024)")
   sourceCharLen   Int
   sourceTruncated Boolean  @default(false)
+  chunkIndex      Int      @default(0)
+  chunkTotal      Int      @default(1)
+  chunkCharStart  Int      @default(0)
+  chunkCharEnd    Int      @default(0)
   createdAt       DateTime @default(now())
   pageVersion     PageVersion @relation(fields: [pageVersionId], references: [id], onDelete: Cascade)
 
-  @@unique([pageVersionId, model])
+  @@unique([pageVersionId, model, chunkIndex])
   @@index([model])
 }
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -6,7 +6,7 @@ generator client {
 datasource db {
   provider   = "postgresql"
   url        = env("DATABASE_URL")
-  extensions = [pgroonga]
+  extensions = [pgroonga, vector]
 }
 
 enum PageVersionImageStatus {
@@ -204,6 +204,7 @@ model PageVersion {
   votes            Vote[]
   images           PageVersionImage[]
   references       PageReference[]
+  embeddings       PageEmbedding[]
 
   @@index([pageId])
   @@index([rating])
@@ -211,6 +212,25 @@ model PageVersion {
   @@index([wikidotId])
   @@index([commentCount])
   @@index([voteCount])
+}
+
+/// 一段 text 生成的语义向量。以 PageVersion 为单位绑定：一次 revision 一个嵌入。
+/// 支持多模型并存（`model` 区分），以后迁移模型不用砸掉旧数据。
+/// `embedding` 是 pgvector 的 halfvec(1024)（FP16），因为 Prisma 不原生支持，
+/// 这里用 Unsupported；具体类型在 migration SQL 里声明，HNSW 索引也在 migration 里建。
+model PageEmbedding {
+  id              Int      @id @default(autoincrement())
+  pageVersionId   Int
+  model           String   @db.VarChar(64)
+  dim             Int
+  embedding       Unsupported("halfvec(1024)")
+  sourceCharLen   Int
+  sourceTruncated Boolean  @default(false)
+  createdAt       DateTime @default(now())
+  pageVersion     PageVersion @relation(fields: [pageVersionId], references: [id], onDelete: Cascade)
+
+  @@unique([pageVersionId, model])
+  @@index([model])
 }
 
 model PageReference {

--- a/backend/services/embedding-server/.gitignore
+++ b/backend/services/embedding-server/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+models/
+__pycache__/
+*.pyc

--- a/backend/services/embedding-server/README.md
+++ b/backend/services/embedding-server/README.md
@@ -1,0 +1,62 @@
+# scpper-embedding (BGE-M3 local)
+
+CPU-only BGE-M3 embedding server. Drop-in replacement for the `/embed` path of
+`ghcr.io/huggingface/text-embeddings-inference` so the Node backend can later
+switch to TEI without changes.
+
+## One-time setup
+
+```bash
+python3 -m virtualenv .venv
+.venv/bin/pip install -i https://pypi.tuna.tsinghua.edu.cn/simple \
+  --extra-index-url https://download.pytorch.org/whl/cpu \
+  -r requirements.txt
+
+# Download ~2.3 GB of model weights from ModelScope (HF mirror in CN)
+.venv/bin/python download_model.py
+```
+
+Or via the backend package wrapper:
+
+```bash
+cd ../.. && npm run embed:server:install
+```
+
+## Start
+
+```bash
+./start.sh                              # 127.0.0.1:18080
+EMBED_PORT=18090 ./start.sh             # override port
+EMBED_NUM_THREADS=32 ./start.sh         # pin torch threads
+EMBED_BATCH_SIZE=16 ./start.sh          # default 8; tune per host
+```
+
+Healthcheck: `curl http://127.0.0.1:18080/health`
+
+## API
+
+```
+POST /embed
+Content-Type: application/json
+{
+  "inputs": ["文本1", "文本2"],
+  "normalize": true,          // default true
+  "batch_size": 8             // optional override
+}
+→ 200 OK
+[[float, float, ...],  // length = inputs[0] dim
+ [float, float, ...]]  // length = inputs[1] dim
+```
+
+Errors surface as HTTP 400/500 JSON `{detail: "..."}`.
+
+## Notes
+
+- CPU inference on a modern x86 box (AVX2): ~100-300ms / 512-token input
+- Full backfill of ~34K SCPPER pages: batch=8 → 1-2h; batch=16 → 45-90min
+- Model weights live in `./models/bge-m3/` (~2.3 GB). `.gitignore` keeps them
+  out of the repo.
+- TEI protocol compatibility is intentional: `POST /embed` with the same body
+  shape works against both this server and a real TEI container; you can
+  later `docker run ghcr.io/huggingface/text-embeddings-inference:cpu-1.8
+  --model-id BAAI/bge-m3` and point `EMBEDDING_SERVER_URL` at it.

--- a/backend/services/embedding-server/download_model.py
+++ b/backend/services/embedding-server/download_model.py
@@ -1,0 +1,42 @@
+"""Download BGE-M3 via ModelScope mirror (avoids HF network issues in CN).
+
+Usage:
+    python download_model.py               # default: BAAI/bge-m3 → ./models/bge-m3
+    python download_model.py --model X     # override model id
+    python download_model.py --dest P      # override dest dir
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="BAAI/bge-m3", help="ModelScope model id")
+    parser.add_argument(
+        "--dest",
+        default=str(Path(__file__).parent / "models" / "bge-m3"),
+        help="Local dir to cache weights into",
+    )
+    args = parser.parse_args()
+
+    dest = Path(args.dest).resolve()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    from modelscope import snapshot_download  # type: ignore
+
+    print(f"Downloading {args.model} → {dest}", flush=True)
+    snapshot_download(
+        model_id=args.model,
+        cache_dir=str(dest.parent),
+        local_dir=str(dest),
+    )
+    print(f"OK. Model at: {dest}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/services/embedding-server/server.py
+++ b/backend/services/embedding-server/server.py
@@ -1,0 +1,109 @@
+"""Minimal CPU BGE-M3 HTTP service, TEI-compatible subset.
+
+Endpoints:
+- `GET  /health` — liveness probe returning `{"status": "ok", "model": ...}`
+- `POST /embed`  — body `{"inputs": ["..."], "normalize": true}` → `[[float, ...], ...]`
+
+Designed to be a drop-in replacement for the `/embed` path of
+`ghcr.io/huggingface/text-embeddings-inference` so the Node caller can
+later switch to TEI without code changes.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+# `sentence-transformers` pulls torch; both need to be installed in the venv.
+from sentence_transformers import SentenceTransformer  # type: ignore
+import torch
+
+
+# ── Configuration (env overrides supported) ─────────────────────────
+MODEL_NAME = os.environ.get("EMBED_MODEL", "BAAI/bge-m3")
+MODEL_PATH = os.environ.get(
+    "EMBED_MODEL_PATH",
+    str(Path(__file__).parent / "models" / "bge-m3"),
+)
+MAX_SEQ_LEN = int(os.environ.get("EMBED_MAX_SEQ_LEN", "8192"))
+DEFAULT_BATCH_SIZE = int(os.environ.get("EMBED_BATCH_SIZE", "8"))
+NUM_THREADS = int(os.environ.get("EMBED_NUM_THREADS", "0"))  # 0 == leave default
+# "onnx" | "torch"；BGE-M3 自带 ONNX 权重 (onnx/model.onnx + model.onnx_data)，
+# CPU 上 ONNX Runtime 一般比 PyTorch 快 2-3x
+BACKEND = os.environ.get("EMBED_BACKEND", "torch").lower()
+
+if NUM_THREADS > 0:
+    torch.set_num_threads(NUM_THREADS)
+
+
+# ── Model load ───────────────────────────────────────────────────────
+print(f"Loading model from {MODEL_PATH} (name={MODEL_NAME}, backend={BACKEND}) …", flush=True)
+if BACKEND == "onnx":
+    # sentence-transformers 5.x 支持 backend='onnx'；会从 `onnx/` 子目录挑 ONNX file
+    model = SentenceTransformer(
+        MODEL_PATH,
+        device="cpu",
+        backend="onnx",
+        trust_remote_code=True,
+        model_kwargs={"file_name": "onnx/model.onnx", "provider": "CPUExecutionProvider"},
+    )
+else:
+    model = SentenceTransformer(
+        MODEL_PATH,
+        device="cpu",
+        trust_remote_code=True,
+    )
+# BGE-M3 默认上限是 8192；如果模型没显式设，这里设死，避免 tokenizer 意外截短。
+try:
+    model.max_seq_length = MAX_SEQ_LEN
+except AttributeError:
+    pass
+
+# 拿实际 embedding dim（BGE-M3 = 1024）；dim mismatch 时 CLI 侧能直接看出
+DIM = int(model.get_sentence_embedding_dimension())
+print(f"Model ready. dim={DIM}, max_seq={MAX_SEQ_LEN}, threads={torch.get_num_threads()}", flush=True)
+
+
+# ── HTTP app ─────────────────────────────────────────────────────────
+app = FastAPI(title="scpper-embedding", version="1.0.0")
+
+
+class EmbedRequest(BaseModel):
+    inputs: List[str] = Field(default_factory=list)
+    normalize: bool = True
+    batch_size: int | None = None
+
+
+class EmbedResponseItem(BaseModel):
+    # TEI 返回纯 nested list；为了兼容，我们也直接返回 list[list[float]]，
+    # 但同时在 `/embed/with-meta` 下提供结构化返回。
+    pass
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok", "model": MODEL_NAME, "dim": DIM, "max_seq_len": MAX_SEQ_LEN}
+
+
+@app.post("/embed")
+def embed(req: EmbedRequest):
+    if not req.inputs:
+        return []
+    if len(req.inputs) > 256:
+        raise HTTPException(status_code=400, detail="too many inputs per request (max 256)")
+    batch = req.batch_size or DEFAULT_BATCH_SIZE
+    try:
+        vectors = model.encode(
+            req.inputs,
+            batch_size=batch,
+            normalize_embeddings=req.normalize,
+            convert_to_numpy=True,
+            show_progress_bar=False,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail=f"encode failed: {exc}") from exc
+    # numpy ndarray → list
+    return vectors.tolist()

--- a/backend/services/embedding-server/start.sh
+++ b/backend/services/embedding-server/start.sh
@@ -2,12 +2,15 @@
 # Convenience launcher for the BGE-M3 embedding service.
 #
 # Env overrides:
-#   EMBED_PORT (default 18080)
-#   EMBED_MODEL_PATH (default ./models/bge-m3)
-#   EMBED_MAX_SEQ_LEN (default 8192)
-#   EMBED_BATCH_SIZE (default 8)
-#   EMBED_NUM_THREADS (default 0 == torch default)
-#   EMBED_HOST (default 127.0.0.1)
+#   EMBED_PORT         默认 18080
+#   EMBED_HOST         默认 127.0.0.1
+#   EMBED_MODEL_PATH   默认 ./models/bge-m3
+#   EMBED_BACKEND      torch (默认) / onnx
+#   EMBED_MAX_SEQ_LEN  默认 8192；截到 4096/2048 能显著加速长文
+#   EMBED_BATCH_SIZE   默认 8
+#   EMBED_NUM_THREADS  默认 0 (torch default)；一台 56-core 机器上 ×workers 不超过总核数
+#   EMBED_WORKERS      uvicorn worker 数，默认 1。每 worker 独立加载模型（~2.3GB 内存）。
+#                      多 worker 下 backfill 客户端可以用 --concurrency N 并行发
 set -euo pipefail
 
 cd "$(dirname "$0")"
@@ -24,9 +27,10 @@ fi
 
 PORT="${EMBED_PORT:-18080}"
 HOST="${EMBED_HOST:-127.0.0.1}"
+WORKERS="${EMBED_WORKERS:-1}"
 
 exec .venv/bin/uvicorn server:app \
   --host "$HOST" \
   --port "$PORT" \
   --log-level info \
-  --workers 1
+  --workers "$WORKERS"

--- a/backend/services/embedding-server/start.sh
+++ b/backend/services/embedding-server/start.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Convenience launcher for the BGE-M3 embedding service.
+#
+# Env overrides:
+#   EMBED_PORT (default 18080)
+#   EMBED_MODEL_PATH (default ./models/bge-m3)
+#   EMBED_MAX_SEQ_LEN (default 8192)
+#   EMBED_BATCH_SIZE (default 8)
+#   EMBED_NUM_THREADS (default 0 == torch default)
+#   EMBED_HOST (default 127.0.0.1)
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [[ ! -d .venv ]]; then
+  echo "venv missing — run: python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" >&2
+  exit 1
+fi
+
+if [[ ! -d "${EMBED_MODEL_PATH:-./models/bge-m3}" ]]; then
+  echo "model dir missing — run: .venv/bin/python download_model.py" >&2
+  exit 1
+fi
+
+PORT="${EMBED_PORT:-18080}"
+HOST="${EMBED_HOST:-127.0.0.1}"
+
+exec .venv/bin/uvicorn server:app \
+  --host "$HOST" \
+  --port "$PORT" \
+  --log-level info \
+  --workers 1

--- a/backend/src/cli/embed.ts
+++ b/backend/src/cli/embed.ts
@@ -21,20 +21,22 @@ export function registerEmbedCommands(program: Command) {
 
   embed
     .command('backfill')
-    .description('Embed all PageVersion rows that do not yet have a row in PageEmbedding for the current model')
-    .option('--batch-size <n>', 'Texts per embed request', (v) => parseInt(v, 10), 16)
-    .option('--limit <n>', 'Cap the number of PageVersions to process', (v) => parseInt(v, 10))
+    .description('Chunk + embed every PageVersion that does not yet have a row in PageEmbedding for the current model')
+    .option('--batch-size <n>', 'Chunks per embed request (server batch)', (v) => parseInt(v, 10), 8)
+    .option('--concurrency <n>', 'Parallel in-flight embed batches (needs server multi-worker to help)', (v) => parseInt(v, 10), 1)
+    .option('--limit <n>', 'Cap the number of PageVersions (not chunks) to process', (v) => parseInt(v, 10))
     .option('--no-deleted', 'Skip pages whose Page.isDeleted=true (default: include)')
     .option('--dry-run', 'List the candidates but do not call the embedding server or write DB')
     .action(async (opts) => {
       try {
         const res = await runPageEmbeddingBackfill({
           batchSize: opts.batchSize,
+          concurrency: opts.concurrency,
           limit: Number.isFinite(opts.limit) ? opts.limit : undefined,
           includeDeletedPages: opts.deleted !== false,
           dryRun: opts.dryRun === true
         });
-        console.log(`[embed:backfill] total=${res.total} written=${res.written} truncated=${res.truncatedCount} skippedEmpty=${res.skippedEmpty} durationMs=${res.durationMs}`);
+        console.log(`[embed:backfill] PV=${res.totalPages} chunks=${res.totalChunks} written=${res.written} truncated=${res.truncatedChunks} skippedEmpty=${res.skippedEmptyPages} durationMs=${res.durationMs}`);
       } finally {
         await disconnectPrisma();
       }
@@ -43,15 +45,17 @@ export function registerEmbedCommands(program: Command) {
   embed
     .command('incremental')
     .description('Embed only the still-missing PageVersions (same query as backfill, smaller batch)')
-    .option('--batch-size <n>', 'Texts per embed request', (v) => parseInt(v, 10), 8)
+    .option('--batch-size <n>', 'Chunks per embed request', (v) => parseInt(v, 10), 8)
+    .option('--concurrency <n>', 'Parallel in-flight embed batches', (v) => parseInt(v, 10), 1)
     .option('--limit <n>', 'Cap per run (safety for cron)', (v) => parseInt(v, 10), 500)
     .action(async (opts) => {
       try {
         const res = await runPageEmbeddingIncremental({
           batchSize: opts.batchSize,
+          concurrency: opts.concurrency,
           limit: Number.isFinite(opts.limit) ? opts.limit : 500
         });
-        console.log(`[embed:incremental] written=${res.written} truncated=${res.truncatedCount} durationMs=${res.durationMs}`);
+        console.log(`[embed:incremental] PV=${res.totalPages} chunks=${res.totalChunks} written=${res.written} truncated=${res.truncatedChunks} durationMs=${res.durationMs}`);
       } finally {
         await disconnectPrisma();
       }
@@ -89,8 +93,11 @@ export function registerEmbedCommands(program: Command) {
         for (const h of hits) {
           const name = h.title || h.alternateTitle || `PV#${h.pageVersionId}`;
           const mark = h.isDeletedPage ? ' (deleted)' : '';
+          const chunkHint = h.hitChunkIndex != null
+            ? ` [chunk ${h.hitChunkIndex} @${h.hitChunkCharStart}-${h.hitChunkCharEnd}]`
+            : '';
           console.log(
-            `${h.finalScore.toFixed(4)}  dense=${h.denseScore.toFixed(3)} sparse=${h.sparseScore.toFixed(3)}  wid=${h.wikidotId ?? '-'}  ${name}${mark}`
+            `${h.finalScore.toFixed(4)}  dense=${h.denseScore.toFixed(3)} sparse=${h.sparseScore.toFixed(3)}  wid=${h.wikidotId ?? '-'}  ${name}${mark}${chunkHint}`
           );
         }
       } finally {

--- a/backend/src/cli/embed.ts
+++ b/backend/src/cli/embed.ts
@@ -1,0 +1,100 @@
+import { Command } from 'commander';
+import { getPrismaClient, disconnectPrisma } from '../utils/db-connection.js';
+import { Logger } from '../utils/Logger.js';
+import { embeddingClientFromEnv } from '../services/embedding/EmbeddingClient.js';
+import { runPageEmbeddingBackfill, runPageEmbeddingIncremental } from '../jobs/PageEmbeddingBackfillJob.js';
+import { hybridSearch } from '../services/embedding/PageEmbeddingRepo.js';
+
+export function registerEmbedCommands(program: Command) {
+  const embed = program
+    .command('embed')
+    .description('Page embedding pipeline (BGE-M3 by default)');
+
+  embed
+    .command('health')
+    .description('Ping the local embedding server and print model info')
+    .action(async () => {
+      const client = embeddingClientFromEnv();
+      const h = await client.health();
+      console.log(JSON.stringify(h, null, 2));
+    });
+
+  embed
+    .command('backfill')
+    .description('Embed all PageVersion rows that do not yet have a row in PageEmbedding for the current model')
+    .option('--batch-size <n>', 'Texts per embed request', (v) => parseInt(v, 10), 16)
+    .option('--limit <n>', 'Cap the number of PageVersions to process', (v) => parseInt(v, 10))
+    .option('--no-deleted', 'Skip pages whose Page.isDeleted=true (default: include)')
+    .option('--dry-run', 'List the candidates but do not call the embedding server or write DB')
+    .action(async (opts) => {
+      try {
+        const res = await runPageEmbeddingBackfill({
+          batchSize: opts.batchSize,
+          limit: Number.isFinite(opts.limit) ? opts.limit : undefined,
+          includeDeletedPages: opts.deleted !== false,
+          dryRun: opts.dryRun === true
+        });
+        console.log(`[embed:backfill] total=${res.total} written=${res.written} truncated=${res.truncatedCount} skippedEmpty=${res.skippedEmpty} durationMs=${res.durationMs}`);
+      } finally {
+        await disconnectPrisma();
+      }
+    });
+
+  embed
+    .command('incremental')
+    .description('Embed only the still-missing PageVersions (same query as backfill, smaller batch)')
+    .option('--batch-size <n>', 'Texts per embed request', (v) => parseInt(v, 10), 8)
+    .option('--limit <n>', 'Cap per run (safety for cron)', (v) => parseInt(v, 10), 500)
+    .action(async (opts) => {
+      try {
+        const res = await runPageEmbeddingIncremental({
+          batchSize: opts.batchSize,
+          limit: Number.isFinite(opts.limit) ? opts.limit : 500
+        });
+        console.log(`[embed:incremental] written=${res.written} truncated=${res.truncatedCount} durationMs=${res.durationMs}`);
+      } finally {
+        await disconnectPrisma();
+      }
+    });
+
+  embed
+    .command('search <query...>')
+    .description('Hybrid pgvector + pgroonga search; useful for smoke tests')
+    .option('--limit <n>', 'Top K', (v) => parseInt(v, 10), 10)
+    .option('--dense <n>', 'Dense candidates', (v) => parseInt(v, 10), 60)
+    .option('--sparse <n>', 'Sparse candidates', (v) => parseInt(v, 10), 60)
+    .option('--dense-weight <w>', 'Weight for dense score', (v) => parseFloat(v), 0.65)
+    .option('--sparse-weight <w>', 'Weight for sparse score', (v) => parseFloat(v), 0.35)
+    .action(async (queryWords: string[], opts) => {
+      const client = embeddingClientFromEnv();
+      const prisma = getPrismaClient();
+      const query = queryWords.join(' ').trim();
+      if (!query) {
+        console.error('empty query');
+        process.exit(1);
+      }
+      try {
+        Logger.info(`[embed:search] "${query}"`);
+        const [vec] = await client.embed([query]);
+        const hits = await hybridSearch(prisma, client.modelId, vec, query, {
+          limit: opts.limit,
+          denseCandidates: opts.dense,
+          sparseCandidates: opts.sparse,
+          denseWeight: opts.denseWeight,
+          sparseWeight: opts.sparseWeight
+        });
+        if (hits.length === 0) {
+          console.log('(no matches)');
+        }
+        for (const h of hits) {
+          const name = h.title || h.alternateTitle || `PV#${h.pageVersionId}`;
+          const mark = h.isDeletedPage ? ' (deleted)' : '';
+          console.log(
+            `${h.finalScore.toFixed(4)}  dense=${h.denseScore.toFixed(3)} sparse=${h.sparseScore.toFixed(3)}  wid=${h.wikidotId ?? '-'}  ${name}${mark}`
+          );
+        }
+      } finally {
+        await disconnectPrisma();
+      }
+    });
+}

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -26,6 +26,7 @@ import { ForumSyncProcessor } from '../core/processors/ForumSyncProcessor.js';
 import { WikidotForumClient } from '../core/client/WikidotForumClient.js';
 import { runSyncHourlyScheduler } from './sync-hourly.js';
 import { runWikidotBindingVerifyLoop } from './wikidot-binding-verify-loop.js';
+import { registerEmbedCommands } from './embed.js';
 
 const program = new Command();
 
@@ -55,6 +56,7 @@ program
   .option('--run-immediately', 'Run one cycle on startup before waiting for next top-of-hour trigger')
   .option('--skip-gacha', 'Skip post-sync gacha-sync step')
   .option('--skip-forum', 'Skip post-sync forum-sync step')
+  .option('--skip-embed', 'Skip post-sync page-embedding incremental step')
   .action(async (options) => {
     if (options.poolId) {
       console.warn(`[sync-hourly] --pool-id=${String(options.poolId)} is deprecated and ignored in single-pool mode.`);
@@ -63,7 +65,8 @@ program
       concurrency: String(options.concurrency ?? '4'),
       runImmediately: Boolean(options.runImmediately),
       runGacha: !Boolean(options.skipGacha),
-      runForum: !Boolean(options.skipForum)
+      runForum: !Boolean(options.skipForum),
+      runEmbed: !Boolean(options.skipEmbed)
     });
   });
 
@@ -1196,5 +1199,7 @@ const handleFatal = async (err: any) => {
 
 process.on('unhandledRejection', handleFatal);
 process.on('uncaughtException', handleFatal);
+
+registerEmbedCommands(program);
 
 program.parse();

--- a/backend/src/cli/sync-hourly.ts
+++ b/backend/src/cli/sync-hourly.ts
@@ -3,12 +3,14 @@ import { syncGachaPool } from './gacha-sync.js';
 import { ForumSyncProcessor } from '../core/processors/ForumSyncProcessor.js';
 import { WikidotForumClient } from '../core/client/WikidotForumClient.js';
 import { analyzeIncremental } from '../jobs/IncrementalAnalyzeJob.js';
+import { runPageEmbeddingIncremental } from '../jobs/PageEmbeddingBackfillJob.js';
 
 type SyncHourlySchedulerOptions = {
   concurrency: string;
   runImmediately: boolean;
   runGacha: boolean;
   runForum: boolean;
+  runEmbed: boolean;
 };
 
 const STALE_PROGRESS_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
@@ -209,6 +211,21 @@ export async function runSyncHourlyScheduler(options: SyncHourlySchedulerOptions
         await syncGachaPool();
       } else {
         console.log('[sync-hourly] gacha-sync disabled by option, skipping.');
+      }
+
+      // Page embeddings incremental (non-fatal; embedding server may be offline).
+      // `runPageEmbeddingIncremental` has its own cap (default 500) so one cycle
+      // can't stall the scheduler — anything still behind is picked up next hour.
+      if (options.runEmbed) {
+        try {
+          const embedResult = await runPageEmbeddingIncremental({ limit: 500, batchSize: 8 });
+          console.log(`[sync-hourly] Embedding incremental done: written=${embedResult.written} (truncated=${embedResult.truncatedCount}, skippedEmpty=${embedResult.skippedEmpty}, durationMs=${embedResult.durationMs}).`);
+        } catch (embedErr: any) {
+          const msg = embedErr instanceof Error ? embedErr.message : String(embedErr);
+          console.error(`[sync-hourly] Embedding incremental failed (non-fatal): ${msg}`);
+        }
+      } else {
+        console.log('[sync-hourly] embed-incremental disabled by option, skipping.');
       }
     } catch (error: any) {
       const message = error instanceof Error ? error.stack || error.message : String(error);

--- a/backend/src/cli/sync-hourly.ts
+++ b/backend/src/cli/sync-hourly.ts
@@ -219,7 +219,7 @@ export async function runSyncHourlyScheduler(options: SyncHourlySchedulerOptions
       if (options.runEmbed) {
         try {
           const embedResult = await runPageEmbeddingIncremental({ limit: 500, batchSize: 8 });
-          console.log(`[sync-hourly] Embedding incremental done: written=${embedResult.written} (truncated=${embedResult.truncatedCount}, skippedEmpty=${embedResult.skippedEmpty}, durationMs=${embedResult.durationMs}).`);
+          console.log(`[sync-hourly] Embedding incremental done: PV=${embedResult.totalPages} chunks=${embedResult.totalChunks} written=${embedResult.written} (truncated=${embedResult.truncatedChunks}, skippedEmpty=${embedResult.skippedEmptyPages}, durationMs=${embedResult.durationMs}).`);
         } catch (embedErr: any) {
           const msg = embedErr instanceof Error ? embedErr.message : String(embedErr);
           console.error(`[sync-hourly] Embedding incremental failed (non-fatal): ${msg}`);

--- a/backend/src/jobs/PageEmbeddingBackfillJob.ts
+++ b/backend/src/jobs/PageEmbeddingBackfillJob.ts
@@ -2,7 +2,7 @@ import type { PrismaClient } from '@prisma/client';
 import { getPrismaClient } from '../utils/db-connection.js';
 import { Logger } from '../utils/Logger.js';
 import { EmbeddingClient, embeddingClientFromEnv } from '../services/embedding/EmbeddingClient.js';
-import { preparePageText } from '../services/embedding/PageTextPreparer.js';
+import { preparePageChunks } from '../services/embedding/PageTextPreparer.js';
 import {
   listEmbeddingCandidates,
   upsertEmbeddings,
@@ -10,9 +10,13 @@ import {
 } from '../services/embedding/PageEmbeddingRepo.js';
 
 export interface BackfillOptions {
-  batchSize?: number;             // default 16（CPU 推理，不要太大）
-  limit?: number;                 // 上限条数；不传=全量
-  includeDeletedPages?: boolean;  // 是否回填已删除 Page（默认 true）
+  /** 发给 embedding server 的一次请求的 chunk 数；CPU 8 合适 */
+  batchSize?: number;
+  /** 并发请求数（对多 uvicorn-worker 的 server 有效，单 worker 下保持 1） */
+  concurrency?: number;
+  /** 处理的 PageVersion 上限；不传=全量 */
+  limit?: number;
+  includeDeletedPages?: boolean;
   dryRun?: boolean;
   onProgress?: (done: number, total: number, sample?: EmbeddingCandidate) => void;
   prisma?: PrismaClient;
@@ -20,52 +24,92 @@ export interface BackfillOptions {
 }
 
 export interface BackfillResult {
-  total: number;
-  written: number;
-  truncatedCount: number;
+  totalPages: number;        // 候选 PV 数
+  totalChunks: number;       // 切段后总 chunk 数
+  written: number;           // 实际写入的 chunk 行数
+  truncatedChunks: number;   // chunk 本身被模型 max_seq 截断的数量
+  skippedEmptyPages: number; // 完全无可嵌入文本的 PV
   durationMs: number;
-  skippedEmpty: number;
+}
+
+interface ChunkItem {
+  pageVersionId: number;
+  chunkIndex: number;
+  chunkTotal: number;
+  chunkCharStart: number;
+  chunkCharEnd: number;
+  text: string;
+  sourceCharLen: number;
+  sourceTruncated: boolean;
 }
 
 /**
- * 把当前还没 embedding 的 PageVersion 批量推过嵌入服务、落 DB。
+ * 把当前还没 embedding 的 PageVersion 切段、批量推过嵌入服务、落 DB。
  *
  * 说明：
- *   - 文本走 `preparePageText`，含 header + denoise + 8000 char 截断
- *   - 每批 N 个文档一发，失败的 batch 整批 skip 并 log；不影响后续批
- *   - 因为 upsertEmbeddings 有 ON CONFLICT DO UPDATE，中途崩了再跑是 resume-safe 的
+ *   - 每个 PV 走 `preparePageChunks` 切成 1-16 段（`MAX_CHUNKS`）
+ *   - 所有 chunk 拍平后按 `batchSize` 打包发请求
+ *   - `concurrency > 1` 时会并发发多个 batch；只有 server 跑多 uvicorn worker
+ *     或主动 `--workers N` 时才有加速
+ *   - 单个 batch 失败整批 skip 并 log；不影响后续批
+ *   - ON CONFLICT DO UPDATE 使操作是 resume-safe
  */
 export async function runPageEmbeddingBackfill(options: BackfillOptions = {}): Promise<BackfillResult> {
   const prisma = options.prisma ?? getPrismaClient();
   const client = options.client ?? embeddingClientFromEnv();
-  const batchSize = options.batchSize ?? 16;
+  const batchSize = Math.max(1, options.batchSize ?? 8);
+  const concurrency = Math.max(1, options.concurrency ?? 1);
   const includeDeletedPages = options.includeDeletedPages ?? true;
   const dryRun = options.dryRun === true;
 
-  Logger.info('[embed-backfill] starting');
+  Logger.info(`[embed-backfill] starting batchSize=${batchSize} concurrency=${concurrency}`);
   const started = Date.now();
 
-  // dry-run 路径提前取候选、不接触 HTTP，方便在 embedding server 还没就绪时检查
-  // SQL 的召回是否合理。
   const candidates = await listEmbeddingCandidates(prisma, client.modelId, {
     limit: options.limit,
     includeDeletedPages
   });
 
+  // 切段 + 平铺
+  const chunks: ChunkItem[] = [];
+  let skippedEmptyPages = 0;
+  for (const pv of candidates) {
+    const pageChunks = preparePageChunks(pv);
+    if (pageChunks.length === 0) {
+      skippedEmptyPages += 1;
+      continue;
+    }
+    for (const ch of pageChunks) {
+      chunks.push({
+        pageVersionId: pv.pageVersionId,
+        chunkIndex: ch.chunkIndex,
+        chunkTotal: ch.chunkTotal,
+        chunkCharStart: ch.contentStart,
+        chunkCharEnd: ch.contentEnd,
+        text: ch.text,
+        sourceCharLen: ch.sourceCharLen,
+        sourceTruncated: ch.truncated
+      });
+    }
+  }
+
   if (dryRun) {
-    Logger.info(`[embed-backfill] dry run — ${candidates.length} candidate PageVersion(s) (model=${client.modelId}), no HTTP / DB write`);
-    if (candidates.length > 0) {
-      const sample = candidates.slice(0, Math.min(5, candidates.length));
-      for (const c of sample) {
-        Logger.info(`  pv=${c.pageVersionId} wid=${c.wikidotId} deleted=${c.isDeletedPage} title=${c.title ?? '—'}`);
-      }
+    Logger.info(`[embed-backfill] dry run — ${candidates.length} PV / ${chunks.length} chunk(s) (model=${client.modelId}) (skippedEmpty=${skippedEmptyPages}); no HTTP / DB write`);
+    const byChunkCount: Record<number, number> = {};
+    for (const c of chunks) {
+      byChunkCount[c.chunkTotal] = (byChunkCount[c.chunkTotal] ?? 0) + 1;
+    }
+    Logger.info(`  chunk distribution (by chunkTotal): ${JSON.stringify(byChunkCount)}`);
+    for (const c of candidates.slice(0, 3)) {
+      Logger.info(`  pv=${c.pageVersionId} wid=${c.wikidotId} deleted=${c.isDeletedPage} title=${c.title ?? '—'}`);
     }
     return {
-      total: candidates.length,
+      totalPages: candidates.length,
+      totalChunks: chunks.length,
       written: 0,
-      truncatedCount: 0,
-      durationMs: Date.now() - started,
-      skippedEmpty: 0
+      truncatedChunks: 0,
+      skippedEmptyPages,
+      durationMs: Date.now() - started
     };
   }
 
@@ -74,75 +118,86 @@ export async function runPageEmbeddingBackfill(options: BackfillOptions = {}): P
     throw err;
   });
   Logger.info(`[embed-backfill] server health: ${JSON.stringify(health)}`);
-
   const dim = Number(health.dim);
   if (!Number.isFinite(dim) || dim <= 0) {
     throw new Error(`invalid embedding dim from server: ${health.dim}`);
   }
 
-  Logger.info(`[embed-backfill] ${candidates.length} candidate PageVersion(s) to embed (model=${client.modelId}, dim=${dim})`);
+  Logger.info(`[embed-backfill] ${candidates.length} PV / ${chunks.length} chunk(s) to embed (model=${client.modelId}, dim=${dim}, skippedEmpty=${skippedEmptyPages})`);
 
   let written = 0;
-  let truncatedCount = 0;
-  let skippedEmpty = 0;
+  let truncatedChunks = 0;
 
-  for (let offset = 0; offset < candidates.length; offset += batchSize) {
-    const batch = candidates.slice(offset, offset + batchSize);
-    const prepared = batch.map(c => ({
-      pv: c,
-      prepared: preparePageText(c)
-    }));
+  // 把 chunk 按 batchSize 切成 batch
+  const batches: ChunkItem[][] = [];
+  for (let i = 0; i < chunks.length; i += batchSize) {
+    batches.push(chunks.slice(i, i + batchSize));
+  }
 
-    // 过滤空文本（某些 deleted 页 textContent 完全为空且 header 也为空）
-    const nonEmpty = prepared.filter(p => p.prepared.text.trim().length > 0);
-    skippedEmpty += prepared.length - nonEmpty.length;
-    if (nonEmpty.length === 0) continue;
+  // 并发 worker 模式：N 个异步 loop 从共享队列取 batch
+  let nextBatchIdx = 0;
+  const total = batches.length;
 
-    const texts = nonEmpty.map(p => p.prepared.text);
-    let vectors: number[][];
-    try {
-      vectors = await client.embed(texts);
-    } catch (err) {
-      Logger.error(`[embed-backfill] batch at offset=${offset} failed: ${err}; skipping batch`);
-      continue;
-    }
-    if (vectors.length !== nonEmpty.length) {
-      Logger.error(`[embed-backfill] shape mismatch at offset=${offset}: got ${vectors.length} vs ${nonEmpty.length}; skipping`);
-      continue;
-    }
+  async function workerLoop(workerId: number): Promise<void> {
+    while (true) {
+      const idx = nextBatchIdx;
+      nextBatchIdx += 1;
+      if (idx >= total) return;
+      const batch = batches[idx];
+      const texts = batch.map(c => c.text);
 
-    const rows = nonEmpty.map((p, i) => ({
-      pageVersionId: p.pv.pageVersionId,
-      embedding: vectors[i],
-      sourceCharLen: p.prepared.sourceCharLen,
-      sourceTruncated: p.prepared.truncated
-    }));
+      let vectors: number[][];
+      try {
+        vectors = await client.embed(texts);
+      } catch (err) {
+        Logger.error(`[embed-backfill] w${workerId} batch ${idx} (${batch.length} chunks) failed: ${err}; skipping`);
+        continue;
+      }
+      if (vectors.length !== batch.length) {
+        Logger.error(`[embed-backfill] w${workerId} batch ${idx} shape mismatch: got ${vectors.length} vs ${batch.length}; skipping`);
+        continue;
+      }
 
-    try {
-      await upsertEmbeddings(prisma, client.modelId, dim, rows);
-    } catch (err) {
-      Logger.error(`[embed-backfill] upsert failed at offset=${offset}: ${err}`);
-      continue;
-    }
+      const rows = batch.map((c, i) => ({
+        pageVersionId: c.pageVersionId,
+        embedding: vectors[i],
+        sourceCharLen: c.sourceCharLen,
+        sourceTruncated: c.sourceTruncated,
+        chunkIndex: c.chunkIndex,
+        chunkTotal: c.chunkTotal,
+        chunkCharStart: c.chunkCharStart,
+        chunkCharEnd: c.chunkCharEnd
+      }));
 
-    written += rows.length;
-    truncatedCount += prepared.filter(p => p.prepared.truncated).length;
+      try {
+        await upsertEmbeddings(prisma, client.modelId, dim, rows);
+      } catch (err) {
+        Logger.error(`[embed-backfill] w${workerId} upsert failed at batch ${idx}: ${err}`);
+        continue;
+      }
 
-    if (options.onProgress) {
-      options.onProgress(offset + batch.length, candidates.length, batch[batch.length - 1]);
-    } else if ((offset / batchSize) % 5 === 0) {
-      Logger.info(`[embed-backfill] progress ${offset + batch.length}/${candidates.length} (+${rows.length}; truncated=${truncatedCount}; skippedEmpty=${skippedEmpty})`);
+      written += rows.length;
+      truncatedChunks += rows.filter(r => r.sourceTruncated).length;
+
+      if (idx % 5 === 0) {
+        Logger.info(`[embed-backfill] progress ${Math.min((idx + 1) * batchSize, chunks.length)}/${chunks.length} chunks (+${rows.length}; truncated=${truncatedChunks})`);
+      }
     }
   }
 
+  await Promise.all(
+    Array.from({ length: concurrency }, (_, i) => workerLoop(i))
+  );
+
   const durationMs = Date.now() - started;
-  Logger.info(`[embed-backfill] done: written=${written} truncated=${truncatedCount} skippedEmpty=${skippedEmpty} durationMs=${durationMs}`);
+  Logger.info(`[embed-backfill] done: written=${written}/${chunks.length} chunks truncated=${truncatedChunks} skippedEmpty=${skippedEmptyPages} durationMs=${durationMs}`);
   return {
-    total: candidates.length,
+    totalPages: candidates.length,
+    totalChunks: chunks.length,
     written,
-    truncatedCount,
-    durationMs,
-    skippedEmpty
+    truncatedChunks,
+    skippedEmptyPages,
+    durationMs
   };
 }
 
@@ -156,6 +211,7 @@ export async function runPageEmbeddingBackfill(options: BackfillOptions = {}): P
 export async function runPageEmbeddingIncremental(options: BackfillOptions = {}): Promise<BackfillResult> {
   return runPageEmbeddingBackfill({
     batchSize: 8,
+    concurrency: 1,
     ...options
   });
 }

--- a/backend/src/jobs/PageEmbeddingBackfillJob.ts
+++ b/backend/src/jobs/PageEmbeddingBackfillJob.ts
@@ -1,0 +1,161 @@
+import type { PrismaClient } from '@prisma/client';
+import { getPrismaClient } from '../utils/db-connection.js';
+import { Logger } from '../utils/Logger.js';
+import { EmbeddingClient, embeddingClientFromEnv } from '../services/embedding/EmbeddingClient.js';
+import { preparePageText } from '../services/embedding/PageTextPreparer.js';
+import {
+  listEmbeddingCandidates,
+  upsertEmbeddings,
+  type EmbeddingCandidate
+} from '../services/embedding/PageEmbeddingRepo.js';
+
+export interface BackfillOptions {
+  batchSize?: number;             // default 16（CPU 推理，不要太大）
+  limit?: number;                 // 上限条数；不传=全量
+  includeDeletedPages?: boolean;  // 是否回填已删除 Page（默认 true）
+  dryRun?: boolean;
+  onProgress?: (done: number, total: number, sample?: EmbeddingCandidate) => void;
+  prisma?: PrismaClient;
+  client?: EmbeddingClient;
+}
+
+export interface BackfillResult {
+  total: number;
+  written: number;
+  truncatedCount: number;
+  durationMs: number;
+  skippedEmpty: number;
+}
+
+/**
+ * 把当前还没 embedding 的 PageVersion 批量推过嵌入服务、落 DB。
+ *
+ * 说明：
+ *   - 文本走 `preparePageText`，含 header + denoise + 8000 char 截断
+ *   - 每批 N 个文档一发，失败的 batch 整批 skip 并 log；不影响后续批
+ *   - 因为 upsertEmbeddings 有 ON CONFLICT DO UPDATE，中途崩了再跑是 resume-safe 的
+ */
+export async function runPageEmbeddingBackfill(options: BackfillOptions = {}): Promise<BackfillResult> {
+  const prisma = options.prisma ?? getPrismaClient();
+  const client = options.client ?? embeddingClientFromEnv();
+  const batchSize = options.batchSize ?? 16;
+  const includeDeletedPages = options.includeDeletedPages ?? true;
+  const dryRun = options.dryRun === true;
+
+  Logger.info('[embed-backfill] starting');
+  const started = Date.now();
+
+  // dry-run 路径提前取候选、不接触 HTTP，方便在 embedding server 还没就绪时检查
+  // SQL 的召回是否合理。
+  const candidates = await listEmbeddingCandidates(prisma, client.modelId, {
+    limit: options.limit,
+    includeDeletedPages
+  });
+
+  if (dryRun) {
+    Logger.info(`[embed-backfill] dry run — ${candidates.length} candidate PageVersion(s) (model=${client.modelId}), no HTTP / DB write`);
+    if (candidates.length > 0) {
+      const sample = candidates.slice(0, Math.min(5, candidates.length));
+      for (const c of sample) {
+        Logger.info(`  pv=${c.pageVersionId} wid=${c.wikidotId} deleted=${c.isDeletedPage} title=${c.title ?? '—'}`);
+      }
+    }
+    return {
+      total: candidates.length,
+      written: 0,
+      truncatedCount: 0,
+      durationMs: Date.now() - started,
+      skippedEmpty: 0
+    };
+  }
+
+  const health = await client.health().catch(err => {
+    Logger.error(`[embed-backfill] embedding server health failed: ${err}`);
+    throw err;
+  });
+  Logger.info(`[embed-backfill] server health: ${JSON.stringify(health)}`);
+
+  const dim = Number(health.dim);
+  if (!Number.isFinite(dim) || dim <= 0) {
+    throw new Error(`invalid embedding dim from server: ${health.dim}`);
+  }
+
+  Logger.info(`[embed-backfill] ${candidates.length} candidate PageVersion(s) to embed (model=${client.modelId}, dim=${dim})`);
+
+  let written = 0;
+  let truncatedCount = 0;
+  let skippedEmpty = 0;
+
+  for (let offset = 0; offset < candidates.length; offset += batchSize) {
+    const batch = candidates.slice(offset, offset + batchSize);
+    const prepared = batch.map(c => ({
+      pv: c,
+      prepared: preparePageText(c)
+    }));
+
+    // 过滤空文本（某些 deleted 页 textContent 完全为空且 header 也为空）
+    const nonEmpty = prepared.filter(p => p.prepared.text.trim().length > 0);
+    skippedEmpty += prepared.length - nonEmpty.length;
+    if (nonEmpty.length === 0) continue;
+
+    const texts = nonEmpty.map(p => p.prepared.text);
+    let vectors: number[][];
+    try {
+      vectors = await client.embed(texts);
+    } catch (err) {
+      Logger.error(`[embed-backfill] batch at offset=${offset} failed: ${err}; skipping batch`);
+      continue;
+    }
+    if (vectors.length !== nonEmpty.length) {
+      Logger.error(`[embed-backfill] shape mismatch at offset=${offset}: got ${vectors.length} vs ${nonEmpty.length}; skipping`);
+      continue;
+    }
+
+    const rows = nonEmpty.map((p, i) => ({
+      pageVersionId: p.pv.pageVersionId,
+      embedding: vectors[i],
+      sourceCharLen: p.prepared.sourceCharLen,
+      sourceTruncated: p.prepared.truncated
+    }));
+
+    try {
+      await upsertEmbeddings(prisma, client.modelId, dim, rows);
+    } catch (err) {
+      Logger.error(`[embed-backfill] upsert failed at offset=${offset}: ${err}`);
+      continue;
+    }
+
+    written += rows.length;
+    truncatedCount += prepared.filter(p => p.prepared.truncated).length;
+
+    if (options.onProgress) {
+      options.onProgress(offset + batch.length, candidates.length, batch[batch.length - 1]);
+    } else if ((offset / batchSize) % 5 === 0) {
+      Logger.info(`[embed-backfill] progress ${offset + batch.length}/${candidates.length} (+${rows.length}; truncated=${truncatedCount}; skippedEmpty=${skippedEmpty})`);
+    }
+  }
+
+  const durationMs = Date.now() - started;
+  Logger.info(`[embed-backfill] done: written=${written} truncated=${truncatedCount} skippedEmpty=${skippedEmpty} durationMs=${durationMs}`);
+  return {
+    total: candidates.length,
+    written,
+    truncatedCount,
+    durationMs,
+    skippedEmpty
+  };
+}
+
+/**
+ * 增量：和 backfill 同一个查询（`NOT EXISTS ... PageEmbedding`），
+ * 没 embedding 的 PageVersion 都会被拉出来。所以"增量"和"全量"其实是同一个
+ * 操作，只是量不同。外层自己决定用哪个 limit。
+ *
+ * 这里额外接受 `minIntervalMs`，用来在 cron/sync-hourly 钩子里做一次性滤流。
+ */
+export async function runPageEmbeddingIncremental(options: BackfillOptions = {}): Promise<BackfillResult> {
+  return runPageEmbeddingBackfill({
+    batchSize: 8,
+    ...options
+  });
+}

--- a/backend/src/services/embedding/EmbeddingClient.ts
+++ b/backend/src/services/embedding/EmbeddingClient.ts
@@ -1,0 +1,95 @@
+/**
+ * HTTP client for the local BGE-M3 embedding service
+ * (`backend/services/embedding-server`).
+ *
+ * The wire protocol is a subset of Hugging Face Text Embeddings Inference (TEI):
+ *   POST /embed   { "inputs": [...], "normalize": true } → number[][]
+ *   GET  /health  → { status, model, dim, ... }
+ *
+ * Keeping this subset means we can later replace the Python service with a
+ * real TEI container (once the ghcr.io network situation improves) without
+ * touching callers.
+ */
+
+export interface EmbeddingClientOptions {
+  baseUrl: string;            // e.g. http://127.0.0.1:18080
+  model: string;              // identifier to stamp onto each row (e.g. "BAAI/bge-m3")
+  timeoutMs?: number;         // default 600000 (10min — CPU 上 batch=8 长文本可能 2-4min)
+  normalize?: boolean;        // default true
+  fetchImpl?: typeof fetch;   // tests can inject
+}
+
+export interface EmbeddingHealth {
+  status: 'ok' | string;
+  model?: string;
+  dim?: number;
+  max_seq_len?: number;
+}
+
+export class EmbeddingClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(private opts: EmbeddingClientOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, '');
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  get modelId(): string {
+    return this.opts.model;
+  }
+
+  async health(): Promise<EmbeddingHealth> {
+    const res = await this.request('/health', { method: 'GET' }, 5000);
+    if (!res.ok) {
+      throw new Error(`embedding health ${res.status}: ${await safeText(res)}`);
+    }
+    return (await res.json()) as EmbeddingHealth;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    const body = JSON.stringify({
+      inputs: texts,
+      normalize: this.opts.normalize ?? true
+    });
+    const res = await this.request('/embed', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body
+    });
+    if (!res.ok) {
+      throw new Error(`embedding ${res.status}: ${await safeText(res)}`);
+    }
+    const out = (await res.json()) as number[][];
+    if (!Array.isArray(out) || out.length !== texts.length) {
+      throw new Error(`embedding response shape mismatch: got ${Array.isArray(out) ? out.length : typeof out}, expected ${texts.length}`);
+    }
+    return out;
+  }
+
+  private async request(path: string, init: RequestInit, timeoutOverrideMs?: number): Promise<Response> {
+    const ctl = new AbortController();
+    const t = setTimeout(() => ctl.abort(), timeoutOverrideMs ?? this.opts.timeoutMs ?? 600_000);
+    try {
+      return await this.fetchImpl(`${this.baseUrl}${path}`, { ...init, signal: ctl.signal });
+    } finally {
+      clearTimeout(t);
+    }
+  }
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    const t = await res.text();
+    return t.slice(0, 500);
+  } catch {
+    return '<no body>';
+  }
+}
+
+export function embeddingClientFromEnv(): EmbeddingClient {
+  const baseUrl = process.env.EMBEDDING_SERVER_URL || 'http://127.0.0.1:18080';
+  const model = process.env.EMBEDDING_MODEL || 'BAAI/bge-m3';
+  return new EmbeddingClient({ baseUrl, model });
+}

--- a/backend/src/services/embedding/PageEmbeddingRepo.ts
+++ b/backend/src/services/embedding/PageEmbeddingRepo.ts
@@ -119,8 +119,8 @@ export async function listEmbeddingCandidates(
 }
 
 /**
- * 批量 upsert embedding。collisions 按 `(pageVersionId, model)` 唯一键 ON CONFLICT 更新。
- * 使用 INSERT ... VALUES ..., ...ON CONFLICT DO UPDATE 一次提交 N 行，减少 round-trip。
+ * 批量 upsert chunk embedding。collisions 按 `(pageVersionId, model, chunkIndex)`
+ * 唯一键 ON CONFLICT DO UPDATE。一次 INSERT 多行，减少 round-trip。
  */
 export async function upsertEmbeddings(
   prisma: PrismaClient,
@@ -131,37 +131,49 @@ export async function upsertEmbeddings(
     embedding: number[];
     sourceCharLen: number;
     sourceTruncated: boolean;
+    chunkIndex: number;
+    chunkTotal: number;
+    chunkCharStart: number;
+    chunkCharEnd: number;
   }>
 ): Promise<number> {
   if (rows.length === 0) return 0;
 
-  // 拼 VALUES 字面量：所有 halfvec 字面串 + 其他参数走 $n 位置
-  // pgvector 接收 `[n1,n2,...]::halfvec(1024)` 的 cast 形式
+  // placeholder: ($pvId, $1, $2, $vec::halfvec(dim), $len, $trunc, $cIdx, $cTotal, $cStart, $cEnd)
   const placeholders: string[] = [];
   const params: any[] = [model, dim];
   let idx = 3;
   for (const r of rows) {
     placeholders.push(
-      `($${idx++}, $1, $2, $${idx++}::halfvec(${dim}), $${idx++}, $${idx++})`
+      `($${idx++}, $1, $2, $${idx++}::halfvec(${dim}), $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++})`
     );
     params.push(
       r.pageVersionId,
       toVectorLiteral(r.embedding),
       r.sourceCharLen,
-      r.sourceTruncated
+      r.sourceTruncated,
+      r.chunkIndex,
+      r.chunkTotal,
+      r.chunkCharStart,
+      r.chunkCharEnd
     );
   }
 
   const sql = `
     INSERT INTO "PageEmbedding" (
-      "pageVersionId", "model", "dim", "embedding", "sourceCharLen", "sourceTruncated"
+      "pageVersionId", "model", "dim", "embedding",
+      "sourceCharLen", "sourceTruncated",
+      "chunkIndex", "chunkTotal", "chunkCharStart", "chunkCharEnd"
     )
     VALUES ${placeholders.join(',')}
-    ON CONFLICT ("pageVersionId", "model") DO UPDATE SET
+    ON CONFLICT ("pageVersionId", "model", "chunkIndex") DO UPDATE SET
       "embedding" = EXCLUDED."embedding",
       "dim" = EXCLUDED."dim",
       "sourceCharLen" = EXCLUDED."sourceCharLen",
       "sourceTruncated" = EXCLUDED."sourceTruncated",
+      "chunkTotal" = EXCLUDED."chunkTotal",
+      "chunkCharStart" = EXCLUDED."chunkCharStart",
+      "chunkCharEnd" = EXCLUDED."chunkCharEnd",
       "createdAt" = CURRENT_TIMESTAMP
   `;
   const res: any = await prisma.$executeRawUnsafe(sql, ...params);
@@ -177,15 +189,21 @@ export interface SearchHit {
   rating: number | null;
   category: string | null;
   tags: string[];
-  denseScore: number;            // 1 - cosine distance
+  denseScore: number;            // 1 - cosine distance（chunk 里的最高分）
   sparseScore: number;           // pgroonga score normalized roughly to [0,1]
   finalScore: number;            // weighted combination
   isDeletedPage: boolean;
+  /** 命中的最佳 chunk 序号（若 dense 命中）。用于 UI 跳转/高亮。 */
+  hitChunkIndex: number | null;
+  hitChunkCharStart: number | null;
+  hitChunkCharEnd: number | null;
 }
 
 /**
- * Hybrid search: dense cosine（pgvector HNSW）+ sparse（pgroonga 全文）+ tag 交集加权。
- * 前 K 直接在 SQL 里融合；真实权重可以随 query 日志调。
+ * Hybrid search: dense cosine（pgvector HNSW，chunk 粒度）+ sparse（pgroonga 全文，
+ * PageVersion 粒度）。chunk 候选按 max 聚合到 PageVersion，再与 sparse UNION。
+ *
+ * 权重可配，默认 dense 0.65 / sparse 0.35；真实权重可以随 query 日志调。
  */
 export async function hybridSearch(
   prisma: PrismaClient,
@@ -201,7 +219,8 @@ export async function hybridSearch(
   } = {}
 ): Promise<SearchHit[]> {
   const limit = opts.limit ?? 10;
-  const denseN = opts.denseCandidates ?? 60;
+  // chunk 比 PV 多，所以 denseN 要拉大一些，保证聚合后还能覆盖够多 PV
+  const denseN = opts.denseCandidates ?? 200;
   const sparseN = opts.sparseCandidates ?? 60;
   const wd = opts.denseWeight ?? 0.65;
   const ws = opts.sparseWeight ?? 0.35;
@@ -209,13 +228,23 @@ export async function hybridSearch(
 
   const rows = await prisma.$queryRawUnsafe<any[]>(
     `
-    WITH dense AS (
+    WITH dense_chunks AS (
       SELECT pe."pageVersionId",
+             pe."chunkIndex",
+             pe."chunkCharStart",
+             pe."chunkCharEnd",
              1 - (pe.embedding <=> $1::halfvec(${queryEmbedding.length})) AS score
       FROM "PageEmbedding" pe
       WHERE pe.model = $2
       ORDER BY pe.embedding <=> $1::halfvec(${queryEmbedding.length})
       LIMIT $3
+    ),
+    dense AS (
+      -- 每个 PV 只保留分数最高的 chunk
+      SELECT DISTINCT ON ("pageVersionId")
+        "pageVersionId", score, "chunkIndex", "chunkCharStart", "chunkCharEnd"
+      FROM dense_chunks
+      ORDER BY "pageVersionId", score DESC
     ),
     sparse AS (
       SELECT pv.id AS "pageVersionId",
@@ -246,7 +275,10 @@ export async function hybridSearch(
       p."isDeleted" AS "isDeletedPage",
       COALESCE(dense.score, 0)::float AS "denseScore",
       COALESCE(sparse.score / (SELECT mx FROM max_sparse), 0)::float AS "sparseScore",
-      (COALESCE(dense.score, 0) * $6 + COALESCE(sparse.score / (SELECT mx FROM max_sparse), 0) * $7)::float AS "finalScore"
+      (COALESCE(dense.score, 0) * $6 + COALESCE(sparse.score / (SELECT mx FROM max_sparse), 0) * $7)::float AS "finalScore",
+      dense."chunkIndex" AS "hitChunkIndex",
+      dense."chunkCharStart" AS "hitChunkCharStart",
+      dense."chunkCharEnd" AS "hitChunkCharEnd"
     FROM merged m
     JOIN "PageVersion" pv ON pv.id = m."pageVersionId"
     JOIN "Page" p ON p.id = pv."pageId"
@@ -277,6 +309,9 @@ export async function hybridSearch(
     denseScore: Number(r.denseScore ?? 0),
     sparseScore: Number(r.sparseScore ?? 0),
     finalScore: Number(r.finalScore ?? 0),
-    isDeletedPage: Boolean(r.isDeletedPage)
+    isDeletedPage: Boolean(r.isDeletedPage),
+    hitChunkIndex: r.hitChunkIndex == null ? null : Number(r.hitChunkIndex),
+    hitChunkCharStart: r.hitChunkCharStart == null ? null : Number(r.hitChunkCharStart),
+    hitChunkCharEnd: r.hitChunkCharEnd == null ? null : Number(r.hitChunkCharEnd)
   }));
 }

--- a/backend/src/services/embedding/PageEmbeddingRepo.ts
+++ b/backend/src/services/embedding/PageEmbeddingRepo.ts
@@ -1,0 +1,282 @@
+/**
+ * DB-side helpers for reading/writing `PageEmbedding` rows.
+ * Kept separate from the job code so the raw SQL for pgvector stays
+ * in one place (Prisma doesn't natively support `halfvec`).
+ */
+import type { PrismaClient } from '@prisma/client';
+
+/** Turn a JS number[] into the literal form pgvector accepts in text (`[1,2,3]`). */
+export function toVectorLiteral(vec: number[]): string {
+  const parts: string[] = new Array(vec.length);
+  for (let i = 0; i < vec.length; i += 1) {
+    const v = vec[i];
+    // NaN/Infinity → 0 防炸。pg halfvec 会对非法浮点 reject，这里一起兜住。
+    parts[i] = Number.isFinite(v) ? String(v) : '0';
+  }
+  return `[${parts.join(',')}]`;
+}
+
+export interface EmbeddingCandidate {
+  pageVersionId: number;
+  pageId: number;
+  wikidotId: number | null;
+  title: string | null;
+  alternateTitle: string | null;
+  category: string | null;
+  tags: string[];
+  textContent: string | null;
+  isDeletedPage: boolean;
+}
+
+/**
+ * 取出"需要回填"的 PageVersion 列表 —— 用的是 effective-version 选择：
+ *   - Page 当前版本非 tombstone → 选 current PV
+ *   - Page 当前版本是 tombstone → 选该 Page 最后一个非 deleted PV
+ *
+ * 然后排除已经有同模型 embedding 的记录。
+ */
+export async function listEmbeddingCandidates(
+  prisma: PrismaClient,
+  model: string,
+  opts: { limit?: number; includeDeletedPages?: boolean } = {}
+): Promise<EmbeddingCandidate[]> {
+  const limit = opts.limit ?? 1_000_000;
+  const includeDeletedPages = opts.includeDeletedPages ?? true;
+
+  // 两段：active pages 用 current；deleted pages 用 last non-deleted（若存在）
+  const rows = await prisma.$queryRawUnsafe<any[]>(
+    `
+    WITH current_pv AS (
+      SELECT DISTINCT ON (pv."pageId")
+        pv.id AS "pageVersionId",
+        pv."pageId",
+        pv."isDeleted" AS "versionIsDeleted"
+      FROM "PageVersion" pv
+      WHERE pv."validTo" IS NULL
+      ORDER BY pv."pageId", pv.id DESC
+    ),
+    chosen_pv AS (
+      -- 非 deleted 当前版本：直接用
+      SELECT c."pageVersionId", c."pageId", false AS "fromFallback"
+      FROM current_pv c
+      JOIN "Page" p ON p.id = c."pageId"
+      WHERE c."versionIsDeleted" = false
+        AND ($2::boolean OR p."isDeleted" = false)
+
+      UNION ALL
+
+      -- 已删除 Page：回退到最后一个非 deleted PV
+      SELECT fb.id AS "pageVersionId", c."pageId", true AS "fromFallback"
+      FROM current_pv c
+      JOIN "Page" p ON p.id = c."pageId"
+      JOIN LATERAL (
+        SELECT id
+          FROM "PageVersion"
+         WHERE "pageId" = c."pageId" AND "isDeleted" = false
+         ORDER BY "validFrom" DESC NULLS LAST, id DESC
+         LIMIT 1
+      ) fb ON true
+      WHERE c."versionIsDeleted" = true
+        AND $2::boolean
+    )
+    SELECT
+      chosen."pageVersionId",
+      pv."pageId",
+      p."wikidotId",
+      pv.title,
+      pv."alternateTitle",
+      pv.category,
+      pv.tags,
+      pv."textContent",
+      p."isDeleted" AS "isDeletedPage"
+    FROM chosen_pv chosen
+    JOIN "PageVersion" pv ON pv.id = chosen."pageVersionId"
+    JOIN "Page" p ON p.id = pv."pageId"
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "PageEmbedding" pe
+      WHERE pe."pageVersionId" = chosen."pageVersionId"
+        AND pe.model = $1
+    )
+    ORDER BY chosen."pageVersionId"
+    LIMIT $3
+    `,
+    model,
+    includeDeletedPages,
+    limit
+  );
+
+  return rows.map((r) => ({
+    pageVersionId: Number(r.pageVersionId),
+    pageId: Number(r.pageId),
+    wikidotId: r.wikidotId == null ? null : Number(r.wikidotId),
+    title: r.title ?? null,
+    alternateTitle: r.alternateTitle ?? null,
+    category: r.category ?? null,
+    tags: Array.isArray(r.tags) ? r.tags : [],
+    textContent: r.textContent ?? null,
+    isDeletedPage: Boolean(r.isDeletedPage)
+  }));
+}
+
+/**
+ * 批量 upsert embedding。collisions 按 `(pageVersionId, model)` 唯一键 ON CONFLICT 更新。
+ * 使用 INSERT ... VALUES ..., ...ON CONFLICT DO UPDATE 一次提交 N 行，减少 round-trip。
+ */
+export async function upsertEmbeddings(
+  prisma: PrismaClient,
+  model: string,
+  dim: number,
+  rows: Array<{
+    pageVersionId: number;
+    embedding: number[];
+    sourceCharLen: number;
+    sourceTruncated: boolean;
+  }>
+): Promise<number> {
+  if (rows.length === 0) return 0;
+
+  // 拼 VALUES 字面量：所有 halfvec 字面串 + 其他参数走 $n 位置
+  // pgvector 接收 `[n1,n2,...]::halfvec(1024)` 的 cast 形式
+  const placeholders: string[] = [];
+  const params: any[] = [model, dim];
+  let idx = 3;
+  for (const r of rows) {
+    placeholders.push(
+      `($${idx++}, $1, $2, $${idx++}::halfvec(${dim}), $${idx++}, $${idx++})`
+    );
+    params.push(
+      r.pageVersionId,
+      toVectorLiteral(r.embedding),
+      r.sourceCharLen,
+      r.sourceTruncated
+    );
+  }
+
+  const sql = `
+    INSERT INTO "PageEmbedding" (
+      "pageVersionId", "model", "dim", "embedding", "sourceCharLen", "sourceTruncated"
+    )
+    VALUES ${placeholders.join(',')}
+    ON CONFLICT ("pageVersionId", "model") DO UPDATE SET
+      "embedding" = EXCLUDED."embedding",
+      "dim" = EXCLUDED."dim",
+      "sourceCharLen" = EXCLUDED."sourceCharLen",
+      "sourceTruncated" = EXCLUDED."sourceTruncated",
+      "createdAt" = CURRENT_TIMESTAMP
+  `;
+  const res: any = await prisma.$executeRawUnsafe(sql, ...params);
+  return Number(res) || rows.length;
+}
+
+export interface SearchHit {
+  pageVersionId: number;
+  pageId: number;
+  wikidotId: number | null;
+  title: string | null;
+  alternateTitle: string | null;
+  rating: number | null;
+  category: string | null;
+  tags: string[];
+  denseScore: number;            // 1 - cosine distance
+  sparseScore: number;           // pgroonga score normalized roughly to [0,1]
+  finalScore: number;            // weighted combination
+  isDeletedPage: boolean;
+}
+
+/**
+ * Hybrid search: dense cosine（pgvector HNSW）+ sparse（pgroonga 全文）+ tag 交集加权。
+ * 前 K 直接在 SQL 里融合；真实权重可以随 query 日志调。
+ */
+export async function hybridSearch(
+  prisma: PrismaClient,
+  model: string,
+  queryEmbedding: number[],
+  queryText: string,
+  opts: {
+    limit?: number;
+    denseCandidates?: number;
+    sparseCandidates?: number;
+    denseWeight?: number;
+    sparseWeight?: number;
+  } = {}
+): Promise<SearchHit[]> {
+  const limit = opts.limit ?? 10;
+  const denseN = opts.denseCandidates ?? 60;
+  const sparseN = opts.sparseCandidates ?? 60;
+  const wd = opts.denseWeight ?? 0.65;
+  const ws = opts.sparseWeight ?? 0.35;
+  const vec = toVectorLiteral(queryEmbedding);
+
+  const rows = await prisma.$queryRawUnsafe<any[]>(
+    `
+    WITH dense AS (
+      SELECT pe."pageVersionId",
+             1 - (pe.embedding <=> $1::halfvec(${queryEmbedding.length})) AS score
+      FROM "PageEmbedding" pe
+      WHERE pe.model = $2
+      ORDER BY pe.embedding <=> $1::halfvec(${queryEmbedding.length})
+      LIMIT $3
+    ),
+    sparse AS (
+      SELECT pv.id AS "pageVersionId",
+             pgroonga_score(tableoid, ctid) AS score
+      FROM "PageVersion" pv
+      WHERE pv.search_text &@~ $4
+        AND pv."validTo" IS NULL
+      ORDER BY pgroonga_score(tableoid, ctid) DESC
+      LIMIT $5
+    ),
+    merged AS (
+      SELECT "pageVersionId" FROM dense
+      UNION
+      SELECT "pageVersionId" FROM sparse
+    ),
+    max_sparse AS (
+      SELECT GREATEST(MAX(score), 1e-6) AS mx FROM sparse
+    )
+    SELECT
+      pv.id AS "pageVersionId",
+      pv."pageId",
+      p."wikidotId",
+      pv.title,
+      pv."alternateTitle",
+      pv.rating,
+      pv.category,
+      pv.tags,
+      p."isDeleted" AS "isDeletedPage",
+      COALESCE(dense.score, 0)::float AS "denseScore",
+      COALESCE(sparse.score / (SELECT mx FROM max_sparse), 0)::float AS "sparseScore",
+      (COALESCE(dense.score, 0) * $6 + COALESCE(sparse.score / (SELECT mx FROM max_sparse), 0) * $7)::float AS "finalScore"
+    FROM merged m
+    JOIN "PageVersion" pv ON pv.id = m."pageVersionId"
+    JOIN "Page" p ON p.id = pv."pageId"
+    LEFT JOIN dense ON dense."pageVersionId" = m."pageVersionId"
+    LEFT JOIN sparse ON sparse."pageVersionId" = m."pageVersionId"
+    ORDER BY "finalScore" DESC
+    LIMIT $8
+    `,
+    vec,
+    model,
+    denseN,
+    queryText,
+    sparseN,
+    wd,
+    ws,
+    limit
+  );
+
+  return rows.map((r: any) => ({
+    pageVersionId: Number(r.pageVersionId),
+    pageId: Number(r.pageId),
+    wikidotId: r.wikidotId == null ? null : Number(r.wikidotId),
+    title: r.title ?? null,
+    alternateTitle: r.alternateTitle ?? null,
+    rating: r.rating == null ? null : Number(r.rating),
+    category: r.category ?? null,
+    tags: Array.isArray(r.tags) ? r.tags : [],
+    denseScore: Number(r.denseScore ?? 0),
+    sparseScore: Number(r.sparseScore ?? 0),
+    finalScore: Number(r.finalScore ?? 0),
+    isDeletedPage: Boolean(r.isDeletedPage)
+  }));
+}

--- a/backend/src/services/embedding/PageTextPreparer.ts
+++ b/backend/src/services/embedding/PageTextPreparer.ts
@@ -1,0 +1,89 @@
+/**
+ * Build the input text fed to the embedding model for one PageVersion.
+ *
+ * Structure:
+ *   标题: <title>
+ *   别名: <alternateTitle>         (optional)
+ *   分类: <category>               (optional)
+ *   标签: <tags joined>            (optional)
+ *
+ *   <textContent, trimmed/truncated>
+ *
+ * Truncation rule: BGE-M3 allows 8192 tokens. For Chinese text ~1 char = 1 token
+ * (most CJK codepoints tokenize as 1 piece). We keep an 8000-char safety cap on
+ * the final composed string. Longer inputs get trimmed at the end of textContent
+ * and `truncated=true` is reported so the caller can log it for downstream QA.
+ */
+
+export interface PageTextInput {
+  title: string | null;
+  alternateTitle: string | null;
+  category: string | null;
+  tags: string[] | null;
+  textContent: string | null;
+}
+
+export interface PreparedPageText {
+  text: string;
+  sourceCharLen: number;
+  truncated: boolean;
+}
+
+const MAX_FINAL_CHARS = 8000;
+const HEADER_BUDGET = 600; // tags + category + title rarely exceed this; reserve
+
+// 粗清洗：Wikidot 源码片段会有 [[include]] / [[module]] / [[div ...]] 噪音；
+// 我们只是做 embedding，把这类语法标记剥掉能让相似度比对更纯。
+// 不尝试完整渲染 — 只是减噪。
+const WIKIDOT_NOISE_PATTERNS: RegExp[] = [
+  /\[\[include[^\]]*\]\]/gi,
+  /\[\[\/?module[^\]]*\]\]/gi,
+  /\[\[\/?div[^\]]*\]\]/gi,
+  /\[\[\/?span[^\]]*\]\]/gi,
+  /\[\[\/?size[^\]]*\]\]/gi,
+  /\[\[\/?a[^\]]*\]\]/gi,
+  /\[\[\/?collapsible[^\]]*\]\]/gi,
+  /\[\[\/?iframe[^\]]*\]\]/gi,
+  /\[\[\/?image[^\]]*\]\]/gi,
+  /\[\[\/?footnoteblock[^\]]*\]\]/gi,
+  /\[\[\/?footnote[^\]]*\]\]/gi,
+  /\[\[\/?bibliography[^\]]*\]\]/gi
+];
+
+function denoise(raw: string): string {
+  let s = raw;
+  for (const re of WIKIDOT_NOISE_PATTERNS) {
+    s = s.replace(re, ' ');
+  }
+  // 折叠空白（换行保留一次用于分段）
+  s = s.replace(/\t+/g, ' ').replace(/[  ]{2,}/g, ' ');
+  s = s.replace(/\n{3,}/g, '\n\n');
+  return s.trim();
+}
+
+export function preparePageText(input: PageTextInput): PreparedPageText {
+  const header: string[] = [];
+  if (input.title) header.push(`标题: ${input.title}`);
+  if (input.alternateTitle && input.alternateTitle !== input.title) {
+    header.push(`别名: ${input.alternateTitle}`);
+  }
+  if (input.category) header.push(`分类: ${input.category}`);
+  const tagsTrimmed = (input.tags ?? []).filter(t => t && !t.startsWith('_')).slice(0, 32);
+  if (tagsTrimmed.length) header.push(`标签: ${tagsTrimmed.join(', ')}`);
+
+  const headerText = header.join('\n');
+  const contentBudget = Math.max(0, MAX_FINAL_CHARS - Math.min(headerText.length, HEADER_BUDGET) - 4);
+  const body = denoise(input.textContent || '');
+  const truncated = body.length > contentBudget;
+  const bodyTrimmed = truncated ? body.slice(0, contentBudget) : body;
+
+  const composed = bodyTrimmed
+    ? `${headerText}\n\n${bodyTrimmed}`
+    : headerText;
+
+  return {
+    text: composed,
+    sourceCharLen: composed.length,
+    truncated
+  };
+}

--- a/backend/src/services/embedding/PageTextPreparer.ts
+++ b/backend/src/services/embedding/PageTextPreparer.ts
@@ -1,18 +1,15 @@
 /**
- * Build the input text fed to the embedding model for one PageVersion.
+ * Prepare one PageVersion for chunk-level embedding.
  *
- * Structure:
- *   标题: <title>
- *   别名: <alternateTitle>         (optional)
- *   分类: <category>               (optional)
- *   标签: <tags joined>            (optional)
+ * Output is a list of chunks (>=1). Each chunk carries:
+ *   - 和整页共享的 header（title / alt / category / tags）
+ *   - 正文的某一段（char 粒度滑窗 + overlap）
+ *   - 段在整页原文中的 [start, end) 字符范围（便于后续高亮/跳转）
  *
- *   <textContent, trimmed/truncated>
- *
- * Truncation rule: BGE-M3 allows 8192 tokens. For Chinese text ~1 char = 1 token
- * (most CJK codepoints tokenize as 1 piece). We keep an 8000-char safety cap on
- * the final composed string. Longer inputs get trimmed at the end of textContent
- * and `truncated=true` is reported so the caller can log it for downstream QA.
+ * 为什么按字符而不是 token 切：
+ *   1. 不需要在 Node 端引入 tokenizer（不想额外装 transformers/tokenizer 原生包）
+ *   2. 中文下 char ≈ token，英文混合也只差 2-3x，embedding 模型自己会在末端截
+ *   3. overlap 只需要粗略"跨段连续"，不需要精确 token 对齐
  */
 
 export interface PageTextInput {
@@ -23,18 +20,31 @@ export interface PageTextInput {
   textContent: string | null;
 }
 
-export interface PreparedPageText {
+export interface PreparedChunk {
+  /** 实际喂给模型的完整字符串（header + content slice） */
   text: string;
+  /** 字符长度（含 header），作为 sourceCharLen 存库 */
   sourceCharLen: number;
+  /** 这个 chunk 对应的正文 char 范围 [start, end) */
+  contentStart: number;
+  contentEnd: number;
+  /** 从 0 开始；同一 PV 的 chunk 序号 */
+  chunkIndex: number;
+  /** 这个 PV 的总 chunk 数（chunks[i].chunkTotal 对所有 i 相同） */
+  chunkTotal: number;
+  /** 尾部是否被 BGE-M3 截掉（chunk 本身 > 模型 max_seq 时发生，目前几乎不会） */
   truncated: boolean;
 }
 
-const MAX_FINAL_CHARS = 8000;
-const HEADER_BUDGET = 600; // tags + category + title rarely exceed this; reserve
+/** Chunk 大小 / overlap / 上限。对 BGE-M3 (8K token ~ 8K char on 中文) 是安全值。 */
+const CHUNK_SIZE = 1500;
+const CHUNK_OVERLAP = 200;
+const HEADER_BUDGET = 600;
+/** 硬上限：即使 header + chunk 超过 model max_seq，server 端会再截一次。 */
+const MODEL_MAX_CHARS = 7500;
+/** 每篇最多切几段；过长页（如 85K char hub）截断到 MAX_CHUNKS × CHUNK_SIZE。 */
+const MAX_CHUNKS = 16;
 
-// 粗清洗：Wikidot 源码片段会有 [[include]] / [[module]] / [[div ...]] 噪音；
-// 我们只是做 embedding，把这类语法标记剥掉能让相似度比对更纯。
-// 不尝试完整渲染 — 只是减噪。
 const WIKIDOT_NOISE_PATTERNS: RegExp[] = [
   /\[\[include[^\]]*\]\]/gi,
   /\[\[\/?module[^\]]*\]\]/gi,
@@ -55,35 +65,75 @@ function denoise(raw: string): string {
   for (const re of WIKIDOT_NOISE_PATTERNS) {
     s = s.replace(re, ' ');
   }
-  // 折叠空白（换行保留一次用于分段）
-  s = s.replace(/\t+/g, ' ').replace(/[  ]{2,}/g, ' ');
+  s = s.replace(/\t+/g, ' ').replace(/[  ]{2,}/g, ' ');
   s = s.replace(/\n{3,}/g, '\n\n');
   return s.trim();
 }
 
-export function preparePageText(input: PageTextInput): PreparedPageText {
-  const header: string[] = [];
-  if (input.title) header.push(`标题: ${input.title}`);
+function buildHeader(input: PageTextInput): string {
+  const h: string[] = [];
+  if (input.title) h.push(`标题: ${input.title}`);
   if (input.alternateTitle && input.alternateTitle !== input.title) {
-    header.push(`别名: ${input.alternateTitle}`);
+    h.push(`别名: ${input.alternateTitle}`);
   }
-  if (input.category) header.push(`分类: ${input.category}`);
-  const tagsTrimmed = (input.tags ?? []).filter(t => t && !t.startsWith('_')).slice(0, 32);
-  if (tagsTrimmed.length) header.push(`标签: ${tagsTrimmed.join(', ')}`);
+  if (input.category) h.push(`分类: ${input.category}`);
+  const tags = (input.tags ?? []).filter(t => t && !t.startsWith('_')).slice(0, 32);
+  if (tags.length) h.push(`标签: ${tags.join(', ')}`);
+  return h.join('\n');
+}
 
-  const headerText = header.join('\n');
-  const contentBudget = Math.max(0, MAX_FINAL_CHARS - Math.min(headerText.length, HEADER_BUDGET) - 4);
+export function preparePageChunks(input: PageTextInput): PreparedChunk[] {
+  const header = buildHeader(input);
+  const headerForChunk = header.length > HEADER_BUDGET
+    ? header.slice(0, HEADER_BUDGET)
+    : header;
   const body = denoise(input.textContent || '');
-  const truncated = body.length > contentBudget;
-  const bodyTrimmed = truncated ? body.slice(0, contentBudget) : body;
 
-  const composed = bodyTrimmed
-    ? `${headerText}\n\n${bodyTrimmed}`
-    : headerText;
+  // 极短页或完全无正文：只 embed header。仍产出 1 个 chunk（长度为 0 的正文段）。
+  if (!body) {
+    if (!headerForChunk) {
+      return [];
+    }
+    return [
+      {
+        text: headerForChunk,
+        sourceCharLen: headerForChunk.length,
+        contentStart: 0,
+        contentEnd: 0,
+        chunkIndex: 0,
+        chunkTotal: 1,
+        truncated: false
+      }
+    ];
+  }
 
-  return {
-    text: composed,
-    sourceCharLen: composed.length,
-    truncated
-  };
+  // 切段：滑窗 [i, i + CHUNK_SIZE)，下一段从 i + CHUNK_SIZE - CHUNK_OVERLAP 开始
+  const step = CHUNK_SIZE - CHUNK_OVERLAP;
+  const rawChunks: Array<{ start: number; end: number }> = [];
+  for (let start = 0; start < body.length; start += step) {
+    const end = Math.min(start + CHUNK_SIZE, body.length);
+    rawChunks.push({ start, end });
+    if (end === body.length) break;
+    if (rawChunks.length >= MAX_CHUNKS) break;
+  }
+
+  const total = rawChunks.length;
+  const chunks: PreparedChunk[] = rawChunks.map((c, idx) => {
+    const bodySlice = body.slice(c.start, c.end);
+    // header + 正文片段 + chunk 序号提示（帮助模型区分"这是第几段"）
+    const segTag = total > 1 ? `\n[段 ${idx + 1}/${total}]\n` : '\n\n';
+    const composed = `${headerForChunk}${segTag}${bodySlice}`;
+    const truncated = composed.length > MODEL_MAX_CHARS;
+    return {
+      text: truncated ? composed.slice(0, MODEL_MAX_CHARS) : composed,
+      sourceCharLen: truncated ? MODEL_MAX_CHARS : composed.length,
+      contentStart: c.start,
+      contentEnd: c.end,
+      chunkIndex: idx,
+      chunkTotal: total,
+      truncated
+    };
+  });
+
+  return chunks;
 }


### PR DESCRIPTION
## Summary

为未来的语义检索搭底：对每个 PageVersion 用本地 BGE-M3 生成 1024-d halfvec 向量，pgvector HNSW 索引，dense+sparse(pgroonga) hybrid 搜索。

## 做了什么

- **DB**: 新增 `PageEmbedding(pageVersionId, model, dim, embedding halfvec(1024), sourceCharLen, sourceTruncated)`；`(pageVersionId, model)` 唯一键；HNSW cosine index（m=16, ef=64）。Prisma schema 声明 `vector` extension。Raw migration SQL 因为 halfvec/HNSW 不是原生 Prisma 类型。
- **推理服务**: `backend/services/embedding-server/`，Python 3.10 + FastAPI + sentence-transformers，CPU 跑 BGE-M3。TEI 协议 `/embed` 兼容子集，后续想换 HF TEI 容器 drop-in。模型从 ModelScope 拉（HF 境内不稳）。
- **TS service 层**: EmbeddingClient / PageTextPreparer / PageEmbeddingRepo / PageEmbeddingBackfillJob。effective-version 选择和 badge 回退口径一致（deleted Page 回到最后非 deleted PV）。upsert ON CONFLICT DO UPDATE。
- **CLI**: `scpper embed {health,backfill,incremental,search}`，含 `--dry-run` / `--limit` / `--batch-size` / `--no-deleted`。hybrid search 权重 dense 0.65 + sparse(pgroonga) 0.35。
- **sync-hourly 接入**: 新增 `--skip-embed` flag；默认每小时扫 `NOT EXISTS PageEmbedding` 的 PageVersion 最多 500 条。失败非致命。

## 选型理由

- **本地 BGE-M3**（没选 OpenAI 3-small）：已删除页源码不外发、SCP 专有词 dense+sparse(pgroonga) 互补、查询端延迟本地稳定。
- **没选 Qwen3-Embedding**：0.6B dense 质量与 BGE-M3 持平但无 sparse；4B/8B 在 CPU 不可接受。
- **pgvector halfvec(1024)** 而非 vector(1024)：FP16 存储省 50%（36K × 1024 × 2 = 67MB），cosine 精度几乎无损。

## 验证

- `npx tsc --noEmit` 过
- migration 在生产库手工先 `CREATE EXTENSION vector`（需 superuser）后 `prisma migrate deploy` 成功
- pgvector halfvec roundtrip 测过（insert / `<=>` cosine / delete）
- 50 条 sanity backfill 2.34s/doc → 全量 36,076 候选估算 ~20h CPU
- 语义 smoke（仅基于 50 条样本）：
  * `代号Brown` → top1 dense 0.572 ✓
  * `Clef 和 Dmitri` → top1 dense 0.617 + sparse 0.693 ✓
  * `被困的特工` → 语义返回相关 Clef 故事 ✓

## Operational

- 全量 backfill 目前正在 feat worktree 的 embedding server 跑（后台 nohup，PID 3763226，~23h 内完成）
- 写入直接落到共享生产 DB — merge/deploy 之后 sync-hourly 的增量 hook 自动接管
- 若要改模型：加一行 `EMBEDDING_MODEL=...` 重跑 backfill，新旧向量按 `model` 列并存

## Test plan
- [x] TS tsc clean
- [x] pg_vector extension install + halfvec roundtrip
- [x] Small sanity backfill (50 rows) + semantic smoke search
- [ ] 全量 ~36K backfill 跑完 + 搜索质量回看
- [ ] 生产部署：extension + migration + sync-hourly 自动装

## Non-goals

- 暴露 `/api/search` 路由 — 下一个 PR 做
- 向量 chunking — 目前 doc-level；p95 页面 4K token 内
- 任何前端 UI