### PR TITLE
feat(about): 新增赞助者 four_clovers 条目 (2026.4.22)

### DIFF
--- a/frontend/pages/about.vue
+++ b/frontend/pages/about.vue
@@ -73,6 +73,10 @@
             <UserCard class="inline-flex align-[-0.5ex] mr-2 h-6" size="S" :wikidot-id="6238162" :display-name="'Northern Lake'" bare />
             ：答案是42 -- 2026.2.13 
           </p>
+          <p class="text-sm leading-6 text-neutral-700 dark:text-neutral-300">
+            <UserCard class="inline-flex align-[-0.5ex] mr-2 h-6" size="S" :wikidot-id="8274616" :display-name="'four_clovers'" bare />
+            ：看到这句话的人去观看50遍《超时空辉夜姬》，我知道这很难但这是命令。 -- 2026.4.22
+          </p>
 
           <p class="text-sm leading-6 text-neutral-700 dark:text-neutral-300 mt-3">
             感谢以上赞助者对网站的支持！


### PR DESCRIPTION
## Summary
- 在 `frontend/pages/about.vue` 「赞助者的话」区块新增 four_clovers (wikidotId 8274616) 的赞助留言。
- 沿用既有 `<UserCard ... bare />` + 文案 + 日期模板,无样式或脚本变化。

## Test plan
- [x] BFF `users/by-wikidot-id?wikidotId=8274616` 已确认对应 displayName=`four_clovers`。
- [ ] 部署后访问 `/about`,确认新条目渲染正常、头像加载、与其他条目对齐一致。