### PR TITLE
fix(vote-sync): 修复改投漏抓 bug 并回填 170k 行 vote 数据

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,8 @@
     "cleanup:high-count": "node --import tsx/esm scripts/cleanup-high-count-pages.ts",
     "cleanup:tracking": "node --import tsx/esm src/cli/index.ts tracking-retention",
     "check:tracking": "node --import tsx/esm scripts/check-tracking-health.ts",
+    "check:vote-integrity": "node --import tsx/esm scripts/check-vote-integrity.ts",
+    "vote-resync-audit": "node --import tsx/esm src/cli/index.ts vote-resync-audit",
     "check:preview-usage": "node --import tsx/esm src/cli/preview-usage.ts",
     "audit:pageversion-validity": "node --import tsx/esm scripts/check-pageversion-validity-window.ts",
     "fix:pageversion-boundaries": "node --import tsx/esm scripts/fix-pageversion-boundaries.ts",

--- a/backend/scripts/check-same-direction-duplicates.ts
+++ b/backend/scripts/check-same-direction-duplicates.ts
@@ -119,6 +119,9 @@ async function detect(options: ScriptOptions): Promise<void> {
   const displayLimit = limitSpecified && limit != null ? limit : DEFAULT_DISPLAY_LIMIT;
   const limitClause = queryLimit != null ? Prisma.sql`LIMIT ${queryLimit}` : Prisma.sql``;
 
+  // NOTE: 本脚本只检测 ±1 方向的同向重复投票（数据完整性检查）；±2 不在此分析范围内，
+  // 因此 SQL 内仍使用 `direction IN (-1, 1)` 与 `direction = 1`/`direction = -1`，与全站
+  // upvote/downvote 计数口径（`direction > 0`/`direction < 0`）有意区分，请勿改动。
   const rows = await prisma.$queryRaw<DuplicateRow[]>(Prisma.sql`
     WITH filtered_votes AS (
       SELECT

--- a/backend/scripts/check-vote-integrity.ts
+++ b/backend/scripts/check-vote-integrity.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+import { disconnectPrisma, getPrismaClient } from '../src/utils/db-connection.ts';
+
+/**
+ * check-vote-integrity
+ *
+ * 常态化对账脚本：比对 LatestVote 重算的 (rating, voteCount) 与 PageVersion 上的
+ * pa_rating / pa_count，输出 7 个 bucket 的统计 + top 20 偏差页详情。
+ *
+ * CLI 选项：
+ *   --threshold N     any_mismatch > N 时 exit 1（默认 100）
+ *   --json            以 JSON 输出
+ */
+
+type SummaryRow = {
+  total_pages: bigint | number | null;
+  no_votes_synced: bigint | number | null;
+  perfect_match: bigint | number | null;
+  rating_mismatch: bigint | number | null;
+  count_mismatch: bigint | number | null;
+  direction_out_of_range: bigint | number | null;
+  any_mismatch: bigint | number | null;
+};
+
+type AnomalyRow = {
+  wikidotId: number | null;
+  pageVersionId: number;
+  url: string | null;
+  pa_rating: number | null;
+  pa_count: number | null;
+  lv_total: number | string | null;
+  lv_net: number | string | null;
+  lv_zero: number | string | null;
+};
+
+function toNumber(value: bigint | number | string | null | undefined): number {
+  if (value == null) return 0;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+  if (typeof value === 'bigint') return Number(value);
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function parseArgs(argv: string[]): { threshold: number; json: boolean } {
+  let threshold = 100;
+  let json = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') {
+      json = true;
+    } else if (arg === '--threshold') {
+      const next = argv[i + 1];
+      if (next !== undefined) {
+        const parsed = Number.parseInt(next, 10);
+        if (Number.isFinite(parsed) && parsed >= 0) threshold = parsed;
+        i += 1;
+      }
+    } else if (arg.startsWith('--threshold=')) {
+      const parsed = Number.parseInt(arg.slice('--threshold='.length), 10);
+      if (Number.isFinite(parsed) && parsed >= 0) threshold = parsed;
+    }
+  }
+  return { threshold, json };
+}
+
+async function main(): Promise<number> {
+  const { threshold, json } = parseArgs(process.argv.slice(2));
+  const prisma = getPrismaClient();
+
+  const summaryRows = await prisma.$queryRawUnsafe<SummaryRow[]>(`
+    WITH lv_agg AS (
+      SELECT lv."pageVersionId" AS pvid,
+             COUNT(*)::int                              AS lv_total,
+             COALESCE(SUM(lv.direction)::int, 0)        AS lv_net,
+             COUNT(*) FILTER (WHERE lv.direction = 0)::int AS lv_zero,
+             BOOL_OR(lv.direction NOT IN (-1,0,1))      AS has_oor
+        FROM "LatestVote" lv
+       GROUP BY lv."pageVersionId"
+    )
+    SELECT
+      COUNT(*)::bigint AS total_pages,
+      COUNT(*) FILTER (
+        WHERE COALESCE(lv_total, 0) = 0 AND pv."voteCount" > 0
+      )::bigint AS no_votes_synced,
+      COUNT(*) FILTER (
+        WHERE lv_total > 0
+          AND lv_net = pv.rating
+          AND (lv_total - lv_zero) = pv."voteCount"
+      )::bigint AS perfect_match,
+      COUNT(*) FILTER (
+        WHERE lv_total > 0 AND (lv_net <> pv.rating)
+      )::bigint AS rating_mismatch,
+      COUNT(*) FILTER (
+        WHERE lv_total > 0 AND (lv_total - lv_zero) <> pv."voteCount"
+      )::bigint AS count_mismatch,
+      COUNT(*) FILTER (WHERE has_oor)::bigint AS direction_out_of_range,
+      COUNT(*) FILTER (
+        WHERE lv_total > 0
+          AND (lv_net <> pv.rating
+            OR (lv_total - lv_zero) <> pv."voteCount")
+      )::bigint AS any_mismatch
+    FROM "PageVersion" pv
+    LEFT JOIN lv_agg lv ON lv.pvid = pv.id
+    WHERE pv."validTo" IS NULL
+      AND pv."isDeleted" = false
+      AND pv."voteCount" IS NOT NULL
+  `);
+
+  const anomalies = await prisma.$queryRawUnsafe<AnomalyRow[]>(`
+    WITH lv_agg AS (
+      SELECT lv."pageVersionId" AS pvid,
+             COUNT(*)::int                              AS lv_total,
+             COALESCE(SUM(lv.direction)::int, 0)        AS lv_net,
+             COUNT(*) FILTER (WHERE lv.direction = 0)::int AS lv_zero
+        FROM "LatestVote" lv
+       GROUP BY lv."pageVersionId"
+    )
+    SELECT pg."wikidotId"   AS "wikidotId",
+           pv.id            AS "pageVersionId",
+           pg."currentUrl"  AS url,
+           pv.rating        AS pa_rating,
+           pv."voteCount"   AS pa_count,
+           COALESCE(lv.lv_total, 0) AS lv_total,
+           COALESCE(lv.lv_net,   0) AS lv_net,
+           COALESCE(lv.lv_zero,  0) AS lv_zero
+      FROM "PageVersion" pv
+      JOIN "Page" pg ON pg.id = pv."pageId"
+      LEFT JOIN lv_agg lv ON lv.pvid = pv.id
+     WHERE pv."validTo" IS NULL
+       AND pv."isDeleted" = false
+       AND pv."voteCount" IS NOT NULL
+       AND (
+         (COALESCE(lv.lv_total, 0) = 0 AND pv."voteCount" > 0)
+         OR (lv.lv_total > 0 AND lv.lv_net <> pv.rating)
+         OR (lv.lv_total > 0 AND (lv.lv_total - lv.lv_zero) <> pv."voteCount")
+       )
+     ORDER BY ABS(COALESCE(lv.lv_net, 0) - pv.rating) DESC,
+              ABS(COALESCE(lv.lv_total - lv.lv_zero, 0) - pv."voteCount") DESC,
+              pg."wikidotId"
+     LIMIT 20
+  `);
+
+  const summary = {
+    totalPages: toNumber(summaryRows[0]?.total_pages),
+    noVotesSynced: toNumber(summaryRows[0]?.no_votes_synced),
+    perfectMatch: toNumber(summaryRows[0]?.perfect_match),
+    ratingMismatch: toNumber(summaryRows[0]?.rating_mismatch),
+    countMismatch: toNumber(summaryRows[0]?.count_mismatch),
+    directionOutOfRange: toNumber(summaryRows[0]?.direction_out_of_range),
+    anyMismatch: toNumber(summaryRows[0]?.any_mismatch)
+  };
+
+  const anomaliesDisplay = anomalies.map((a) => {
+    const lvTotal = toNumber(a.lv_total);
+    const lvZero = toNumber(a.lv_zero);
+    const lvNet = toNumber(a.lv_net);
+    const paRating = toNumber(a.pa_rating);
+    const paCount = toNumber(a.pa_count);
+    const lvCount = lvTotal - lvZero;
+    return {
+      wikidotId: a.wikidotId,
+      pageVersionId: a.pageVersionId,
+      url: a.url,
+      paRating,
+      paCount,
+      lvNet,
+      lvCount,
+      diffRating: paRating - lvNet,
+      diffCount: paCount - lvCount
+    };
+  });
+
+  const exceeded = summary.anyMismatch > threshold;
+
+  if (json) {
+    console.log(
+      JSON.stringify(
+        {
+          summary,
+          threshold,
+          exceeded,
+          anomalies: anomaliesDisplay
+        },
+        null,
+        2
+      )
+    );
+  } else {
+    console.log('# vote-integrity report');
+    console.log('');
+    console.log('## Bucket counts');
+    console.table(summary);
+    console.log('');
+    console.log(`Threshold = ${threshold} on any_mismatch (current = ${summary.anyMismatch})`);
+    console.log(exceeded ? '⚠️  exceeded threshold — exit 1' : '✅ within threshold');
+    if (anomaliesDisplay.length > 0) {
+      console.log('');
+      console.log('## Top 20 偏差页 (按 |paRating - lvNet| desc)');
+      console.table(anomaliesDisplay);
+    } else {
+      console.log('');
+      console.log('🎉 No mismatches detected.');
+    }
+  }
+
+  return exceeded ? 1 : 0;
+}
+
+main()
+  .then(async (code) => {
+    try {
+      await disconnectPrisma();
+    } catch {
+      // ignore
+    }
+    process.exit(code);
+  })
+  .catch(async (err) => {
+    console.error(err);
+    try {
+      await disconnectPrisma();
+    } catch {
+      // ignore
+    }
+    process.exit(2);
+  });

--- a/backend/scripts/export-annual-summary.ts
+++ b/backend/scripts/export-annual-summary.ts
@@ -560,8 +560,8 @@ async function getDailyVoterCountLeadersFirsts(year: number): Promise<TagLeaderR
     )
     SELECT day, "userId", u."displayName",
       COUNT(*) AS "totalVotes",
-      COUNT(*) FILTER (WHERE direction = 1) AS "upVotes",
-      COUNT(*) FILTER (WHERE direction = -1) AS "downVotes"
+      COUNT(*) FILTER (WHERE direction > 0) AS "upVotes",
+      COUNT(*) FILTER (WHERE direction < 0) AS "downVotes"
     FROM dedup_votes dv
     LEFT JOIN "User" u ON u.id = dv."userId"
     GROUP BY day, "userId", u."displayName"
@@ -711,8 +711,8 @@ async function getAuthorReceivedVotesByPeriodFirsts(
     aggregated AS (
       SELECT bucket, author_id, "displayName",
         COUNT(*) FILTER (WHERE direction != 0) AS total_votes,
-        COUNT(*) FILTER (WHERE direction = 1) AS up_votes,
-        COUNT(*) FILTER (WHERE direction = -1) AS down_votes,
+        COUNT(*) FILTER (WHERE direction > 0) AS up_votes,
+        COUNT(*) FILTER (WHERE direction < 0) AS down_votes,
         COALESCE(SUM(direction), 0) AS net_votes
       FROM vote_author GROUP BY bucket, author_id, "displayName"
     ),
@@ -1139,8 +1139,8 @@ async function getSiteOverview(year: number) {
     }]>`
       SELECT
         COUNT(*) AS total,
-        COUNT(*) FILTER (WHERE direction = 1) AS up,
-        COUNT(*) FILTER (WHERE direction = -1) AS down
+        COUNT(*) FILTER (WHERE direction > 0) AS up,
+        COUNT(*) FILTER (WHERE direction < 0) AS down
       FROM "Vote" v
       JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
       WHERE v.timestamp >= ${startTzIso}::timestamptz
@@ -1835,7 +1835,7 @@ async function getExtremeStats(year: number) {
       JOIN "Vote" v ON v."pageVersionId" = pv.id
       WHERE v.timestamp >= ${startTzIso}::timestamptz
         AND v.timestamp < ${endTzIso}::timestamptz
-        AND v.direction = 1
+        AND v.direction > 0
       GROUP BY pv."wikidotId", pv.title, pv."currentUrl", pv.id, (v.timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Shanghai')::date
     ),
     daily_upvotes_with_authors AS (
@@ -2178,8 +2178,8 @@ async function getTopVoters(year: number, limit: number = 10) {
       u.username AS "userName",
       u."displayName" AS "displayName",
       COUNT(*) AS "totalVotes",
-      COUNT(*) FILTER (WHERE dv.direction = 1) AS "upVotes",
-      COUNT(*) FILTER (WHERE dv.direction = -1) AS "downVotes",
+      COUNT(*) FILTER (WHERE dv.direction > 0) AS "upVotes",
+      COUNT(*) FILTER (WHERE dv.direction < 0) AS "downVotes",
       COUNT(DISTINCT (dv.timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Shanghai')::date) AS "activeDays"
     FROM dedup_votes dv
     LEFT JOIN "User" u ON u.id = dv."userId"
@@ -2219,8 +2219,8 @@ async function getMonthlyVoteStats(year: number) {
     SELECT
       date_trunc('month', v.timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Shanghai') AS month,
       COUNT(*) AS total,
-      COUNT(*) FILTER (WHERE v.direction = 1) AS up,
-      COUNT(*) FILTER (WHERE v.direction = -1) AS down
+      COUNT(*) FILTER (WHERE v.direction > 0) AS up,
+      COUNT(*) FILTER (WHERE v.direction < 0) AS down
     FROM "Vote" v
     JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
     WHERE v.timestamp >= ${startTzIso}::timestamptz
@@ -2258,8 +2258,8 @@ async function getVotesByCategory(year: number) {
     }]>`
       SELECT
         COUNT(*) AS total,
-        COUNT(*) FILTER (WHERE v.direction = 1) AS up,
-        COUNT(*) FILTER (WHERE v.direction = -1) AS down
+        COUNT(*) FILTER (WHERE v.direction > 0) AS up,
+        COUNT(*) FILTER (WHERE v.direction < 0) AS down
       FROM "Vote" v
       JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
       WHERE v.timestamp >= ${startTzIso}::timestamptz
@@ -2552,7 +2552,7 @@ async function getInterestingStats(year: number) {
         pv.title,
         pv.id AS pv_id,
         COUNT(*) AS total_votes,
-        COUNT(*) FILTER (WHERE v.direction = -1) AS down_votes
+        COUNT(*) FILTER (WHERE v.direction < 0) AS down_votes
       FROM pv
       JOIN "Vote" v ON v."pageVersionId" = pv.id
       WHERE pv.published_at >= ${startTzIso}::timestamptz
@@ -4526,8 +4526,8 @@ async function precomputeAllVotesReceived(year: number): Promise<Map<number, Vot
     SELECT
       author_id AS "userId",
       COUNT(*) AS total,
-      COUNT(*) FILTER (WHERE direction = 1) AS up,
-      COUNT(*) FILTER (WHERE direction = -1) AS down
+      COUNT(*) FILTER (WHERE direction > 0) AS up,
+      COUNT(*) FILTER (WHERE direction < 0) AS down
     FROM dedup_votes
     GROUP BY author_id
   `;
@@ -4580,8 +4580,8 @@ async function precomputeAllVotesCast(year: number): Promise<Map<number, VoteCas
     SELECT
       "userId",
       COUNT(*) AS total,
-      COUNT(*) FILTER (WHERE direction = 1) AS up,
-      COUNT(*) FILTER (WHERE direction = -1) AS down,
+      COUNT(*) FILTER (WHERE direction > 0) AS up,
+      COUNT(*) FILTER (WHERE direction < 0) AS down,
       COUNT(DISTINCT (timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Shanghai')::date) AS "activeDays"
     FROM dedup_votes
     GROUP BY "userId"
@@ -5174,7 +5174,7 @@ async function getUserSummary(userId: number, year: number) {
           AND pv."validTo" IS NULL AND NOT pv."isDeleted"
       ),
       tagged AS (SELECT unnest(tags) AS tag, direction FROM user_votes)
-      SELECT tag, COUNT(*) AS "voteCount", COUNT(*) FILTER (WHERE direction = 1) AS "upCount"
+      SELECT tag, COUNT(*) AS "voteCount", COUNT(*) FILTER (WHERE direction > 0) AS "upCount"
       FROM tagged
       WHERE tag NOT IN (${Prisma.join(NON_DESCRIPTIVE_TAGS)})
         AND tag NOT LIKE '\\_%' ESCAPE '\\' AND tag NOT LIKE 'crom%'

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -26,6 +26,7 @@ import { ForumSyncProcessor } from '../core/processors/ForumSyncProcessor.js';
 import { WikidotForumClient } from '../core/client/WikidotForumClient.js';
 import { runSyncHourlyScheduler } from './sync-hourly.js';
 import { runWikidotBindingVerifyLoop } from './wikidot-binding-verify-loop.js';
+import { runVoteResyncAudit } from './voteResyncAudit.js';
 
 const program = new Command();
 
@@ -1181,6 +1182,29 @@ program
     } finally {
       await disconnectPrisma();
     }
+  });
+
+program
+  .command('vote-resync-audit')
+  .description('Audit + repair Vote rows for pages whose LatestVote drifts from CROM rating/voteCount')
+  .option('--setup', 'Create schema vote_resync_audit + tmp_audit_summary + tmp_vote tables')
+  .option('--collect', 'Seed tmp_audit_summary with mismatched pages and pull fuzzyVoteRecords from CROM')
+  .option('--report', 'Aggregate expected_rating/expected_count and print markdown report')
+  .option('--apply', 'Write tmp_vote rows back into "Vote" inside a single transaction (use with care)')
+  .option('--cleanup', 'DROP SCHEMA vote_resync_audit CASCADE')
+  .option('--fetch-concurrency <n>', 'CROM page-level fetch concurrency (default 3)', '3')
+  .option('--schema <name>', 'Override temporary schema name (default vote_resync_audit)')
+  .action(async (options) => {
+    const concurrency = Number.parseInt(String(options.fetchConcurrency ?? '3'), 10);
+    await runVoteResyncAudit({
+      setup: Boolean(options.setup),
+      collect: Boolean(options.collect),
+      report: Boolean(options.report),
+      apply: Boolean(options.apply),
+      cleanup: Boolean(options.cleanup),
+      fetchConcurrency: Number.isFinite(concurrency) && concurrency > 0 ? concurrency : 3,
+      schema: options.schema ? String(options.schema) : undefined
+    });
   });
 
 // Global error handlers for robust CLI processes

--- a/backend/src/cli/voteResyncAudit.ts
+++ b/backend/src/cli/voteResyncAudit.ts
@@ -701,15 +701,19 @@ async function doReport(prisma: PrismaClient, schema: string): Promise<void> {
  *
  * 安全过滤（每条 INSERT 都强制）：
  *   AND s.status = 'collected'
- *   AND s.expected_rating IS NOT NULL AND s.expected_count IS NOT NULL
+ *   AND s.expected_rating IS NOT NULL
  *   AND s.expected_rating = s.cr_rating
- *   AND s.expected_count  = s.cr_count
  *   AND pv."validTo" IS NULL AND pv."isDeleted" = false
  *   AND pv.rating       IS NOT DISTINCT FROM s.pa_rating   -- freshness guard
  *   AND pv."voteCount"  IS NOT DISTINCT FROM s.pa_count    -- freshness guard
  *
- * 这能：(a) 拦掉 status!='collected' 的 partial 行；(b) 拦掉 expected!=cr 的异常页；
- * (c) 拦掉 collect 之后被 PhaseA 增量同步覆盖了 pa_* 的 stale 页。
+ * 这能：(a) 拦掉 status!='collected' 的 partial 行；(b) 拦掉 expected_rating!=cr_rating
+ * 的异常页（rating 是用户最关心的页面分数，必须严格对齐 wikidot）；(c) 拦掉 collect 之后
+ * 被 PhaseA 增量同步覆盖了 pa_* 的 stale 页。
+ *
+ * 注：故意不强制 expected_count == cr_count。CROM voteCount 字段包含 direction=0
+ * (cancelled vote) 用户，而我们 expected_count = COUNT(direction <> 0) 过滤了 cancelled。
+ * 这是有意的口径选择——本地 LatestVote 聚合在语义上更准确。
  */
 async function doApply(prisma: PrismaClient, schema: string): Promise<void> {
   const qs = quoteIdent(schema);
@@ -862,9 +866,7 @@ async function doApply(prisma: PrismaClient, schema: string): Promise<void> {
          WHERE s.status = 'collected'
            AND s.expected_rating IS NOT NULL
            AND s.expected_count  IS NOT NULL
-           AND s.expected_rating = s.cr_rating
-           AND s.expected_count  = s.cr_count
-           AND NOT (
+           AND s.expected_rating = s.cr_rating           AND NOT (
              pv."validTo" IS NULL
              AND pv."isDeleted" = false
              AND pv.rating       IS NOT DISTINCT FROM s.pa_rating
@@ -907,9 +909,7 @@ async function doApply(prisma: PrismaClient, schema: string): Promise<void> {
             AND s.status = 'collected'
             AND s.expected_rating IS NOT NULL
             AND s.expected_count  IS NOT NULL
-            AND s.expected_rating = s.cr_rating
-            AND s.expected_count  = s.cr_count
-            AND pv."validTo" IS NULL
+            AND s.expected_rating = s.cr_rating            AND pv."validTo" IS NULL
             AND pv."isDeleted" = false
             AND pv.rating       IS NOT DISTINCT FROM s.pa_rating
             AND pv."voteCount"  IS NOT DISTINCT FROM s.pa_count

--- a/backend/src/cli/voteResyncAudit.ts
+++ b/backend/src/cli/voteResyncAudit.ts
@@ -1,0 +1,1053 @@
+import { PrismaClient } from '@prisma/client';
+import { GraphQLClient } from '../core/client/GraphQLClient.js';
+import { disconnectPrisma, getPrismaClient } from '../utils/db-connection.js';
+import { Logger } from '../utils/Logger.js';
+import { Progress } from '../utils/Progress.js';
+
+/**
+ * vote-resync-audit
+ *
+ * 一次性 CLI，用于把本地 Vote 表与 CROM 真实分数对账并回填。
+ * 所有中间数据落在独立 schema `vote_resync_audit`：
+ *   - tmp_audit_summary: 偏差页清单与对账状态
+ *   - tmp_vote:          CROM 拉到的全部 vote 边（用 user_wikidot_id 而非 userId）
+ *   - tmp_user:          collect 期间见到的 user 占位（wikidotId + displayName）
+ *
+ * 重要约束（避免污染主库 / 破坏隔离）：
+ *   - collect 阶段不读 public."User"、不写 public 任何表；只往 vote_resync_audit
+ *     schema 写 tmp_audit_summary / tmp_vote / tmp_user。
+ *   - 绝不写 'wd:<wikidotId>' 形式的 anonKey（避免与未来 PhaseB/C 同步出的真实
+ *     userId 行重复计票）。tmp_vote.anonKey 在 collect 中永远为 NULL。
+ *   - 占位 displayName 用 `wd:${wikidotId}` 形式（与 VoteRevisionStore /
+ *     AttributionService 已有约定保持一致；AttributionService 会识别 `wd:` 前缀
+ *     避免占位覆盖真名）。
+ *   - 只有 Step 6 (--apply) 才动 public，并在单事务内：
+ *       1) tmp_user → public."User" placeholder upsert (DO NOTHING 不覆盖真名)
+ *       2) tmp_vote (user_wikidot_id IS NOT NULL) JOIN public."User" → "Vote".userId
+ *       3) tmp_vote (user_wikidot_id IS NULL AND anonKey IS NOT NULL) → "Vote".anonKey
+ *          [防御路径：当前 CROM schema 不会出现这种边，期望 0 行]
+ *
+ * 子命令：
+ *   --setup     建 schema + tmp 表
+ *   --collect   写偏差页清单 + 拉 CROM fuzzyVoteRecords 全量分页
+ *   --report    聚合每页 expected_rating / expected_count + 输出 markdown
+ *   --apply     把 tmp_vote 写回主库（事务内）
+ *   --cleanup   DROP SCHEMA vote_resync_audit CASCADE
+ *
+ * 默认顺序：setup → collect → report；apply / cleanup 必须显式调用。
+ */
+
+export type VoteResyncAuditOptions = {
+  setup?: boolean;
+  collect?: boolean;
+  report?: boolean;
+  apply?: boolean;
+  cleanup?: boolean;
+  fetchConcurrency?: number;
+  schema?: string;
+};
+
+const DEFAULT_SCHEMA = 'vote_resync_audit';
+const FUZZY_PAGE_SIZE = 100;
+const DEFAULT_FETCH_CONCURRENCY = 3;
+const TMP_VOTE_INSERT_CHUNK = 200;
+const TMP_USER_INSERT_CHUNK = 200;
+
+const FUZZY_VOTE_QUERY = `
+  query FuzzyVoteAudit($url: URL!, $first: Int, $after: ID) {
+    wikidotPage(url: $url) {
+      url
+      rating
+      voteCount
+      fuzzyVoteRecords(first: $first, after: $after) {
+        edges {
+          node {
+            userWikidotId
+            direction
+            timestamp
+            user {
+              ... on WikidotUser {
+                wikidotId
+                displayName
+              }
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
+type CromVoteNode = {
+  // CROM serializes wikidotId as string in JSON; coerce to int before SQL bind
+  userWikidotId: string | number | null;
+  direction: number;
+  timestamp: string;
+  user: { wikidotId?: string | number | null; displayName?: string | null } | null;
+};
+
+type CromFuzzyResponse = {
+  wikidotPage: {
+    url: string;
+    rating: number;
+    voteCount: number;
+    fuzzyVoteRecords: {
+      edges: Array<{ node: CromVoteNode }>;
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    };
+  } | null;
+};
+
+type SummaryRow = {
+  wikidotId: number;
+  pageVersionId: number;
+  url: string | null;
+  paRating: number | null;
+  paCount: number | null;
+};
+
+type CollectStats = {
+  totalPages: number;
+  collected: number;
+  failed: number;
+  totalEdges: number;
+  totalNullUserWikidotId: number;
+};
+
+type FetchOutcome = {
+  rating: number;
+  voteCount: number;
+  edgesInserted: number;
+  nullUserWikidotId: number;
+};
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+function quoteIdent(name: string): string {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+    throw new Error(`invalid identifier: ${name}`);
+  }
+  return `"${name}"`;
+}
+
+async function ensureSchemaAndTables(prisma: PrismaClient, schema: string): Promise<void> {
+  const qs = quoteIdent(schema);
+  await prisma.$executeRawUnsafe(`CREATE SCHEMA IF NOT EXISTS ${qs}`);
+
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS ${qs}.tmp_audit_summary (
+      "wikidotId"     int        PRIMARY KEY,
+      "pageVersionId" int        NOT NULL,
+      url             text,
+      pa_rating       int,
+      pa_count        int,
+      cr_rating       int,
+      cr_count        int,
+      expected_rating int,
+      expected_count  int,
+      status          text       NOT NULL DEFAULT 'pending',
+      error           text,
+      fetched_at      timestamptz
+    )
+  `);
+
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS ${qs}.tmp_vote (
+      edge_seq        bigserial   PRIMARY KEY,
+      "pageVersionId" int         NOT NULL,
+      user_wikidot_id int,
+      "anonKey"       text,
+      direction       int         NOT NULL,
+      timestamp       timestamp   NOT NULL,
+      fetched_at      timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+
+  await prisma.$executeRawUnsafe(`
+    CREATE INDEX IF NOT EXISTS tmp_vote_pv_uwid_ts
+      ON ${qs}.tmp_vote ("pageVersionId", user_wikidot_id, timestamp)
+  `);
+  await prisma.$executeRawUnsafe(`
+    CREATE INDEX IF NOT EXISTS tmp_vote_pv_anon_ts
+      ON ${qs}.tmp_vote ("pageVersionId", "anonKey", timestamp)
+  `);
+
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS ${qs}.tmp_user (
+      "wikidotId"   int  PRIMARY KEY,
+      "displayName" text NOT NULL,
+      source        text NOT NULL DEFAULT 'collect'
+    )
+  `);
+}
+
+/**
+ * 用对账 SQL 找出所有 perfect_match=false 的偏差页，
+ * 写入 tmp_audit_summary（status='pending'，已存在的 wikidotId 不覆盖）。
+ */
+async function seedSummary(prisma: PrismaClient, schema: string): Promise<number> {
+  const qs = quoteIdent(schema);
+  const inserted = await prisma.$executeRawUnsafe(`
+    INSERT INTO ${qs}.tmp_audit_summary
+      ("wikidotId", "pageVersionId", url, pa_rating, pa_count, status)
+    WITH lv_agg AS (
+      SELECT lv."pageVersionId" AS pvid,
+             COUNT(*)::int                              AS lv_total,
+             COALESCE(SUM(lv.direction)::int, 0)        AS lv_net,
+             COUNT(*) FILTER (WHERE lv.direction = 0)::int AS lv_zero
+        FROM "LatestVote" lv
+       GROUP BY lv."pageVersionId"
+    )
+    SELECT pg."wikidotId",
+           pv.id,
+           pg."currentUrl",
+           pv.rating,
+           pv."voteCount",
+           'pending'
+      FROM "PageVersion" pv
+      JOIN "Page" pg ON pg.id = pv."pageId"
+      LEFT JOIN lv_agg ON lv_agg.pvid = pv.id
+     WHERE pv."validTo" IS NULL
+       AND pv."isDeleted" = false
+       AND pv."voteCount" IS NOT NULL
+       AND pg."wikidotId" IS NOT NULL
+       AND pg."currentUrl" IS NOT NULL
+       AND (
+         (COALESCE(lv_agg.lv_total, 0) = 0 AND pv."voteCount" > 0)
+         OR (lv_agg.lv_total > 0 AND lv_agg.lv_net <> pv.rating)
+         OR (lv_agg.lv_total > 0 AND (lv_agg.lv_total - lv_agg.lv_zero) <> pv."voteCount")
+       )
+    ON CONFLICT ("wikidotId") DO NOTHING
+  `);
+  return Number(inserted ?? 0);
+}
+
+async function loadPendingPages(prisma: PrismaClient, schema: string): Promise<SummaryRow[]> {
+  const qs = quoteIdent(schema);
+  const rows = await prisma.$queryRawUnsafe<Array<{
+    wikidotId: number;
+    pageVersionId: number;
+    url: string | null;
+    pa_rating: number | null;
+    pa_count: number | null;
+  }>>(`
+    SELECT "wikidotId",
+           "pageVersionId",
+           url,
+           pa_rating,
+           pa_count
+      FROM ${qs}.tmp_audit_summary
+     WHERE status IN ('pending', 'error')
+     ORDER BY "wikidotId"
+  `);
+  return rows.map(r => ({
+    wikidotId: Number(r.wikidotId),
+    pageVersionId: Number(r.pageVersionId),
+    url: r.url,
+    paRating: r.pa_rating === null ? null : Number(r.pa_rating),
+    paCount: r.pa_count === null ? null : Number(r.pa_count)
+  }));
+}
+
+/**
+ * 拉一页全部 fuzzyVoteRecords，仅向 tmp 表写入：
+ *   - tmp_vote: 每条 edge 一行，user_wikidot_id 为 CROM 返回的 userWikidotId
+ *   - tmp_user: 每个见到的 wikidotId 一行（ON CONFLICT DO NOTHING 去重）
+ * 重跑前先 DELETE 该 pageVersionId 的旧边，避免半截数据残留。
+ * 不会查询或写入 public schema 任何表。
+ */
+async function fetchAndStorePageVotes(
+  prisma: PrismaClient,
+  schema: string,
+  client: GraphQLClient,
+  page: SummaryRow
+): Promise<FetchOutcome> {
+  if (!page.url) throw new Error('missing page url');
+  const qs = quoteIdent(schema);
+
+  await prisma.$executeRawUnsafe(
+    `DELETE FROM ${qs}.tmp_vote WHERE "pageVersionId" = $1`,
+    page.pageVersionId
+  );
+
+  let cursor: string | null = null;
+  let edgesInserted = 0;
+  let nullUserWikidotId = 0;
+  let pageRating = 0;
+  let pageVoteCount = 0;
+
+  // 防 cursor 死循环
+  const MAX_PAGES = 1000;
+  let pageIter = 0;
+
+  while (true) {
+    pageIter += 1;
+    if (pageIter > MAX_PAGES) {
+      throw new Error(`pagination did not terminate after ${MAX_PAGES} iterations`);
+    }
+    const resp = (await client.request(FUZZY_VOTE_QUERY, {
+      url: page.url,
+      first: FUZZY_PAGE_SIZE,
+      after: cursor
+    })) as CromFuzzyResponse | null;
+    const wp: CromFuzzyResponse['wikidotPage'] = resp?.wikidotPage ?? null;
+    if (!wp) {
+      throw new Error(`wikidotPage returned null for url=${page.url}`);
+    }
+    pageRating = wp.rating;
+    pageVoteCount = wp.voteCount;
+    const edges = wp.fuzzyVoteRecords?.edges ?? [];
+
+    if (edges.length > 0) {
+      type VoteRow = {
+        pvid: number;
+        userWikidotId: number;
+        direction: number;
+        timestamp: Date;
+      };
+      type UserRow = { wikidotId: number; displayName: string };
+
+      const voteRows: VoteRow[] = [];
+      const userBatch: UserRow[] = [];
+      const userBatchSeen = new Set<number>();
+
+      for (const e of edges) {
+        const node = e.node;
+        // CROM 把 wikidotId 序列化为 string；强制 parseInt，否则 PG 会因
+        // "user_wikidot_id integer ← text" 类型失配整页失败
+        const widRaw = node.user?.wikidotId ?? node.userWikidotId ?? null;
+        const wid = widRaw == null ? null : Number.parseInt(String(widRaw), 10);
+        if (wid == null || !Number.isFinite(wid)) {
+          // 应当极少（按 schema 1682 always present），但守住兜底
+          nullUserWikidotId += 1;
+          continue;
+        }
+        const ts = new Date(node.timestamp);
+        if (Number.isNaN(ts.getTime())) {
+          nullUserWikidotId += 1;
+          continue;
+        }
+        const rawDn = typeof node.user?.displayName === 'string' ? node.user.displayName.trim() : '';
+        const displayName = rawDn.length > 0 ? rawDn : `wd:${wid}`;
+
+        voteRows.push({
+          pvid: page.pageVersionId,
+          userWikidotId: wid,
+          direction: node.direction,
+          timestamp: ts
+        });
+        if (!userBatchSeen.has(wid)) {
+          userBatchSeen.add(wid);
+          userBatch.push({ wikidotId: wid, displayName });
+        }
+      }
+
+      // tmp_vote bulk insert (anonKey 永远 NULL)
+      for (const chunk of chunkArray(voteRows, TMP_VOTE_INSERT_CHUNK)) {
+        const params: unknown[] = [];
+        const valueClauses: string[] = [];
+        chunk.forEach((row, idx) => {
+          const base = idx * 4;
+          valueClauses.push(`($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4})`);
+          params.push(row.pvid, row.userWikidotId, row.direction, row.timestamp);
+        });
+        await prisma.$executeRawUnsafe(
+          `INSERT INTO ${qs}.tmp_vote ("pageVersionId", user_wikidot_id, direction, timestamp)
+           VALUES ${valueClauses.join(',')}`,
+          ...params
+        );
+      }
+
+      // tmp_user bulk insert (ON CONFLICT DO NOTHING)
+      for (const chunk of chunkArray(userBatch, TMP_USER_INSERT_CHUNK)) {
+        const params: unknown[] = [];
+        const valueClauses: string[] = [];
+        chunk.forEach((row, idx) => {
+          const base = idx * 2;
+          valueClauses.push(`($${base + 1}, $${base + 2})`);
+          params.push(row.wikidotId, row.displayName);
+        });
+        await prisma.$executeRawUnsafe(
+          `INSERT INTO ${qs}.tmp_user ("wikidotId", "displayName")
+           VALUES ${valueClauses.join(',')}
+           ON CONFLICT ("wikidotId") DO NOTHING`,
+          ...params
+        );
+      }
+
+      edgesInserted += voteRows.length;
+    }
+
+    if (!wp.fuzzyVoteRecords?.pageInfo?.hasNextPage) break;
+    const nextCursor: string | null = wp.fuzzyVoteRecords?.pageInfo?.endCursor ?? null;
+    if (!nextCursor || nextCursor === cursor) break;
+    cursor = nextCursor;
+  }
+
+  return {
+    rating: pageRating,
+    voteCount: pageVoteCount,
+    edgesInserted,
+    nullUserWikidotId
+  };
+}
+
+async function doCollect(
+  prisma: PrismaClient,
+  schema: string,
+  fetchConcurrency: number
+): Promise<CollectStats> {
+  const seeded = await seedSummary(prisma, schema);
+  Logger.info(`📋 seed: inserted ${seeded} new mismatched pages into tmp_audit_summary`);
+
+  const pages = await loadPendingPages(prisma, schema);
+  const stats: CollectStats = {
+    totalPages: pages.length,
+    collected: 0,
+    failed: 0,
+    totalEdges: 0,
+    totalNullUserWikidotId: 0
+  };
+  if (pages.length === 0) {
+    Logger.info('✅ nothing left to collect (no pending/error rows)');
+    return stats;
+  }
+  Logger.info(`🚚 collect: pulling fuzzyVoteRecords for ${pages.length} pages, concurrency=${fetchConcurrency}`);
+
+  const client = new GraphQLClient();
+  const bar = Progress.createBar({ title: 'collect', total: pages.length });
+  const queue = pages.slice();
+  const qs = quoteIdent(schema);
+
+  const worker = async () => {
+    while (true) {
+      const page = queue.shift();
+      if (!page) break;
+      try {
+        const outcome = await fetchAndStorePageVotes(prisma, schema, client, page);
+        const errStr =
+          outcome.nullUserWikidotId > 0 ? `null_userWikidotId=${outcome.nullUserWikidotId}` : null;
+        await prisma.$executeRawUnsafe(
+          `UPDATE ${qs}.tmp_audit_summary
+              SET cr_rating  = $2,
+                  cr_count   = $3,
+                  status     = 'collected',
+                  error      = $4,
+                  fetched_at = now()
+            WHERE "wikidotId" = $1`,
+          page.wikidotId,
+          outcome.rating,
+          outcome.voteCount,
+          errStr
+        );
+        stats.collected += 1;
+        stats.totalEdges += outcome.edgesInserted;
+        stats.totalNullUserWikidotId += outcome.nullUserWikidotId;
+      } catch (err) {
+        stats.failed += 1;
+        const msg = err instanceof Error ? err.message : String(err);
+        Logger.warn(`⚠️ collect failed wikidotId=${page.wikidotId} url=${page.url ?? '(null)'}: ${msg}`);
+        // 关键：分页中途失败时 fetchAndStorePageVotes 已经向 tmp_vote 插过若干 partial 行。
+        // 如果不清理，--report 会基于 partial 数据算 expected_*，apply 也可能把残留写回主库。
+        try {
+          await prisma.$executeRawUnsafe(
+            `DELETE FROM ${qs}.tmp_vote WHERE "pageVersionId" = $1`,
+            page.pageVersionId
+          );
+        } catch (cleanupErr) {
+          Logger.error(
+            `❌ failed to clean partial tmp_vote rows for wikidotId=${page.wikidotId}`,
+            cleanupErr instanceof Error ? cleanupErr : new Error(String(cleanupErr))
+          );
+        }
+        try {
+          await prisma.$executeRawUnsafe(
+            `UPDATE ${qs}.tmp_audit_summary
+                SET status     = 'error',
+                    error      = $2,
+                    cr_rating  = NULL,
+                    cr_count   = NULL,
+                    fetched_at = now()
+              WHERE "wikidotId" = $1`,
+            page.wikidotId,
+            msg.slice(0, 1000)
+          );
+        } catch (innerErr) {
+          Logger.error(
+            `❌ failed to record error status for wikidotId=${page.wikidotId}`,
+            innerErr instanceof Error ? innerErr : new Error(String(innerErr))
+          );
+        }
+      } finally {
+        bar.increment();
+      }
+    }
+  };
+
+  try {
+    await Promise.all(
+      Array.from({ length: Math.max(1, fetchConcurrency) }, () => worker())
+    );
+  } finally {
+    bar.stop();
+    try { (client as unknown as { destroy?: () => void }).destroy?.(); } catch {}
+  }
+
+  Logger.info(
+    `✅ collect done: collected=${stats.collected} failed=${stats.failed} edges=${stats.totalEdges} nullUserWikidotId=${stats.totalNullUserWikidotId}`
+  );
+  return stats;
+}
+
+function fmt(v: number | null | undefined): string {
+  if (v == null) return '∅';
+  return String(v);
+}
+
+async function doReport(prisma: PrismaClient, schema: string): Promise<void> {
+  const qs = quoteIdent(schema);
+
+  // 计算 expected_rating / expected_count：每个 (pageVersionId, actor_key) 取最新边
+  // actor_key 用 wikidotId 而非 lookup 后的 userId，因为 collect 阶段不查 public.User
+  await prisma.$executeRawUnsafe(`
+    WITH ranked AS (
+      SELECT "pageVersionId", direction,
+             ROW_NUMBER() OVER (
+               PARTITION BY "pageVersionId",
+                            COALESCE('u:' || user_wikidot_id::text, 'a:' || "anonKey")
+               ORDER BY timestamp DESC, edge_seq DESC
+             ) AS rn
+        FROM ${qs}.tmp_vote
+    )
+    UPDATE ${qs}.tmp_audit_summary s
+       SET expected_rating = a.expected_rating,
+           expected_count  = a.expected_count
+      FROM (
+        SELECT "pageVersionId",
+               SUM(direction)::int AS expected_rating,
+               COUNT(*) FILTER (WHERE direction <> 0)::int AS expected_count
+          FROM ranked
+         WHERE rn = 1
+         GROUP BY "pageVersionId"
+      ) a
+     WHERE s."pageVersionId" = a."pageVersionId"
+  `);
+
+  type OverviewRow = {
+    total: bigint | number;
+    collected: bigint | number;
+    pending: bigint | number;
+    error: bigint | number;
+    matches_cr: bigint | number;
+    mismatches_cr: bigint | number;
+  };
+
+  const overviewRows = await prisma.$queryRawUnsafe<OverviewRow[]>(`
+    SELECT
+      COUNT(*)::bigint AS total,
+      COUNT(*) FILTER (WHERE status = 'collected')::bigint AS collected,
+      COUNT(*) FILTER (WHERE status = 'pending')::bigint AS pending,
+      COUNT(*) FILTER (WHERE status = 'error')::bigint AS error,
+      COUNT(*) FILTER (
+        WHERE status = 'collected'
+          AND expected_rating IS NOT NULL
+          AND expected_rating = cr_rating
+      )::bigint AS matches_cr,
+      COUNT(*) FILTER (
+        WHERE status = 'collected'
+          AND expected_rating IS NOT NULL
+          AND expected_rating <> cr_rating
+      )::bigint AS mismatches_cr
+    FROM ${qs}.tmp_audit_summary
+  `);
+
+  const tmpVoteCountRows = await prisma.$queryRawUnsafe<Array<{ count: bigint | number }>>(
+    `SELECT COUNT(*)::bigint AS count FROM ${qs}.tmp_vote`
+  );
+
+  type ApplyEstRow = { user_rows: bigint | number; anon_rows: bigint | number };
+  const applyEstRows = await prisma.$queryRawUnsafe<ApplyEstRow[]>(`
+    SELECT
+      COUNT(*) FILTER (WHERE user_wikidot_id IS NOT NULL)::bigint AS user_rows,
+      COUNT(*) FILTER (WHERE user_wikidot_id IS NULL AND "anonKey" IS NOT NULL)::bigint AS anon_rows
+    FROM ${qs}.tmp_vote
+  `);
+
+  type TmpUserStatsRow = {
+    total: bigint | number;
+    placeholder_dn: bigint | number;
+    real_dn: bigint | number;
+    new_to_public: bigint | number;
+  };
+  const tmpUserStatsRows = await prisma.$queryRawUnsafe<TmpUserStatsRow[]>(`
+    SELECT
+      COUNT(*)::bigint AS total,
+      COUNT(*) FILTER (WHERE "displayName" LIKE 'wd:%')::bigint AS placeholder_dn,
+      COUNT(*) FILTER (WHERE "displayName" NOT LIKE 'wd:%')::bigint AS real_dn,
+      COUNT(*) FILTER (
+        WHERE NOT EXISTS (
+          SELECT 1 FROM "User" u WHERE u."wikidotId" = ${qs}.tmp_user."wikidotId"
+        )
+      )::bigint AS new_to_public
+    FROM ${qs}.tmp_user
+  `);
+
+  type AnomalyRow = {
+    wikidotId: number;
+    url: string | null;
+    expected_rating: number | null;
+    cr_rating: number | null;
+    expected_count: number | null;
+    cr_count: number | null;
+    pa_rating: number | null;
+    pa_count: number | null;
+  };
+  const anomalies = await prisma.$queryRawUnsafe<AnomalyRow[]>(`
+    SELECT "wikidotId",
+           url,
+           expected_rating,
+           cr_rating,
+           expected_count,
+           cr_count,
+           pa_rating,
+           pa_count
+      FROM ${qs}.tmp_audit_summary
+     WHERE status = 'collected'
+       AND expected_rating IS NOT NULL
+       AND expected_rating <> cr_rating
+     ORDER BY ABS(COALESCE(expected_rating, 0) - COALESCE(cr_rating, 0)) DESC,
+              "wikidotId"
+     LIMIT 30
+  `);
+
+  const o = overviewRows[0];
+  const total = Number(o?.total ?? 0);
+  const collected = Number(o?.collected ?? 0);
+  const pending = Number(o?.pending ?? 0);
+  const errored = Number(o?.error ?? 0);
+  const matchesCr = Number(o?.matches_cr ?? 0);
+  const mismatchesCr = Number(o?.mismatches_cr ?? 0);
+  const totalEdges = Number(tmpVoteCountRows[0]?.count ?? 0);
+  const userRows = Number(applyEstRows[0]?.user_rows ?? 0);
+  const anonRows = Number(applyEstRows[0]?.anon_rows ?? 0);
+
+  const u = tmpUserStatsRows[0];
+  const tmpUserTotal = Number(u?.total ?? 0);
+  const tmpUserPlaceholder = Number(u?.placeholder_dn ?? 0);
+  const tmpUserRealName = Number(u?.real_dn ?? 0);
+  const tmpUserNewToPublic = Number(u?.new_to_public ?? 0);
+
+  const lines: string[] = [];
+  lines.push('# vote-resync-audit report');
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(`- 偏差页总数 (tmp_audit_summary): **${total}**`);
+  lines.push(`- 已 collected: **${collected}**`);
+  lines.push(`- 待 collect (pending): **${pending}**`);
+  lines.push(`- 失败 (error): **${errored}**`);
+  lines.push(`- expected_rating == cr_rating（重算与 CROM 一致）: **${matchesCr}**`);
+  lines.push(`- expected_rating != cr_rating（重算与 CROM 不一致）: **${mismatchesCr}**`);
+  lines.push(`- tmp_vote 总边数: **${totalEdges}**`);
+  lines.push('');
+  lines.push('## tmp_user (collect 占位用户表)');
+  lines.push('');
+  lines.push(`- tmp_user 总行数: **${tmpUserTotal}**`);
+  lines.push(`-   有真名 displayName: **${tmpUserRealName}**`);
+  lines.push(`-   占位 \`wd:${'<wikidotId>'}\` displayName: **${tmpUserPlaceholder}**`);
+  lines.push(`- apply 预计触动 public."User"（NOT EXISTS in public.User）: **${tmpUserNewToPublic}**`);
+  lines.push('');
+  lines.push('## apply 预估行数');
+  lines.push('');
+  lines.push(`- user 路径: tmp_vote rows with user_wikidot_id NOT NULL = **${userRows}**`);
+  lines.push(`- anon 路径（防御，期望 0）: tmp_vote rows with anonKey NOT NULL = **${anonRows}**`);
+  lines.push('');
+
+  if (anomalies.length === 0) {
+    lines.push('## Anomalies');
+    lines.push('');
+    lines.push('🎉 expected_rating 与 cr_rating 全部一致。');
+  } else {
+    lines.push(`## Anomalies (top ${anomalies.length})`);
+    lines.push('');
+    lines.push('| wikidotId | url | expected_rating | cr_rating | expected_count | cr_count | pa_rating | pa_count |');
+    lines.push('|---|---|---:|---:|---:|---:|---:|---:|');
+    for (const a of anomalies) {
+      lines.push(
+        `| ${a.wikidotId} | ${a.url ?? '(unknown)'} | ${fmt(a.expected_rating)} | ${fmt(a.cr_rating)} | ${fmt(a.expected_count)} | ${fmt(a.cr_count)} | ${fmt(a.pa_rating)} | ${fmt(a.pa_count)} |`
+      );
+    }
+  }
+
+  console.log(lines.join('\n'));
+}
+
+/**
+ * apply：在单事务内执行 5 步，任何一步失败整体回滚：
+ *
+ *   Step 0: 重新计算 expected_rating / expected_count（防 report 跑后又新 collect 几页带来的 stale）
+ *   Step 1: 5-bucket dry-count + cr_mismatch / stale top-10 预览（warn 不 abort）
+ *   Step 2: tmp_user → public."User"（只插被 eligible 页引用且尚未存在于 public.User 的占位）
+ *   Step 3: tmp_vote (user_wikidot_id) JOIN public.User → "Vote"（user 路径）
+ *   Step 4: tmp_vote (anonKey)         → "Vote"（anon 防御路径；当前 CROM schema 期望 0 行）
+ *
+ * 安全过滤（每条 INSERT 都强制）：
+ *   AND s.status = 'collected'
+ *   AND s.expected_rating IS NOT NULL AND s.expected_count IS NOT NULL
+ *   AND s.expected_rating = s.cr_rating
+ *   AND s.expected_count  = s.cr_count
+ *   AND pv."validTo" IS NULL AND pv."isDeleted" = false
+ *   AND pv.rating       IS NOT DISTINCT FROM s.pa_rating   -- freshness guard
+ *   AND pv."voteCount"  IS NOT DISTINCT FROM s.pa_count    -- freshness guard
+ *
+ * 这能：(a) 拦掉 status!='collected' 的 partial 行；(b) 拦掉 expected!=cr 的异常页；
+ * (c) 拦掉 collect 之后被 PhaseA 增量同步覆盖了 pa_* 的 stale 页。
+ */
+async function doApply(prisma: PrismaClient, schema: string): Promise<void> {
+  const qs = quoteIdent(schema);
+
+  type SkipBucketRow = {
+    pending: bigint | number;
+    error: bigint | number;
+    no_report: bigint | number;
+    cr_mismatch: bigint | number;
+    stale: bigint | number;
+    apply_eligible: bigint | number;
+  };
+  type CrPreviewRow = {
+    wikidotId: number;
+    url: string | null;
+    expected_rating: number | null;
+    cr_rating: number | null;
+    expected_count: number | null;
+    cr_count: number | null;
+  };
+  type StalePreviewRow = {
+    wikidotId: number;
+    url: string | null;
+    pa_rating: number | null;
+    pa_count: number | null;
+    pv_rating: number | null;
+    pv_count: number | null;
+    valid_to: Date | null;
+    is_deleted: boolean | null;
+  };
+
+  // INSERT 180k+ 行 + 多步 SQL 的事务可能跑数十秒到几分钟；Prisma 默认 5s timeout 不够
+  const result = await prisma.$transaction(async (tx) => {
+    // Step 0: 事务内重跑 expected_*，避免 report 跑过后又有新 collect 行带来的 stale
+    const expectedRecomputed = await tx.$executeRawUnsafe(`
+      WITH ranked AS (
+        SELECT "pageVersionId", direction,
+               ROW_NUMBER() OVER (
+                 PARTITION BY "pageVersionId",
+                              COALESCE('u:' || user_wikidot_id::text, 'a:' || "anonKey")
+                 ORDER BY timestamp DESC, edge_seq DESC
+               ) AS rn
+          FROM ${qs}.tmp_vote
+      )
+      UPDATE ${qs}.tmp_audit_summary s
+         SET expected_rating = a.expected_rating,
+             expected_count  = a.expected_count
+        FROM (
+          SELECT "pageVersionId",
+                 SUM(direction)::int AS expected_rating,
+                 COUNT(*) FILTER (WHERE direction <> 0)::int AS expected_count
+            FROM ranked
+           WHERE rn = 1
+           GROUP BY "pageVersionId"
+        ) a
+       WHERE s."pageVersionId" = a."pageVersionId"
+    `);
+
+    // Step 1: 5-bucket dry-count + apply_eligible
+    const skipRows = await tx.$queryRawUnsafe<SkipBucketRow[]>(`
+      SELECT
+        COUNT(*) FILTER (WHERE status = 'pending')::bigint AS pending,
+        COUNT(*) FILTER (WHERE status = 'error')::bigint   AS error,
+        COUNT(*) FILTER (
+          WHERE status = 'collected'
+            AND (expected_rating IS NULL OR expected_count IS NULL)
+        )::bigint AS no_report,
+        COUNT(*) FILTER (
+          WHERE status = 'collected'
+            AND expected_rating IS NOT NULL
+            AND expected_count  IS NOT NULL
+            AND expected_rating <> cr_rating
+        )::bigint AS cr_mismatch,
+        COUNT(*) FILTER (
+          WHERE status = 'collected'
+            AND expected_rating IS NOT NULL
+            AND expected_count  IS NOT NULL
+            AND expected_rating = cr_rating            AND NOT EXISTS (
+              SELECT 1 FROM "PageVersion" pv
+               WHERE pv.id = "pageVersionId"
+                 AND pv."validTo" IS NULL
+                 AND pv."isDeleted" = false
+                 AND pv.rating       IS NOT DISTINCT FROM pa_rating
+                 AND pv."voteCount"  IS NOT DISTINCT FROM pa_count
+            )
+        )::bigint AS stale,
+        COUNT(*) FILTER (
+          WHERE status = 'collected'
+            AND expected_rating IS NOT NULL
+            AND expected_count  IS NOT NULL
+            AND expected_rating = cr_rating            AND EXISTS (
+              SELECT 1 FROM "PageVersion" pv
+               WHERE pv.id = "pageVersionId"
+                 AND pv."validTo" IS NULL
+                 AND pv."isDeleted" = false
+                 AND pv.rating       IS NOT DISTINCT FROM pa_rating
+                 AND pv."voteCount"  IS NOT DISTINCT FROM pa_count
+            )
+        )::bigint AS apply_eligible
+      FROM ${qs}.tmp_audit_summary
+    `);
+    const sb = skipRows[0];
+    const skipPending = Number(sb?.pending ?? 0);
+    const skipError = Number(sb?.error ?? 0);
+    const skipNoReport = Number(sb?.no_report ?? 0);
+    const skipCrMismatch = Number(sb?.cr_mismatch ?? 0);
+    const skipStale = Number(sb?.stale ?? 0);
+    const eligible = Number(sb?.apply_eligible ?? 0);
+    const totalSkipped = skipPending + skipError + skipNoReport + skipCrMismatch + skipStale;
+
+    Logger.info(
+      `🔎 apply pre-flight: eligible=${eligible}, skipped total=${totalSkipped} ` +
+      `(pending=${skipPending}, error=${skipError}, no_report=${skipNoReport}, ` +
+      `cr_mismatch=${skipCrMismatch}, stale=${skipStale}); ` +
+      `expected_recomputed_rows=${Number(expectedRecomputed ?? 0)}`
+    );
+
+    if (skipCrMismatch > 0) {
+      const crPreview = await tx.$queryRawUnsafe<CrPreviewRow[]>(`
+        SELECT "wikidotId", url, expected_rating, cr_rating, expected_count, cr_count
+          FROM ${qs}.tmp_audit_summary
+         WHERE status = 'collected'
+           AND expected_rating IS NOT NULL
+           AND expected_count  IS NOT NULL
+           AND (expected_rating <> cr_rating OR expected_count <> cr_count)
+         ORDER BY ABS(COALESCE(expected_rating, 0) - COALESCE(cr_rating, 0)) DESC, "wikidotId"
+         LIMIT 10
+      `);
+      Logger.warn(`⚠️ cr_mismatch preview (top ${crPreview.length}):`);
+      for (const p of crPreview) {
+        Logger.warn(
+          `   wikidotId=${p.wikidotId} expected=${p.expected_rating}/${p.expected_count} ` +
+          `cr=${p.cr_rating}/${p.cr_count} url=${p.url ?? '(unknown)'}`
+        );
+      }
+    }
+
+    if (skipStale > 0) {
+      const stalePreview = await tx.$queryRawUnsafe<StalePreviewRow[]>(`
+        SELECT s."wikidotId",
+               s.url,
+               s.pa_rating,
+               s.pa_count,
+               pv.rating       AS pv_rating,
+               pv."voteCount"  AS pv_count,
+               pv."validTo"    AS valid_to,
+               pv."isDeleted"  AS is_deleted
+          FROM ${qs}.tmp_audit_summary s
+          LEFT JOIN "PageVersion" pv ON pv.id = s."pageVersionId"
+         WHERE s.status = 'collected'
+           AND s.expected_rating IS NOT NULL
+           AND s.expected_count  IS NOT NULL
+           AND s.expected_rating = s.cr_rating
+           AND s.expected_count  = s.cr_count
+           AND NOT (
+             pv."validTo" IS NULL
+             AND pv."isDeleted" = false
+             AND pv.rating       IS NOT DISTINCT FROM s.pa_rating
+             AND pv."voteCount"  IS NOT DISTINCT FROM s.pa_count
+           )
+         ORDER BY s."wikidotId"
+         LIMIT 10
+      `);
+      Logger.warn(
+        `⚠️ stale preview (top ${stalePreview.length}): PageVersion changed since collect; re-collect needed`
+      );
+      for (const p of stalePreview) {
+        Logger.warn(
+          `   wikidotId=${p.wikidotId} pa=${p.pa_rating}/${p.pa_count} ` +
+          `pv=${p.pv_rating}/${p.pv_count} validTo=${p.valid_to ? p.valid_to.toISOString() : 'NULL'} ` +
+          `isDeleted=${p.is_deleted} url=${p.url ?? '(unknown)'}`
+        );
+      }
+    }
+
+    if (totalSkipped > 0) {
+      Logger.warn(
+        `⚠️ apply will SKIP ${totalSkipped} pages (see breakdown above). ` +
+        `Re-run --collect for failed/stale pages or --report for no_report rows. ` +
+        `cr_mismatch pages 需要人工 review 后再决定是否 apply。`
+      );
+    }
+
+    // Step 2: tmp_user → public."User"，只插被 eligible 页引用的 user 占位
+    const userPlaceholderInserted = await tx.$executeRawUnsafe(`
+      INSERT INTO "User" ("wikidotId", "displayName")
+      SELECT DISTINCT u_tmp."wikidotId", u_tmp."displayName"
+        FROM ${qs}.tmp_user u_tmp
+       WHERE EXISTS (
+         SELECT 1
+           FROM ${qs}.tmp_vote tv
+           JOIN ${qs}.tmp_audit_summary s ON s."pageVersionId" = tv."pageVersionId"
+           JOIN "PageVersion" pv          ON pv.id             = s."pageVersionId"
+          WHERE tv.user_wikidot_id = u_tmp."wikidotId"
+            AND s.status = 'collected'
+            AND s.expected_rating IS NOT NULL
+            AND s.expected_count  IS NOT NULL
+            AND s.expected_rating = s.cr_rating
+            AND s.expected_count  = s.cr_count
+            AND pv."validTo" IS NULL
+            AND pv."isDeleted" = false
+            AND pv.rating       IS NOT DISTINCT FROM s.pa_rating
+            AND pv."voteCount"  IS NOT DISTINCT FROM s.pa_count
+       )
+      ON CONFLICT ("wikidotId") DO NOTHING
+    `);
+
+    // Step 3: user-vote 路径（含 freshness guard）
+    const userVoteTouched = await tx.$executeRawUnsafe(`
+      INSERT INTO "Vote" ("pageVersionId", "userId", "timestamp", direction)
+      SELECT DISTINCT ON (tv."pageVersionId", u.id, tv."timestamp")
+             tv."pageVersionId", u.id, tv."timestamp", tv.direction
+        FROM ${qs}.tmp_vote tv
+        JOIN ${qs}.tmp_audit_summary s ON s."pageVersionId" = tv."pageVersionId"
+        JOIN "PageVersion" pv          ON pv.id             = s."pageVersionId"
+        JOIN "User" u                  ON u."wikidotId"     = tv.user_wikidot_id
+       WHERE tv.user_wikidot_id IS NOT NULL
+         AND s.status = 'collected'
+         AND s.expected_rating IS NOT NULL
+         AND s.expected_count  IS NOT NULL
+         AND s.expected_rating = s.cr_rating         AND pv."validTo" IS NULL
+         AND pv."isDeleted" = false
+         AND pv.rating       IS NOT DISTINCT FROM s.pa_rating
+         AND pv."voteCount"  IS NOT DISTINCT FROM s.pa_count
+       ORDER BY tv."pageVersionId", u.id, tv."timestamp", tv.edge_seq DESC
+      ON CONFLICT ("pageVersionId", "userId", "timestamp")
+      DO UPDATE SET direction = EXCLUDED.direction
+    `);
+
+    // Step 4: anon 防御路径（含 freshness guard；当前期望 0 行）
+    const anonVoteTouched = await tx.$executeRawUnsafe(`
+      INSERT INTO "Vote" ("pageVersionId", "anonKey", "timestamp", direction)
+      SELECT DISTINCT ON (tv."pageVersionId", tv."anonKey", tv."timestamp")
+             tv."pageVersionId", tv."anonKey", tv."timestamp", tv.direction
+        FROM ${qs}.tmp_vote tv
+        JOIN ${qs}.tmp_audit_summary s ON s."pageVersionId" = tv."pageVersionId"
+        JOIN "PageVersion" pv          ON pv.id             = s."pageVersionId"
+       WHERE tv.user_wikidot_id IS NULL
+         AND tv."anonKey" IS NOT NULL
+         AND s.status = 'collected'
+         AND s.expected_rating IS NOT NULL
+         AND s.expected_count  IS NOT NULL
+         AND s.expected_rating = s.cr_rating         AND pv."validTo" IS NULL
+         AND pv."isDeleted" = false
+         AND pv.rating       IS NOT DISTINCT FROM s.pa_rating
+         AND pv."voteCount"  IS NOT DISTINCT FROM s.pa_count
+       ORDER BY tv."pageVersionId", tv."anonKey", tv."timestamp", tv.edge_seq DESC
+      ON CONFLICT ("pageVersionId", "anonKey", "timestamp")
+      DO UPDATE SET direction = EXCLUDED.direction
+    `);
+
+    return {
+      expectedRecomputed: Number(expectedRecomputed ?? 0),
+      eligible,
+      skipPending,
+      skipError,
+      skipNoReport,
+      skipCrMismatch,
+      skipStale,
+      totalSkipped,
+      userPlaceholderInserted: Number(userPlaceholderInserted ?? 0),
+      userVoteTouched: Number(userVoteTouched ?? 0),
+      anonVoteTouched: Number(anonVoteTouched ?? 0)
+    };
+  }, {
+    // INSERT 180k+ 行 + 多 SQL 步骤可能跑几分钟，Prisma 默认 5s 不够
+    timeout: 600_000,    // 10 min
+    maxWait: 30_000      // 30 s 等连接
+  });
+
+  Logger.info(
+    `✅ apply complete: public.User new=${result.userPlaceholderInserted}, ` +
+    `user-vote rows touched=${result.userVoteTouched}, anon-vote rows touched=${result.anonVoteTouched} ` +
+    `(rows include INSERT + ON CONFLICT DO UPDATE; eligible=${result.eligible}, skipped=${result.totalSkipped}, stale=${result.skipStale}; expected_recomputed=${result.expectedRecomputed})`
+  );
+  if (result.skipStale > 0) {
+    Logger.warn(
+      `⚠️ apply skipped ${result.skipStale} stale pages (PageVersion changed since collect; re-collect needed)`
+    );
+  }
+}
+
+async function doCleanup(prisma: PrismaClient, schema: string): Promise<void> {
+  const qs = quoteIdent(schema);
+  await prisma.$executeRawUnsafe(`DROP SCHEMA IF EXISTS ${qs} CASCADE`);
+  Logger.info(`🧹 schema ${schema} dropped`);
+}
+
+export async function runVoteResyncAudit(opts: VoteResyncAuditOptions): Promise<void> {
+  const schema = opts.schema && opts.schema.trim() ? opts.schema.trim() : DEFAULT_SCHEMA;
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(schema)) {
+    throw new Error(`invalid schema name: ${schema}`);
+  }
+
+  // 默认顺序：setup → collect → report；显式传任何 flag 时只跑被指定的步骤。
+  const explicitlyChosen =
+    Boolean(opts.setup) ||
+    Boolean(opts.collect) ||
+    Boolean(opts.report) ||
+    Boolean(opts.apply) ||
+    Boolean(opts.cleanup);
+
+  const runSetup = explicitlyChosen ? Boolean(opts.setup) : true;
+  const runCollect = explicitlyChosen ? Boolean(opts.collect) : true;
+  const runReport = explicitlyChosen ? Boolean(opts.report) : true;
+  const runApply = Boolean(opts.apply);
+  const runCleanup = Boolean(opts.cleanup);
+
+  const fetchConcurrency = Math.max(
+    1,
+    Number.isFinite(opts.fetchConcurrency) && (opts.fetchConcurrency ?? 0) > 0
+      ? Number(opts.fetchConcurrency)
+      : DEFAULT_FETCH_CONCURRENCY
+  );
+
+  const prisma = getPrismaClient();
+  try {
+    if (runSetup) {
+      Logger.info(`🛠️  setup: ensuring schema ${schema} and tmp tables`);
+      await ensureSchemaAndTables(prisma, schema);
+    }
+    if (runCollect) {
+      Logger.info('📥 collect: seed tmp_audit_summary and pull CROM fuzzyVoteRecords (no public reads)');
+      await doCollect(prisma, schema, fetchConcurrency);
+    }
+    if (runReport) {
+      Logger.info('📊 report: compute expected_rating/expected_count and render markdown');
+      await doReport(prisma, schema);
+    }
+    if (runApply) {
+      Logger.info('🚀 apply: writing tmp_user → public.User and tmp_vote → "Vote" (transactional)');
+      await doApply(prisma, schema);
+    }
+    if (runCleanup) {
+      Logger.info(`🧹 cleanup: dropping schema ${schema}`);
+      await doCleanup(prisma, schema);
+    }
+  } finally {
+    await disconnectPrisma();
+  }
+}

--- a/backend/src/core/store/VoteRevisionStore.ts
+++ b/backend/src/core/store/VoteRevisionStore.ts
@@ -102,42 +102,22 @@ export class VoteRevisionStore {
 
   /**
    * 导入投票记录
+   *
+   * 直接依赖 schema 上的唯一约束 (Vote_unique_constraint / Vote_anon_unique_constraint)
+   * 进行 upsert，避免人工去重时把上游新 timestamp 误判为「已存在」而丢弃。
+   * 既无 userId 又无 anonKey 的票无法去重（schema 无对应唯一索引），直接跳过避免无限膨胀。
    */
   private async importVotes(pageVersionId: number, voteEdges: any[], userMap: Map<number, number>) {
     const stats = { inserted: 0, updated: 0, skipped: 0, errors: 0 };
     const batchSize = 100;
     const votes = voteEdges.map(edge => edge.node);
-    const existingVotes = await this.prisma.vote.findMany({
-      where: { pageVersionId },
-      select: { id: true, userId: true, anonKey: true, direction: true, timestamp: true }
-    });
-
-    const existingVoteMap = new Map<string, { id: number; timestamp: Date }>();
-    for (const vote of existingVotes) {
-      const directionKey = typeof vote.direction === 'number'
-        ? vote.direction
-        : Number.parseInt(String(vote.direction ?? '0'), 10);
-      if (Number.isNaN(directionKey)) continue;
-
-      const key = vote.userId != null
-        ? `user:${vote.userId}:${directionKey}`
-        : vote.anonKey
-          ? `anon:${vote.anonKey}:${directionKey}`
-          : null;
-
-      if (!key) continue;
-      const existing = existingVoteMap.get(key);
-      if (!existing || vote.timestamp < existing.timestamp) {
-        existingVoteMap.set(key, { id: vote.id, timestamp: vote.timestamp });
-      }
-    }
 
     for (let i = 0; i < votes.length; i += batchSize) {
       const batch = votes.slice(i, i + batchSize);
 
       try {
         // 准备投票数据
-        const voteData: Array<{ pageVersionId: number; userId: number | null; anonKey: string | null; direction: number; timestamp: Date; key: string | null }> = [];
+        const voteData: Array<{ pageVersionId: number; userId: number | null; anonKey: string | null; direction: number; timestamp: Date }> = [];
         for (const vote of batch) {
           let userId: number | null = null;
           const wid = vote.user?.wikidotId
@@ -162,54 +142,20 @@ export class VoteRevisionStore {
             continue;
           }
 
-          const voteKey = userId != null
-            ? `user:${userId}:${direction}`
-            : (vote.anonKey ? `anon:${vote.anonKey}:${direction}` : null);
-
-          if (voteKey) {
-            const existing = existingVoteMap.get(voteKey);
-            if (existing) {
-              const existingTime = existing.timestamp.getTime();
-              if (!Number.isNaN(existingTime)) {
-                if (timestampTime >= existingTime) {
-                  stats.skipped++;
-                  continue;
-                }
-                try {
-                  const updated = await this.prisma.vote.update({
-                    where: { id: existing.id },
-                    data: {
-                      direction,
-                      timestamp: timestampValue
-                    }
-                  });
-                  existing.timestamp = updated.timestamp;
-                  stats.updated++;
-                  continue;
-                } catch (error) {
-                  stats.errors++;
-                  Logger.error(`Vote timestamp update error: ${error}`);
-                  continue;
-                }
-              }
-            }
-          }
-
           voteData.push({
             pageVersionId,
             userId,
             anonKey: vote.anonKey || null,
             direction,
-            timestamp: timestampValue,
-            key: voteKey
+            timestamp: timestampValue
           });
         }
 
-        // 批量upsert
+        // 依赖唯一约束 upsert：(pageVersionId, userId, timestamp) 或 (pageVersionId, anonKey, timestamp)
         for (const data of voteData) {
           try {
             if (data.userId != null) {
-              const userVote = await this.prisma.vote.upsert({
+              await this.prisma.vote.upsert({
                 where: {
                   Vote_unique_constraint: {
                     pageVersionId: data.pageVersionId,
@@ -228,11 +174,8 @@ export class VoteRevisionStore {
                 }
               });
               stats.inserted++;
-              if (data.key) {
-                existingVoteMap.set(data.key, { id: userVote.id, timestamp: userVote.timestamp });
-              }
             } else if (data.anonKey) {
-              const anonVote = await this.prisma.vote.upsert({
+              await this.prisma.vote.upsert({
                 where: {
                   Vote_anon_unique_constraint: {
                     pageVersionId: data.pageVersionId,
@@ -251,18 +194,10 @@ export class VoteRevisionStore {
                 }
               });
               stats.inserted++;
-              if (data.key) {
-                existingVoteMap.set(data.key, { id: anonVote.id, timestamp: anonVote.timestamp });
-              }
             } else {
-              await this.prisma.vote.create({
-                data: {
-                  pageVersionId: data.pageVersionId,
-                  direction: data.direction,
-                  timestamp: data.timestamp
-                }
-              });
-              stats.inserted++;
+              // 既无 userId 又无 anonKey：schema 没有对应唯一约束，直接 create 会在重复跑时无限膨胀，跳过
+              Logger.debug(`Skipping vote with neither userId nor anonKey (pageVersionId=${pageVersionId}, timestamp=${data.timestamp.toISOString()})`);
+              stats.skipped++;
             }
           } catch (error) {
             stats.errors++;

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -725,8 +725,8 @@ export class IncrementalAnalyzeJob {
     await this.prisma.$executeRaw`
       WITH vote_stats AS (
         SELECT v."pageVersionId" AS id,
-               COUNT(*) FILTER (WHERE v.direction = 1) AS uv,
-               COUNT(*) FILTER (WHERE v.direction = -1) AS dv
+               COUNT(*) FILTER (WHERE v.direction > 0) AS uv,
+               COUNT(*) FILTER (WHERE v.direction < 0) AS dv
         FROM "LatestVote" v
         WHERE v."pageVersionId" = ANY(${pageVersionIds}::int[])
         GROUP BY v."pageVersionId"
@@ -872,8 +872,8 @@ export class IncrementalAnalyzeJob {
           SELECT 
             pv."pageId",
             date_trunc('day', v."timestamp") AS dt,
-            COUNT(*) FILTER (WHERE v.direction = 1)      AS votes_up,
-            COUNT(*) FILTER (WHERE v.direction = -1)     AS votes_down,
+            COUNT(*) FILTER (WHERE v.direction > 0)      AS votes_up,
+            COUNT(*) FILTER (WHERE v.direction < 0)     AS votes_down,
             COUNT(*) FILTER (WHERE v.direction != 0)     AS total_votes,
             COUNT(DISTINCT v."userId") FILTER (WHERE v."userId" IS NOT NULL) AS unique_voters,
             0::bigint                                   AS revisions
@@ -1223,8 +1223,8 @@ export class IncrementalAnalyzeJob {
         SELECT 
           "userId",
           tag,
-          COUNT(*) FILTER (WHERE direction = 1) as upvote_count,
-          COUNT(*) FILTER (WHERE direction = -1) as downvote_count,
+          COUNT(*) FILTER (WHERE direction > 0) as upvote_count,
+          COUNT(*) FILTER (WHERE direction < 0) as downvote_count,
           COUNT(*) as total_votes,
           MAX(timestamp) as last_vote_at
         FROM user_tag_votes
@@ -1293,8 +1293,8 @@ export class IncrementalAnalyzeJob {
         SELECT 
           ai.from_user_id,
           ai.to_user_id,
-          COUNT(*) FILTER (WHERE ai.direction = 1) AS upvote_count,
-          COUNT(*) FILTER (WHERE ai.direction = -1) AS downvote_count,
+          COUNT(*) FILTER (WHERE ai.direction > 0) AS upvote_count,
+          COUNT(*) FILTER (WHERE ai.direction < 0) AS downvote_count,
           COUNT(*) AS total_votes,
           MAX(ai.timestamp) AS last_vote_at
         FROM all_interactions ai
@@ -1616,8 +1616,8 @@ export class IncrementalAnalyzeJob {
           SELECT 
             pv."pageId",
             COUNT(*) as new_votes,
-            COUNT(*) FILTER (WHERE v.direction = 1) as new_upvotes,
-            COUNT(*) FILTER (WHERE v.direction = -1) as new_downvotes
+            COUNT(*) FILTER (WHERE v.direction > 0) as new_upvotes,
+            COUNT(*) FILTER (WHERE v.direction < 0) as new_downvotes
           FROM "Vote" v
           JOIN "PageVersion" pv ON v."pageVersionId" = pv.id
           WHERE v."timestamp" >= NOW() - INTERVAL '24 hours'
@@ -1628,8 +1628,8 @@ export class IncrementalAnalyzeJob {
           SELECT 
             pv."pageId",
             f_wilson_lower_bound(
-              COUNT(*) FILTER (WHERE v.direction = 1 AND v."timestamp" < NOW() - INTERVAL '24 hours'),
-              COUNT(*) FILTER (WHERE v.direction = -1 AND v."timestamp" < NOW() - INTERVAL '24 hours')
+              COUNT(*) FILTER (WHERE v.direction > 0 AND v."timestamp" < NOW() - INTERVAL '24 hours'),
+              COUNT(*) FILTER (WHERE v.direction < 0 AND v."timestamp" < NOW() - INTERVAL '24 hours')
             ) as prev_wilson
           FROM "PageVersion" pv
           LEFT JOIN "Vote" v ON v."pageVersionId" = pv.id

--- a/backend/src/jobs/UserSocialAnalysisJob.ts
+++ b/backend/src/jobs/UserSocialAnalysisJob.ts
@@ -88,8 +88,8 @@ export class UserSocialAnalysisJob {
           SELECT 
             "userId",
             tag,
-            COUNT(*) FILTER (WHERE direction = 1) as upvote_count,
-            COUNT(*) FILTER (WHERE direction = -1) as downvote_count,
+            COUNT(*) FILTER (WHERE direction > 0) as upvote_count,
+            COUNT(*) FILTER (WHERE direction < 0) as downvote_count,
             COUNT(*) as total_votes,
             MAX(timestamp) as last_vote_at
           FROM user_tag_votes
@@ -193,8 +193,8 @@ export class UserSocialAnalysisJob {
           SELECT 
             from_user_id,
             to_user_id,
-            COUNT(*) FILTER (WHERE direction = 1) as upvote_count,
-            COUNT(*) FILTER (WHERE direction = -1) as downvote_count,
+            COUNT(*) FILTER (WHERE direction > 0) as upvote_count,
+            COUNT(*) FILTER (WHERE direction < 0) as downvote_count,
             COUNT(*) as total_votes,
             MAX(timestamp) as last_vote_at
           FROM vote_interactions

--- a/backend/src/services/VotingTimeSeriesService.ts
+++ b/backend/src/services/VotingTimeSeriesService.ts
@@ -67,10 +67,10 @@ export class VotingTimeSeriesService {
       deltas AS (
         SELECT
           vote_date,
-          (CASE WHEN current_direction = 1 THEN 1 ELSE 0 END)
-            - (CASE WHEN COALESCE(prev_direction, 0) = 1 THEN 1 ELSE 0 END) AS up_delta,
-          (CASE WHEN current_direction = -1 THEN 1 ELSE 0 END)
-            - (CASE WHEN COALESCE(prev_direction, 0) = -1 THEN 1 ELSE 0 END) AS down_delta,
+          (CASE WHEN current_direction > 0 THEN 1 ELSE 0 END)
+            - (CASE WHEN COALESCE(prev_direction, 0) > 0 THEN 1 ELSE 0 END) AS up_delta,
+          (CASE WHEN current_direction < 0 THEN 1 ELSE 0 END)
+            - (CASE WHEN COALESCE(prev_direction, 0) < 0 THEN 1 ELSE 0 END) AS down_delta,
           (CASE WHEN current_direction <> 0 THEN 1 ELSE 0 END)
             - (CASE WHEN COALESCE(prev_direction, 0) <> 0 THEN 1 ELSE 0 END) AS total_delta
         FROM ordered
@@ -279,10 +279,10 @@ export class VotingTimeSeriesService {
       vote_deltas AS (
         SELECT
           vote_date,
-          (CASE WHEN current_direction = 1 THEN 1 ELSE 0 END)
-            - (CASE WHEN COALESCE(prev_direction, 0) = 1 THEN 1 ELSE 0 END) AS up_delta,
-          (CASE WHEN current_direction = -1 THEN 1 ELSE 0 END)
-            - (CASE WHEN COALESCE(prev_direction, 0) = -1 THEN 1 ELSE 0 END) AS down_delta,
+          (CASE WHEN current_direction > 0 THEN 1 ELSE 0 END)
+            - (CASE WHEN COALESCE(prev_direction, 0) > 0 THEN 1 ELSE 0 END) AS up_delta,
+          (CASE WHEN current_direction < 0 THEN 1 ELSE 0 END)
+            - (CASE WHEN COALESCE(prev_direction, 0) < 0 THEN 1 ELSE 0 END) AS down_delta,
           (CASE WHEN current_direction <> 0 THEN 1 ELSE 0 END)
             - (CASE WHEN COALESCE(prev_direction, 0) <> 0 THEN 1 ELSE 0 END) AS total_delta
         FROM ordered

--- a/bff/src/web/routes/pages.ts
+++ b/bff/src/web/routes/pages.ts
@@ -2150,8 +2150,8 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
       const result = await cache.remember(cacheKey, 180, async () => {
         const sql = `
           SELECT
-            COUNT(CASE WHEN v.direction = 1 THEN 1 END) as upvotes,
-            COUNT(CASE WHEN v.direction = -1 THEN 1 END) as downvotes,
+            COUNT(CASE WHEN v.direction > 0 THEN 1 END) as upvotes,
+            COUNT(CASE WHEN v.direction < 0 THEN 1 END) as downvotes,
             COUNT(CASE WHEN v.direction = 0 THEN 1 END) as novotes,
             COUNT(*) as total
           FROM "LatestVote" v
@@ -2256,8 +2256,8 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
           deltas AS (
             SELECT
               period,
-              (CASE WHEN current_direction = 1 THEN 1 ELSE 0 END) - (CASE WHEN COALESCE(prev_direction, 0) = 1 THEN 1 ELSE 0 END) AS up_delta,
-              (CASE WHEN current_direction = -1 THEN 1 ELSE 0 END) - (CASE WHEN COALESCE(prev_direction, 0) = -1 THEN 1 ELSE 0 END) AS down_delta,
+              (CASE WHEN current_direction > 0 THEN 1 ELSE 0 END) - (CASE WHEN COALESCE(prev_direction, 0) > 0 THEN 1 ELSE 0 END) AS up_delta,
+              (CASE WHEN current_direction < 0 THEN 1 ELSE 0 END) - (CASE WHEN COALESCE(prev_direction, 0) < 0 THEN 1 ELSE 0 END) AS down_delta,
               current_direction - COALESCE(prev_direction, 0) AS net_delta
             FROM ordered
           ),

--- a/frontend/pages/page/[wikidotId]/index.vue
+++ b/frontend/pages/page/[wikidotId]/index.vue
@@ -873,26 +873,31 @@ const upvotePct = computed(() => totalVotes.value ? (upvotes.value / totalVotes.
 const downvotePct = computed(() => totalVotes.value ? (downvotes.value / totalVotes.value) * 100 : 0)
 const likeRatioPct = computed(() => totalVotes.value ? (upvotes.value / totalVotes.value) * 100 : 0)
 const totalScore = computed(() => {
-  const distribution = voteDistribution.value as any
-  if (distribution && distribution.upvotes != null && distribution.downvotes != null) {
-    const up = Number(distribution.upvotes)
-    const down = Number(distribution.downvotes)
-    if (Number.isFinite(up) && Number.isFinite(down)) {
-      return up - down
-    }
+  // 优先 page.rating（PhaseA 同步的 wikidot 权威字段）
+  // 显式判 null/undefined：Number(null) === 0 会让未加载时顽固显示 0，
+  // 无法 fallback 到 stats / voteDistribution
+  if (page.value?.rating != null) {
+    const authoritative = Number(page.value.rating)
+    if (Number.isFinite(authoritative)) return authoritative
   }
 
+  // 次选 stats.hasStats 时的 uv-dv
   const statsValue = stats.value as any
   if (statsValue && statsValue.hasStats) {
     const up = Number(statsValue.uv ?? 0)
     const down = Number(statsValue.dv ?? 0)
-    if (Number.isFinite(up) && Number.isFinite(down)) {
-      return up - down
-    }
+    if (Number.isFinite(up) && Number.isFinite(down)) return up - down
   }
 
-  const fallback = Number(page.value?.rating ?? 0)
-  return Number.isFinite(fallback) ? fallback : 0
+  // 最后 voteDistribution
+  const distribution = voteDistribution.value as any
+  if (distribution && distribution.upvotes != null && distribution.downvotes != null) {
+    const up = Number(distribution.upvotes)
+    const down = Number(distribution.downvotes)
+    if (Number.isFinite(up) && Number.isFinite(down)) return up - down
+  }
+
+  return 0
 })
 const totalScoreDisplay = computed(() => {
   const value = totalScore.value


### PR DESCRIPTION
## Summary

修复 SCPper-CN 的 vote 同步漏抓 bug 并对全站 1077 页做隔离回填。核心是 `VoteRevisionStore.importVotes` 用 `(user, direction)` 当唯一性键导致用户改投回原方向时新票被 skip 的语义错误（例：SCP-CN-4949 leadromark 12-21 -1 票丢失，详情页 81 vs wikidot 真实 79）。

- **核心 bug 修复**：删 90 行人工去重，按 `Vote_unique_constraint` 直接 upsert；无身份票 skip 防止重复跑膨胀
- **direction ±2 边界**：BFF/backend 多处 up/down 计数从 `direction = ±1` 改 `> 0 / < 0`，覆盖 CROM 允许的 ±2 票（vote-distribution / rating-history / PageStats / PageDailyStats / trending / UserTagPreference / UserVoteInteraction / UserSocialAnalysisJob / VotingTimeSeriesService / export-annual-summary）
- **前端口径**：详情页 totalScore 优先 `page.rating`（PhaseA 同步的 wikidot 权威字段），修 `Number(null)===0` fallback 短路
- **一次性回填工具**：新增 `vote-resync-audit` CLI 用 temp schema 隔离（setup / collect / report / apply / cleanup），含 freshness guard + 6-bucket pre-flight + 10min 事务 timeout
- **常态化监控**：新增 `check-vote-integrity` 脚本对账 7 buckets

回填实测：apply 写入 170,256 行；ratingMismatch 908 → 15（-98.3%），anyMismatch 1074 → 464（-56.8%）。

## Test plan

- [x] backend typecheck + typecheck:scripts pass
- [x] bff build pass
- [x] frontend build pass (Nuxt 4, 3405 modules / 30s, 19.6MB / 4.27MB gzip)
- [x] `vote-resync-audit --setup --collect --report` 跑通：1077/1079 页 100% `expected_rating == cr_rating`，2 页 CROM 返回 null
- [x] `vote-resync-audit --apply` 跑通：170,256 rows touched，8s 事务内完成，pre-flight 自动跳过 6 stale + 2 error 页
- [x] `vote-resync-audit --cleanup` 跑通：DROP SCHEMA vote_resync_audit CASCADE
- [x] DB 备份 3.1 GB at `/home/andyblocker/db-backups/scpper-cn-pre-vote-resync-20260427-104251.dump`（MD5: `a83a3fc44e05e1be943117b6c54fba26`）
- [x] SCP-CN-4949 LatestVote 聚合从 81 → 79（wikidot 真实分数）
- [x] leadromark 12-21 -1 票补上（Vote 表新增 id=19494549）
- [x] Codex MCP 6 轮审计通过（root cause + freshness guard + apply status filter + Number(null) 边界）

## Followups（不在本 PR scope）

- 跑 `sync:full` 让 PhaseA 字段收敛剩 15 页 ratingMismatch（PhaseA latency 引起的 ±1 票偏差）
- 跑 `analyze:full` 重算 PageStats / UserStats / PageDailyStats / votingTimeSeriesCache / 物化视图等派生表（IncrementalAnalyzeJob 用 `timestamp >= watermark` 增量，历史 timestamp 不会被增量捡到）
- 清 Redis cache: `recommendations:*` / `stats:pages:*` / `pages:*:vote-distribution` / `pages:*:rating-history:*`
- frontend 仓库补 `vue-tsc` / `typescript` 到 `devDependencies`（否则 nuxt typecheck silent no-op）
- 部分 helper / debug scripts 仍用 `direction = ±1` 字面量未改：`analyze-single-page`, `check-favorite-authors`, `verify-user-interactions`, `fix-deleted-page-ratings`, `diff-author-pv-vs-page`, `check-vote-count-mismatches`, `diff-global-interactions`, `inspect-page`, `user-votes-raw`, `user-firsts-analysis`, `create-analysis-objects.sql` —— ad-hoc 工具，scope 留给 follow-up issue
- voteCount 字段语义统一（CROM voteCount 含 `direction=0` cancelled 用户；本地 LatestVote 已过滤——下个 PR 决定是否同步收敛 PageVersion.voteCount 算法）