### PR TITLE
fix(wikidot-binding): 放宽 revision timestamp 窗口修 5 用户绑定卡死

### DIFF
--- a/backend/src/jobs/WikidotBindingVerifyJob.ts
+++ b/backend/src/jobs/WikidotBindingVerifyJob.ts
@@ -11,6 +11,25 @@ const NO_MATCH_LOG_EVERY_N_CHECKS = Math.max(
   1,
   Math.floor(Number(process.env.WIKIDOT_BINDING_NO_MATCH_LOG_EVERY ?? '12') || 12)
 );
+// Wikidot revisions reach us via Crom GraphQL with a server-side timestamp that
+// can lag PostgreSQL `now()` by tens of seconds. Without slack, a user who edits
+// /andyblocker right after starting a binding task gets their (correct) revision
+// timestamp recorded *before* task.createdAt and is filtered out forever.
+// verificationCode is already a 6-char base31 unique key, so a generous backstop
+// has effectively zero forgery risk.
+const TASK_TIMESTAMP_SLACK_MS = Math.max(
+  0,
+  Math.floor(Number(process.env.WIKIDOT_BINDING_TIMESTAMP_SLACK_MS ?? '300000') || 300000)
+);
+// Surface stuck tasks so we don't silently burn 500 checks again before noticing.
+const STUCK_TASK_WARN_THRESHOLD = Math.max(
+  1,
+  Math.floor(Number(process.env.WIKIDOT_BINDING_STUCK_WARN_THRESHOLD ?? '60') || 60)
+);
+const STUCK_TASK_WARN_INTERVAL = Math.max(
+  1,
+  Math.floor(Number(process.env.WIKIDOT_BINDING_STUCK_WARN_INTERVAL ?? '60') || 60)
+);
 
 interface PendingTask {
   id: string;
@@ -141,12 +160,13 @@ export class WikidotBindingVerifyJob {
         return;
       }
 
-      // Query revisions on the target page made by this user after task creation
+      // Apply slack on task.createdAt to absorb wikidot↔PG clock skew.
+      const lowerBound = new Date(new Date(task.createdAt).getTime() - TASK_TIMESTAMP_SLACK_MS);
       const revisions = await this.prisma.revision.findMany({
         where: {
           pageVersion: { pageId },
           userId: user.id,
-          timestamp: { gte: new Date(task.createdAt) }
+          timestamp: { gte: lowerBound }
         },
         select: {
           id: true,
@@ -174,6 +194,14 @@ export class WikidotBindingVerifyJob {
         if (shouldLogNoMatch) {
           console.log(
             `ℹ️ No matching revision for task ${task.id} (checked ${revisions.length} revisions, checkCount=${checkCount}).`
+          );
+        }
+        if (
+          checkCount >= STUCK_TASK_WARN_THRESHOLD
+          && checkCount % STUCK_TASK_WARN_INTERVAL === 0
+        ) {
+          console.warn(
+            `⚠️ Wikidot binding task ${task.id} stuck after ${checkCount} checks (wikidotUserId=${task.wikidotUserId}, code=${task.verificationCode}).`
           );
         }
         await this.updateTaskCheck(task.id);


### PR DESCRIPTION
## Summary

- `WikidotBindingVerifyJob` 用 `revision.timestamp >= task.createdAt` 严格筛 revision，但 wikidot timestamp（经 Crom GraphQL 透传）相对 user-backend PG `now()` 系统性早几十秒，导致用户在 task 创建后立刻写的有效验证码 revision 被永远过滤掉。
- 给 timestamp 比对加 5 分钟可配 buffer（`WIKIDOT_BINDING_TIMESTAMP_SLACK_MS`），并对 stuck 任务打 warn 日志。
- verificationCode 已是 6 位 base31 全局唯一 + 48h TTL，不靠时间窗口防造假，放宽窗口零安全风险。

## 故障实证

5 个用户（Dr_Erich-V / Jian_321 / HexavalentCr / Drlin0 / ruscccp）写对验证码后分别被 verify job 检查 168~531 次仍卡 PENDING。各自 revision 比 task.createdAt 早 8.6~42.9 秒：

| 用户 | code | task.createdAt | rev.timestamp | 偏差 | checkCount |
|---|---|---|---|---|---|
| Dr_Erich-V | NN2HYU | 04-25 05:46:52.633 | 04-25 05:46:44 | -8.6s | 531 |
| Jian_321 | JUUSM9 | 04-25 05:52:24.211 | 04-25 05:52:09 | -15.2s | 531 |
| HexavalentCr | XBAT8X | 04-27 17:10:48.945 | 04-27 17:10:19 | -29.9s | 410 |
| Drlin0 | 5T8GW5 | 04-28 06:59:55.336 | 04-28 06:59:46 | -9.3s | 244 |
| ruscccp | SA5WFG | 04-28 12:40:13.898 | 04-28 12:39:31 | -42.9s | 176 |

5 个被卡用户已通过手工 SQL 完成 VERIFIED + linkedWikidotId（事务提交，UserAccount.linkedWikidotId 唯一约束已先 SELECT 验证未冲突）。

## Test plan

- [ ] 部署后等下一轮 binding-verify-loop（默认 5 min）触发，确认无 type/import error
- [ ] 用一个新测试账号走完整 binding 流程，写完验证码后立即（< 30 秒内）查 task 状态应转 VERIFIED
- [ ] 检查 binding-verify 日志，对历史任务的 stuck warn（checkCount ≥ 60）应正确触发
- [ ] 监控接下来 24h 内是否还有新 PENDING 任务 checkCount 异常累积