### PR TITLE
[codex] fix user vote stats duplication

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "query:help": "node --import tsx/esm src/cli/index.ts query --help",
     "query:stats": "node --import tsx/esm src/cli/index.ts query --stats",
     "query:rankings": "node --import tsx/esm src/cli/index.ts query --user-rank",
+    "repair:user-vote-stats": "node --import tsx/esm src/cli/index.ts repair-user-vote-stats",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy",

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -27,6 +27,7 @@ import { WikidotForumClient } from '../core/client/WikidotForumClient.js';
 import { runSyncHourlyScheduler } from './sync-hourly.js';
 import { runWikidotBindingVerifyLoop } from './wikidot-binding-verify-loop.js';
 import { runVoteResyncAudit } from './voteResyncAudit.js';
+import { runRepairUserVoteStats } from './repair-user-vote-stats.js';
 
 const program = new Command();
 
@@ -200,6 +201,28 @@ program
     // but --full forces a complete analysis which is equivalent to the old behavior
     const forceFullAnalysis = options.full || options.since;
     await analyzeIncremental({ forceFullAnalysis });
+  });
+
+program
+  .command('repair-user-vote-stats')
+  .description('Rebuild user vote social stats and user vote totals without running gacha market ticks')
+  .option('--batch-size <n>', 'Batch size for incremental social analysis paths (full rebuild uses set-based SQL)', '1000')
+  .option('--dry-run', 'Recompute summaries in a read-only transaction without writing data')
+  .option('--social-only', 'Only rebuild UserTagPreference and UserVoteInteraction')
+  .option('--user-stats-only', 'Only rebuild UserStats vote totals/rankings')
+  .action(async (options) => {
+    const prisma = getPrismaClient();
+    const batchSize = Math.max(1, Number.parseInt(String(options.batchSize ?? '1000'), 10) || 1000);
+    try {
+      await runRepairUserVoteStats(prisma, {
+        batchSize,
+        dryRun: Boolean(options.dryRun),
+        socialOnly: Boolean(options.socialOnly),
+        userStatsOnly: Boolean(options.userStatsOnly)
+      });
+    } finally {
+      await disconnectPrisma();
+    }
   });
 
 program

--- a/backend/src/cli/repair-user-vote-stats.ts
+++ b/backend/src/cli/repair-user-vote-stats.ts
@@ -1,0 +1,396 @@
+import type { PrismaClient } from '@prisma/client';
+import { UserRatingSystem } from '../jobs/UserRatingJob.js';
+import { UserSocialAnalysisJob } from '../jobs/UserSocialAnalysisJob.js';
+
+export interface RepairUserVoteStatsOptions {
+  batchSize: number;
+  dryRun?: boolean;
+  socialOnly?: boolean;
+  userStatsOnly?: boolean;
+}
+
+function toInt(value: unknown): number {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function printStats(label: string, row: Record<string, unknown>) {
+  console.log(`\n${label}`);
+  for (const [key, value] of Object.entries(row)) {
+    console.log(`  ${key}: ${String(value ?? 0)}`);
+  }
+}
+
+async function dryRunTagPreferences(prisma: PrismaClient) {
+  const rows = await prisma.$queryRaw<Array<Record<string, unknown>>>`
+    WITH latest_vote_candidates AS (
+      SELECT
+        v.id,
+        v."userId",
+        pv."pageId",
+        v.direction,
+        v.timestamp,
+        ROW_NUMBER() OVER (
+          PARTITION BY v."userId", pv."pageId"
+          ORDER BY v.timestamp DESC, v.id DESC
+        ) AS rn
+      FROM "Vote" v
+      JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+      WHERE v."userId" IS NOT NULL
+    ),
+    latest_user_page_votes AS (
+      SELECT "userId", "pageId", direction, timestamp
+      FROM latest_vote_candidates
+      WHERE rn = 1
+        AND direction != 0
+    ),
+    user_tag_votes AS (
+      SELECT
+        lupv."userId",
+        unnest(pv_pick.tags) AS tag,
+        lupv.direction,
+        lupv.timestamp
+      FROM latest_user_page_votes lupv
+      JOIN LATERAL (
+        SELECT pv2.tags, pv2."isDeleted"
+        FROM "PageVersion" pv2
+        WHERE pv2."pageId" = lupv."pageId"
+        ORDER BY
+          (pv2."validTo" IS NULL) DESC,
+          (NOT pv2."isDeleted") DESC,
+          pv2."validFrom" DESC NULLS LAST,
+          pv2.id DESC
+        LIMIT 1
+      ) pv_pick ON TRUE
+      WHERE pv_pick."isDeleted" = false
+        AND pv_pick.tags IS NOT NULL
+        AND array_length(pv_pick.tags, 1) > 0
+    ),
+    recomputed AS (
+      SELECT
+        "userId",
+        tag,
+        COUNT(*) FILTER (WHERE direction > 0)::int AS upvote_count,
+        COUNT(*) FILTER (WHERE direction < 0)::int AS downvote_count,
+        COUNT(*)::int AS total_votes
+      FROM user_tag_votes
+      WHERE tag NOT IN ('页面', '重定向', '管理', '_cc')
+      GROUP BY "userId", tag
+      HAVING COUNT(*) >= 3
+    ),
+    current_stats AS (
+      SELECT
+        COUNT(*)::bigint AS current_rows,
+        COALESCE(SUM("totalVotes"), 0)::bigint AS current_total_votes,
+        COALESCE(SUM("upvoteCount"), 0)::bigint AS current_upvotes,
+        COALESCE(SUM("downvoteCount"), 0)::bigint AS current_downvotes
+      FROM "UserTagPreference"
+    ),
+    recomputed_stats AS (
+      SELECT
+        COUNT(*)::bigint AS recomputed_rows,
+        COALESCE(SUM(total_votes), 0)::bigint AS recomputed_total_votes,
+        COALESCE(SUM(upvote_count), 0)::bigint AS recomputed_upvotes,
+        COALESCE(SUM(downvote_count), 0)::bigint AS recomputed_downvotes
+      FROM recomputed
+    ),
+    diff_stats AS (
+      SELECT
+        COUNT(*) FILTER (WHERE c."userId" IS NULL)::bigint AS rows_to_insert,
+        COUNT(*) FILTER (WHERE r."userId" IS NULL)::bigint AS rows_to_delete,
+        COUNT(*) FILTER (
+          WHERE c."userId" IS NOT NULL
+            AND r."userId" IS NOT NULL
+            AND (
+              c."upvoteCount" <> r.upvote_count
+              OR c."downvoteCount" <> r.downvote_count
+              OR c."totalVotes" <> r.total_votes
+            )
+        )::bigint AS rows_to_update
+      FROM "UserTagPreference" c
+      FULL OUTER JOIN recomputed r
+        ON r."userId" = c."userId"
+       AND r.tag = c.tag
+    )
+    SELECT *
+    FROM current_stats
+    CROSS JOIN recomputed_stats
+    CROSS JOIN diff_stats
+  `;
+
+  printStats('UserTagPreference dry run', rows[0] ?? {});
+}
+
+async function dryRunVoteInteractions(prisma: PrismaClient) {
+  const rows = await prisma.$queryRaw<Array<Record<string, unknown>>>`
+    WITH effective_attributions AS (
+      SELECT DISTINCT a."pageVerId", a."userId"
+      FROM (
+        SELECT
+          a.*,
+          BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a."pageVerId") AS has_non_submitter
+        FROM "Attribution" a
+      ) a
+      WHERE NOT (a.has_non_submitter AND a.type = 'SUBMITTER')
+        AND a."userId" IS NOT NULL
+    ),
+    latest_vote_candidates AS (
+      SELECT
+        v.id,
+        v."userId" AS from_user_id,
+        pv."pageId" AS page_id,
+        v.direction,
+        v.timestamp,
+        ROW_NUMBER() OVER (
+          PARTITION BY v."userId", pv."pageId"
+          ORDER BY v.timestamp DESC, v.id DESC
+        ) AS rn
+      FROM "Vote" v
+      JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+      WHERE v."userId" IS NOT NULL
+    ),
+    latest_user_page_votes AS (
+      SELECT from_user_id, page_id, direction, timestamp
+      FROM latest_vote_candidates
+      WHERE rn = 1
+        AND direction != 0
+    ),
+    vote_interactions AS (
+      SELECT
+        lupv.from_user_id,
+        a."userId" AS to_user_id,
+        lupv.direction
+      FROM latest_user_page_votes lupv
+      JOIN LATERAL (
+        SELECT pv2.id, pv2."isDeleted"
+        FROM "PageVersion" pv2
+        WHERE pv2."pageId" = lupv.page_id
+        ORDER BY
+          (pv2."validTo" IS NULL) DESC,
+          (NOT pv2."isDeleted") DESC,
+          pv2."validFrom" DESC NULLS LAST,
+          pv2.id DESC
+        LIMIT 1
+      ) pv_pick ON TRUE
+      JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
+      WHERE lupv.from_user_id != a."userId"
+        AND pv_pick."isDeleted" = false
+    ),
+    recomputed AS (
+      SELECT
+        from_user_id,
+        to_user_id,
+        COUNT(*) FILTER (WHERE direction > 0)::int AS upvote_count,
+        COUNT(*) FILTER (WHERE direction < 0)::int AS downvote_count,
+        COUNT(*)::int AS total_votes
+      FROM vote_interactions
+      GROUP BY from_user_id, to_user_id
+    ),
+    current_stats AS (
+      SELECT
+        COUNT(*)::bigint AS current_rows,
+        COALESCE(SUM("totalVotes"), 0)::bigint AS current_total_votes,
+        COALESCE(SUM("upvoteCount"), 0)::bigint AS current_upvotes,
+        COALESCE(SUM("downvoteCount"), 0)::bigint AS current_downvotes
+      FROM "UserVoteInteraction"
+    ),
+    recomputed_stats AS (
+      SELECT
+        COUNT(*)::bigint AS recomputed_rows,
+        COALESCE(SUM(total_votes), 0)::bigint AS recomputed_total_votes,
+        COALESCE(SUM(upvote_count), 0)::bigint AS recomputed_upvotes,
+        COALESCE(SUM(downvote_count), 0)::bigint AS recomputed_downvotes
+      FROM recomputed
+    ),
+    diff_stats AS (
+      SELECT
+        COUNT(*) FILTER (WHERE c."fromUserId" IS NULL)::bigint AS rows_to_insert,
+        COUNT(*) FILTER (WHERE r.from_user_id IS NULL)::bigint AS rows_to_delete,
+        COUNT(*) FILTER (
+          WHERE c."fromUserId" IS NOT NULL
+            AND r.from_user_id IS NOT NULL
+            AND (
+              c."upvoteCount" <> r.upvote_count
+              OR c."downvoteCount" <> r.downvote_count
+              OR c."totalVotes" <> r.total_votes
+            )
+        )::bigint AS rows_to_update
+      FROM "UserVoteInteraction" c
+      FULL OUTER JOIN recomputed r
+        ON r.from_user_id = c."fromUserId"
+       AND r.to_user_id = c."toUserId"
+    )
+    SELECT *
+    FROM current_stats
+    CROSS JOIN recomputed_stats
+    CROSS JOIN diff_stats
+  `;
+
+  printStats('UserVoteInteraction dry run', rows[0] ?? {});
+}
+
+async function dryRunUserStatsVoteTotals(prisma: PrismaClient) {
+  const rows = await prisma.$queryRaw<Array<Record<string, unknown>>>`
+    WITH effective_attributions AS (
+      SELECT DISTINCT a."pageVerId", a."userId"
+      FROM (
+        SELECT
+          a.*,
+          BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a."pageVerId") AS has_non_submitter
+        FROM "Attribution" a
+      ) a
+      WHERE NOT (a.has_non_submitter AND a.type = 'SUBMITTER')
+        AND a."userId" IS NOT NULL
+    ),
+    votes_cast_raw AS (
+      SELECT
+        v.id,
+        v."userId",
+        pv."pageId",
+        v.timestamp,
+        v.direction
+      FROM "Vote" v
+      JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+      WHERE v."userId" IS NOT NULL
+    ),
+    votes_cast_ranked AS (
+      SELECT
+        r.*,
+        ROW_NUMBER() OVER (
+          PARTITION BY r."userId", r."pageId"
+          ORDER BY r.timestamp DESC, r.id DESC
+        ) AS rn
+      FROM votes_cast_raw r
+    ),
+    votes_cast AS (
+      SELECT
+        r."userId" AS "userId",
+        COUNT(*) FILTER (WHERE r.direction > 0) AS votes_cast_up,
+        COUNT(*) FILTER (WHERE r.direction < 0) AS votes_cast_down
+      FROM votes_cast_ranked r
+      WHERE r.rn = 1
+      GROUP BY r."userId"
+    ),
+    votes_received_raw AS (
+      SELECT
+        v.id,
+        v.timestamp,
+        v.direction,
+        pv."pageId" AS page_id,
+        CASE
+          WHEN v."userId" IS NOT NULL THEN 'u:' || v."userId"::text
+          WHEN v."anonKey" IS NOT NULL THEN 'a:' || v."anonKey"
+          ELSE 'g:' || v.id::text
+        END AS actor_key
+      FROM "Vote" v
+      JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+    ),
+    votes_received_ranked AS (
+      SELECT
+        r.*,
+        ROW_NUMBER() OVER (
+          PARTITION BY r.page_id, r.actor_key
+          ORDER BY r.timestamp DESC, r.id DESC
+        ) AS rn
+      FROM votes_received_raw r
+    ),
+    latest_received AS (
+      SELECT page_id, direction
+      FROM votes_received_ranked
+      WHERE rn = 1
+        AND direction <> 0
+    ),
+    votes_received_attrib AS (
+      SELECT
+        a."userId" AS "userId",
+        lr.direction AS direction
+      FROM latest_received lr
+      LEFT JOIN LATERAL (
+        SELECT pv3.id
+        FROM "PageVersion" pv3
+        WHERE pv3."pageId" = lr.page_id
+        ORDER BY
+          (pv3."validTo" IS NULL) DESC,
+          (NOT pv3."isDeleted") DESC,
+          pv3."validFrom" DESC NULLS LAST,
+          pv3.id DESC
+        LIMIT 1
+      ) pv_pick ON TRUE
+      JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
+    ),
+    votes_received AS (
+      SELECT
+        vra."userId",
+        COUNT(*) FILTER (WHERE vra.direction > 0) AS votes_received_up,
+        COUNT(*) FILTER (WHERE vra.direction < 0) AS votes_received_down
+      FROM votes_received_attrib vra
+      GROUP BY vra."userId"
+    ),
+    recomputed AS (
+      SELECT
+        us."userId",
+        COALESCE(vc.votes_cast_up, 0)::int AS votes_cast_up,
+        COALESCE(vc.votes_cast_down, 0)::int AS votes_cast_down,
+        COALESCE(vr.votes_received_up, 0)::int AS votes_received_up,
+        COALESCE(vr.votes_received_down, 0)::int AS votes_received_down
+      FROM "UserStats" us
+      LEFT JOIN votes_cast vc ON vc."userId" = us."userId"
+      LEFT JOIN votes_received vr ON vr."userId" = us."userId"
+    )
+    SELECT
+      COUNT(*) FILTER (
+        WHERE us."votesCastUp" <> r.votes_cast_up
+           OR us."votesCastDown" <> r.votes_cast_down
+           OR us."totalUp" <> r.votes_received_up
+           OR us."totalDown" <> r.votes_received_down
+      )::bigint AS rows_to_update,
+      COALESCE(SUM(us."votesCastUp"), 0)::bigint AS current_votes_cast_up,
+      COALESCE(SUM(r.votes_cast_up), 0)::bigint AS recomputed_votes_cast_up,
+      COALESCE(SUM(us."votesCastDown"), 0)::bigint AS current_votes_cast_down,
+      COALESCE(SUM(r.votes_cast_down), 0)::bigint AS recomputed_votes_cast_down,
+      COALESCE(SUM(us."totalUp"), 0)::bigint AS current_votes_received_up,
+      COALESCE(SUM(r.votes_received_up), 0)::bigint AS recomputed_votes_received_up,
+      COALESCE(SUM(us."totalDown"), 0)::bigint AS current_votes_received_down,
+      COALESCE(SUM(r.votes_received_down), 0)::bigint AS recomputed_votes_received_down
+    FROM "UserStats" us
+    JOIN recomputed r ON r."userId" = us."userId"
+  `;
+
+  printStats('UserStats vote totals dry run', rows[0] ?? {});
+}
+
+async function runDryRun(prisma: PrismaClient, options: RepairUserVoteStatsOptions) {
+  console.log('DRY RUN: no writes will be performed; gacha market/category index ticks are not invoked.');
+
+  await prisma.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe('SET TRANSACTION READ ONLY');
+    if (!options.userStatsOnly) {
+      await dryRunTagPreferences(tx as PrismaClient);
+      await dryRunVoteInteractions(tx as PrismaClient);
+    }
+    if (!options.socialOnly) {
+      await dryRunUserStatsVoteTotals(tx as PrismaClient);
+    }
+  }, { timeout: 300_000 });
+}
+
+export async function runRepairUserVoteStats(prisma: PrismaClient, options: RepairUserVoteStatsOptions): Promise<void> {
+  if (options.socialOnly && options.userStatsOnly) {
+    throw new Error('--social-only and --user-stats-only cannot be used together');
+  }
+
+  if (options.dryRun) {
+    await runDryRun(prisma, options);
+    return;
+  }
+
+  if (!options.userStatsOnly) {
+    const socialJob = new UserSocialAnalysisJob(prisma);
+    await socialJob.execute({ forceFullAnalysis: true, batchSize: options.batchSize });
+  }
+
+  if (!options.socialOnly) {
+    const ratingSystem = new UserRatingSystem(prisma);
+    await ratingSystem.updateUserRatingsAndRankings();
+  }
+}

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -1191,7 +1191,6 @@ export class IncrementalAnalyzeJob {
       FROM "Vote" v
       WHERE v."pageVersionId" = ANY(${pageVersionIds}::int[])
         AND v."userId" IS NOT NULL
-        AND v.direction != 0
     `;
     
     if (votingUsers.length === 0) {
@@ -1202,22 +1201,60 @@ export class IncrementalAnalyzeJob {
     const userIds = votingUsers.map(u => u.userId);
     console.log(`  📊 Analyzing social patterns for ${userIds.length} users`);
 
-    // 更新标签偏好（仅针对有新投票的用户）
-    await this.prisma.$executeRaw`
-      WITH user_tag_votes AS (
+    // 更新标签偏好（仅针对有新投票的用户）：Vote 存储改投历史，统计只取每个用户对每页的最后一票。
+    await this.prisma.$transaction([
+      this.prisma.userTagPreference.deleteMany({
+        where: {
+          userId: { in: userIds }
+        }
+      }),
+      this.prisma.$executeRaw`
+      WITH affected_users AS (
+        SELECT unnest(${userIds}::int[]) AS "userId"
+      ),
+      latest_vote_candidates AS (
         SELECT 
+          v.id,
           v."userId",
-          unnest(pv.tags) as tag,
+          pv."pageId",
           v.direction,
-          v.timestamp
+          v.timestamp,
+          ROW_NUMBER() OVER (
+            PARTITION BY v."userId", pv."pageId"
+            ORDER BY v.timestamp DESC, v.id DESC
+          ) AS rn
         FROM "Vote" v
-        JOIN "PageVersion" pv ON v."pageVersionId" = pv.id
-        WHERE v."userId" = ANY(${userIds}::int[])
-          AND v.direction != 0
-          AND pv.tags IS NOT NULL
-          AND array_length(pv.tags, 1) > 0
-          AND pv."validTo" IS NULL
-          AND pv."isDeleted" = false
+        JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+        JOIN affected_users au ON au."userId" = v."userId"
+        WHERE v."userId" IS NOT NULL
+      ),
+      latest_user_page_votes AS (
+        SELECT "userId", "pageId", direction, timestamp
+        FROM latest_vote_candidates
+        WHERE rn = 1
+          AND direction != 0
+      ),
+      user_tag_votes AS (
+        SELECT
+          lupv."userId",
+          unnest(pv_pick.tags) as tag,
+          lupv.direction,
+          lupv.timestamp
+        FROM latest_user_page_votes lupv
+        JOIN LATERAL (
+          SELECT pv2.tags, pv2."isDeleted"
+          FROM "PageVersion" pv2
+          WHERE pv2."pageId" = lupv."pageId"
+          ORDER BY
+            (pv2."validTo" IS NULL) DESC,
+            (NOT pv2."isDeleted") DESC,
+            pv2."validFrom" DESC NULLS LAST,
+            pv2.id DESC
+          LIMIT 1
+        ) pv_pick ON TRUE
+        WHERE pv_pick."isDeleted" = false
+          AND pv_pick.tags IS NOT NULL
+          AND array_length(pv_pick.tags, 1) > 0
       ),
       tag_stats AS (
         SELECT 
@@ -1246,12 +1283,22 @@ export class IncrementalAnalyzeJob {
         "totalVotes" = EXCLUDED."totalVotes",
         "lastVoteAt" = EXCLUDED."lastVoteAt",
         "updatedAt" = NOW()
-    `;
+      `
+    ]);
     
     // 更新用户投票交互（基于新的投票活动）
-    await this.prisma.$executeRaw`
-      WITH effective_attributions AS (
-        SELECT a.*
+    await this.prisma.$transaction([
+      this.prisma.userVoteInteraction.deleteMany({
+        where: {
+          fromUserId: { in: userIds }
+        }
+      }),
+      this.prisma.$executeRaw`
+      WITH affected_voters AS (
+        SELECT unnest(${userIds}::int[]) AS "userId"
+      ),
+      effective_attributions AS (
+        SELECT DISTINCT a."pageVerId", a."userId"
         FROM (
           SELECT 
             a.*,
@@ -1259,35 +1306,51 @@ export class IncrementalAnalyzeJob {
           FROM "Attribution" a
         ) a
         WHERE NOT (a.has_non_submitter AND a.type = 'SUBMITTER')
-      ),
-      affected_pairs AS (
-        SELECT DISTINCT 
-          v."userId" AS from_user_id,
-          a."userId" AS to_user_id
-        FROM "Vote" v
-        JOIN "PageVersion" pv ON v."pageVersionId" = pv.id
-        JOIN effective_attributions a ON a."pageVerId" = pv.id
-        WHERE v."pageVersionId" = ANY(${pageVersionIds}::int[])
-          AND v."userId" IS NOT NULL
           AND a."userId" IS NOT NULL
-          AND v."userId" != a."userId"
-          AND v.direction != 0
+      ),
+      latest_vote_candidates AS (
+        SELECT
+          v.id,
+          v."userId" AS from_user_id,
+          pv."pageId" AS page_id,
+          v.direction,
+          v.timestamp,
+          ROW_NUMBER() OVER (
+            PARTITION BY v."userId", pv."pageId"
+            ORDER BY v.timestamp DESC, v.id DESC
+          ) AS rn
+        FROM "Vote" v
+        JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+        JOIN affected_voters av ON av."userId" = v."userId"
+        WHERE v."userId" IS NOT NULL
+      ),
+      latest_user_page_votes AS (
+        SELECT from_user_id, page_id, direction, timestamp
+        FROM latest_vote_candidates
+        WHERE rn = 1
+          AND direction != 0
       ),
       all_interactions AS (
-        SELECT 
-          v."userId" AS from_user_id,
+        SELECT
+          lupv.from_user_id,
           a."userId" AS to_user_id,
-          v.direction,
-          v.timestamp
-        FROM "Vote" v
-        JOIN "PageVersion" pv ON v."pageVersionId" = pv.id
-        JOIN effective_attributions a ON a."pageVerId" = pv.id
-        WHERE v."userId" IS NOT NULL
-          AND a."userId" IS NOT NULL
-          AND v."userId" != a."userId"
-          AND v.direction != 0
-          AND pv."validTo" IS NULL
-          AND pv."isDeleted" = false
+          lupv.direction,
+          lupv.timestamp
+        FROM latest_user_page_votes lupv
+        JOIN LATERAL (
+          SELECT pv2.id, pv2."isDeleted"
+          FROM "PageVersion" pv2
+          WHERE pv2."pageId" = lupv.page_id
+          ORDER BY
+            (pv2."validTo" IS NULL) DESC,
+            (NOT pv2."isDeleted") DESC,
+            pv2."validFrom" DESC NULLS LAST,
+            pv2.id DESC
+          LIMIT 1
+        ) pv_pick ON TRUE
+        JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
+        WHERE lupv.from_user_id != a."userId"
+          AND pv_pick."isDeleted" = false
       ),
       interaction_stats AS (
         SELECT 
@@ -1298,9 +1361,6 @@ export class IncrementalAnalyzeJob {
           COUNT(*) AS total_votes,
           MAX(ai.timestamp) AS last_vote_at
         FROM all_interactions ai
-        JOIN affected_pairs ap
-          ON ai.from_user_id = ap.from_user_id
-         AND ai.to_user_id = ap.to_user_id
         GROUP BY ai.from_user_id, ai.to_user_id
       )
       INSERT INTO "UserVoteInteraction" (
@@ -1318,7 +1378,8 @@ export class IncrementalAnalyzeJob {
         "totalVotes" = EXCLUDED."totalVotes",
         "lastVoteAt" = EXCLUDED."lastVoteAt",
         "updatedAt" = NOW()
-    `;
+      `
+    ]);
     
     console.log('✅ User social analysis updated');
   }

--- a/backend/src/jobs/UserRatingJob.ts
+++ b/backend/src/jobs/UserRatingJob.ts
@@ -299,7 +299,7 @@ export class UserRatingSystem {
     console.log('🗳️ 计算用户投票汇总...');
     await this.prisma.$executeRaw`
       WITH effective_attributions AS (
-        SELECT a.*
+        SELECT DISTINCT a."pageVerId", a."userId"
         FROM (
           SELECT
             a.*,
@@ -307,6 +307,7 @@ export class UserRatingSystem {
           FROM "Attribution" a
         ) a
         WHERE NOT (a.has_non_submitter AND a.type = 'SUBMITTER')
+          AND a."userId" IS NOT NULL
       ),
       votes_cast_raw AS (
         -- 原始用户投票明细（包含页面维度）
@@ -340,7 +341,7 @@ export class UserRatingSystem {
         WHERE r.rn = 1
         GROUP BY r."userId"
       ),
-      -- 收到的票：按 (actor, page) 去重（最后一票），并在投票时间点映射到当时的归属作者
+      -- 收到的票：按 (actor, page) 去重（最后一票），并映射到当前/最近版本的归属作者
       votes_received_raw AS (
         SELECT 
           v.id,
@@ -354,7 +355,6 @@ export class UserRatingSystem {
           END AS actor_key
         FROM "Vote" v
         JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
-        WHERE v.direction <> 0
       ),
       votes_received_ranked AS (
         SELECT 
@@ -369,6 +369,7 @@ export class UserRatingSystem {
         SELECT page_id, direction
         FROM votes_received_ranked
         WHERE rn = 1
+          AND direction <> 0
       ),
       votes_received_attrib AS (
         SELECT 

--- a/backend/src/jobs/UserSocialAnalysisJob.ts
+++ b/backend/src/jobs/UserSocialAnalysisJob.ts
@@ -18,24 +18,24 @@ export class UserSocialAnalysisJob {
   /**
    * 执行社交分析
    */
-  async execute(options: { 
+  async execute(options: {
     forceFullAnalysis?: boolean;
     batchSize?: number;
   } = {}): Promise<void> {
     const { forceFullAnalysis = false, batchSize = 1000 } = options;
-    
+
     console.log('🔍 Starting user social analysis job...');
-    
+
     try {
       // 1. 更新用户标签偏好
       await this.updateUserTagPreferences(forceFullAnalysis, batchSize);
-      
+
       // 2. 更新用户投票交互
       await this.updateUserVoteInteractions(forceFullAnalysis, batchSize);
-      
+
       // 3. 显示统计信息
       await this.showStatistics();
-      
+
       console.log('✅ User social analysis job completed');
     } catch (error) {
       console.error('❌ User social analysis job failed:', error);
@@ -48,11 +48,10 @@ export class UserSocialAnalysisJob {
    */
   private async updateUserTagPreferences(forceFullAnalysis: boolean, batchSize: number): Promise<void> {
     console.log('🏷️ Updating user tag preferences...');
-    
+
     if (forceFullAnalysis) {
-      // 清空现有数据
-      await this.prisma.userTagPreference.deleteMany({});
-      console.log('  ✓ Cleared existing tag preference data');
+      await this.rebuildAllUserTagPreferences();
+      return;
     }
 
     // 获取需要分析的用户
@@ -60,32 +59,69 @@ export class UserSocialAnalysisJob {
     console.log(`  ✓ Found ${users.length} users to analyze`);
 
     let processedCount = 0;
-    
+
     // 批量处理用户
     for (let i = 0; i < users.length; i += batchSize) {
       const batch = users.slice(i, i + batchSize);
       const userIds = batch.map(u => u.id);
-      
-      // 使用 SQL 批量计算用户的标签偏好
-      await this.prisma.$executeRaw`
-        WITH user_tag_votes AS (
-          SELECT 
+
+      // 使用 SQL 批量计算用户的标签偏好：Vote 存储改投历史，统计只取每个用户对每页的最后一票。
+      await this.prisma.$transaction([
+        this.prisma.userTagPreference.deleteMany({
+          where: {
+            userId: { in: userIds }
+          }
+        }),
+        this.prisma.$executeRaw`
+        WITH affected_users AS (
+          SELECT unnest(${userIds}::int[]) AS "userId"
+        ),
+        latest_vote_candidates AS (
+          SELECT
+            v.id,
             v."userId",
-            unnest(pv.tags) as tag,
+            pv."pageId",
             v.direction,
-            v.timestamp
+            v.timestamp,
+            ROW_NUMBER() OVER (
+              PARTITION BY v."userId", pv."pageId"
+              ORDER BY v.timestamp DESC, v.id DESC
+            ) AS rn
           FROM "Vote" v
-          JOIN "PageVersion" pv ON v."pageVersionId" = pv.id
-          WHERE v."userId" = ANY(${userIds}::int[])
-            AND v."userId" IS NOT NULL
-            AND v.direction != 0
-            AND pv.tags IS NOT NULL
-            AND array_length(pv.tags, 1) > 0
-            AND pv."validTo" IS NULL
-            AND pv."isDeleted" = false
+          JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+          JOIN affected_users au ON au."userId" = v."userId"
+          WHERE v."userId" IS NOT NULL
+        ),
+        latest_user_page_votes AS (
+          SELECT "userId", "pageId", direction, timestamp
+          FROM latest_vote_candidates
+          WHERE rn = 1
+            AND direction != 0
+        ),
+        user_tag_votes AS (
+          SELECT
+            lupv."userId",
+            unnest(pv_pick.tags) as tag,
+            lupv.direction,
+            lupv.timestamp
+          FROM latest_user_page_votes lupv
+          JOIN LATERAL (
+            SELECT pv2.tags, pv2."isDeleted"
+            FROM "PageVersion" pv2
+            WHERE pv2."pageId" = lupv."pageId"
+            ORDER BY
+              (pv2."validTo" IS NULL) DESC,
+              (NOT pv2."isDeleted") DESC,
+              pv2."validFrom" DESC NULLS LAST,
+              pv2.id DESC
+            LIMIT 1
+          ) pv_pick ON TRUE
+          WHERE pv_pick."isDeleted" = false
+            AND pv_pick.tags IS NOT NULL
+            AND array_length(pv_pick.tags, 1) > 0
         ),
         tag_stats AS (
-          SELECT 
+          SELECT
             "userId",
             tag,
             COUNT(*) FILTER (WHERE direction > 0) as upvote_count,
@@ -98,16 +134,16 @@ export class UserSocialAnalysisJob {
           HAVING COUNT(*) >= 3  -- 至少投过3次票的标签才记录
         )
         INSERT INTO "UserTagPreference" (
-          "userId", 
-          tag, 
-          "upvoteCount", 
-          "downvoteCount", 
-          "totalVotes", 
+          "userId",
+          tag,
+          "upvoteCount",
+          "downvoteCount",
+          "totalVotes",
           "lastVoteAt",
           "createdAt",
           "updatedAt"
         )
-        SELECT 
+        SELECT
           "userId",
           tag,
           upvote_count,
@@ -123,15 +159,104 @@ export class UserSocialAnalysisJob {
           "totalVotes" = EXCLUDED."totalVotes",
           "lastVoteAt" = EXCLUDED."lastVoteAt",
           "updatedAt" = NOW()
-      `;
-      
+        `
+      ]);
+
       processedCount += batch.length;
       if (processedCount % 1000 === 0) {
         console.log(`  📈 Progress: ${processedCount}/${users.length} users processed`);
       }
     }
-    
+
     console.log(`  ✓ Updated tag preferences for ${users.length} users`);
+  }
+
+  private async rebuildAllUserTagPreferences(): Promise<void> {
+    console.log('  🔁 Rebuilding all tag preference data...');
+
+    await this.prisma.$transaction([
+      this.prisma.userTagPreference.deleteMany({}),
+      this.prisma.$executeRaw`
+        WITH latest_vote_candidates AS (
+          SELECT
+            v.id,
+            v."userId",
+            pv."pageId",
+            v.direction,
+            v.timestamp,
+            ROW_NUMBER() OVER (
+              PARTITION BY v."userId", pv."pageId"
+              ORDER BY v.timestamp DESC, v.id DESC
+            ) AS rn
+          FROM "Vote" v
+          JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+          WHERE v."userId" IS NOT NULL
+        ),
+        latest_user_page_votes AS (
+          SELECT "userId", "pageId", direction, timestamp
+          FROM latest_vote_candidates
+          WHERE rn = 1
+            AND direction != 0
+        ),
+        user_tag_votes AS (
+          SELECT
+            lupv."userId",
+            unnest(pv_pick.tags) as tag,
+            lupv.direction,
+            lupv.timestamp
+          FROM latest_user_page_votes lupv
+          JOIN LATERAL (
+            SELECT pv2.tags, pv2."isDeleted"
+            FROM "PageVersion" pv2
+            WHERE pv2."pageId" = lupv."pageId"
+            ORDER BY
+              (pv2."validTo" IS NULL) DESC,
+              (NOT pv2."isDeleted") DESC,
+              pv2."validFrom" DESC NULLS LAST,
+              pv2.id DESC
+            LIMIT 1
+          ) pv_pick ON TRUE
+          WHERE pv_pick."isDeleted" = false
+            AND pv_pick.tags IS NOT NULL
+            AND array_length(pv_pick.tags, 1) > 0
+        ),
+        tag_stats AS (
+          SELECT
+            "userId",
+            tag,
+            COUNT(*) FILTER (WHERE direction > 0) as upvote_count,
+            COUNT(*) FILTER (WHERE direction < 0) as downvote_count,
+            COUNT(*) as total_votes,
+            MAX(timestamp) as last_vote_at
+          FROM user_tag_votes
+          WHERE tag NOT IN ('页面', '重定向', '管理', '_cc')
+          GROUP BY "userId", tag
+          HAVING COUNT(*) >= 3
+        )
+        INSERT INTO "UserTagPreference" (
+          "userId",
+          tag,
+          "upvoteCount",
+          "downvoteCount",
+          "totalVotes",
+          "lastVoteAt",
+          "createdAt",
+          "updatedAt"
+        )
+        SELECT
+          "userId",
+          tag,
+          upvote_count,
+          downvote_count,
+          total_votes,
+          last_vote_at,
+          NOW(),
+          NOW()
+        FROM tag_stats
+      `
+    ]);
+
+    console.log('  ✓ Rebuilt all tag preference data');
   }
 
   /**
@@ -139,11 +264,10 @@ export class UserSocialAnalysisJob {
    */
   private async updateUserVoteInteractions(forceFullAnalysis: boolean, batchSize: number): Promise<void> {
     console.log('🤝 Updating user vote interactions...');
-    
+
     if (forceFullAnalysis) {
-      // 清空现有数据
-      await this.prisma.userVoteInteraction.deleteMany({});
-      console.log('  ✓ Cleared existing vote interaction data');
+      await this.rebuildAllUserVoteInteractions();
+      return;
     }
 
     // 获取需要分析的用户对
@@ -157,40 +281,81 @@ export class UserSocialAnalysisJob {
       // 使用 VALUES 构建成对的 from/to 列表并进行半连接，避免文本条件拼接导致的类型问题
       const valuesSql = batch.map(p => `(${Number(p.fromUserId)}, ${Number(p.toUserId)})`).join(', ');
 
-      const sql = `
+      const deleteSql = `
+        WITH pair_list(from_user_id, to_user_id) AS (
+          VALUES ${valuesSql}
+        )
+        DELETE FROM "UserVoteInteraction" uvi
+        USING pair_list pl
+        WHERE uvi."fromUserId" = pl.from_user_id
+          AND uvi."toUserId" = pl.to_user_id
+      `;
+
+      const insertSql = `
         WITH effective_attributions AS (
-          SELECT a.*
+          SELECT DISTINCT a."pageVerId", a."userId"
           FROM (
-            SELECT 
+            SELECT
               a.*,
               BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a."pageVerId") AS has_non_submitter
-            FROM "Attribution" a
+          FROM "Attribution" a
           ) a
           WHERE NOT (a.has_non_submitter AND a.type = 'SUBMITTER')
+            AND a."userId" IS NOT NULL
         ),
         pair_list(from_user_id, to_user_id) AS (
           VALUES ${valuesSql}
         ),
-        vote_interactions AS (
-          SELECT 
-            v."userId" as from_user_id,
-            a."userId" as to_user_id,
+        pair_voters AS (
+          SELECT DISTINCT from_user_id FROM pair_list
+        ),
+        latest_vote_candidates AS (
+          SELECT
+            v.id,
+            v."userId" AS from_user_id,
+            pv."pageId" AS page_id,
             v.direction,
-            v.timestamp
+            v.timestamp,
+            ROW_NUMBER() OVER (
+              PARTITION BY v."userId", pv."pageId"
+              ORDER BY v.timestamp DESC, v.id DESC
+            ) AS rn
           FROM "Vote" v
-          JOIN "PageVersion" pv ON v."pageVersionId" = pv.id
-          JOIN effective_attributions a ON a."pageVerId" = pv.id
-          JOIN pair_list pl ON pl.from_user_id = v."userId" AND pl.to_user_id = a."userId"
-          WHERE v."userId" IS NOT NULL 
-            AND a."userId" IS NOT NULL
-            AND v."userId" != a."userId"
-            AND v.direction != 0
-            -- any attribution type
-            AND pv."validTo" IS NULL
-            AND pv."isDeleted" = false
+          JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+          JOIN pair_voters pvu ON pvu.from_user_id = v."userId"
+          WHERE v."userId" IS NOT NULL
+        ),
+        latest_user_page_votes AS (
+          SELECT from_user_id, page_id, direction, timestamp
+          FROM latest_vote_candidates
+          WHERE rn = 1
+            AND direction != 0
+        ),
+        vote_interactions AS (
+          SELECT
+            lupv.from_user_id,
+            a."userId" as to_user_id,
+            lupv.direction,
+            lupv.timestamp
+          FROM latest_user_page_votes lupv
+          JOIN LATERAL (
+            SELECT pv2.id, pv2."isDeleted"
+            FROM "PageVersion" pv2
+            WHERE pv2."pageId" = lupv.page_id
+            ORDER BY
+              (pv2."validTo" IS NULL) DESC,
+              (NOT pv2."isDeleted") DESC,
+              pv2."validFrom" DESC NULLS LAST,
+              pv2.id DESC
+            LIMIT 1
+          ) pv_pick ON TRUE
+          JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
+          JOIN pair_list pl ON pl.from_user_id = lupv.from_user_id AND pl.to_user_id = a."userId"
+          WHERE lupv.from_user_id != a."userId"
+            AND pv_pick."isDeleted" = false
         ),
         interaction_stats AS (
-          SELECT 
+          SELECT
             from_user_id,
             to_user_id,
             COUNT(*) FILTER (WHERE direction > 0) as upvote_count,
@@ -210,7 +375,7 @@ export class UserSocialAnalysisJob {
           "createdAt",
           "updatedAt"
         )
-        SELECT 
+        SELECT
           from_user_id,
           to_user_id,
           upvote_count,
@@ -229,14 +394,115 @@ export class UserSocialAnalysisJob {
           "updatedAt" = NOW()
       `;
 
-      await this.prisma.$executeRawUnsafe(sql);
-      
+      await this.prisma.$transaction([
+        this.prisma.$executeRawUnsafe(deleteSql),
+        this.prisma.$executeRawUnsafe(insertSql)
+      ]);
+
       if ((i + batch.length) % 5000 === 0) {
         console.log(`  📈 Progress: ${i + batch.length}/${userPairs.length} user pairs processed`);
       }
     }
-    
+
     console.log(`  ✓ Updated vote interactions for ${userPairs.length} user pairs`);
+  }
+
+  private async rebuildAllUserVoteInteractions(): Promise<void> {
+    console.log('  🔁 Rebuilding all vote interaction data...');
+
+    await this.prisma.$transaction([
+      this.prisma.userVoteInteraction.deleteMany({}),
+      this.prisma.$executeRaw`
+        WITH effective_attributions AS (
+          SELECT DISTINCT a."pageVerId", a."userId"
+          FROM (
+            SELECT
+              a.*,
+              BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a."pageVerId") AS has_non_submitter
+            FROM "Attribution" a
+          ) a
+          WHERE NOT (a.has_non_submitter AND a.type = 'SUBMITTER')
+            AND a."userId" IS NOT NULL
+        ),
+        latest_vote_candidates AS (
+          SELECT
+            v.id,
+            v."userId" AS from_user_id,
+            pv."pageId" AS page_id,
+            v.direction,
+            v.timestamp,
+            ROW_NUMBER() OVER (
+              PARTITION BY v."userId", pv."pageId"
+              ORDER BY v.timestamp DESC, v.id DESC
+            ) AS rn
+          FROM "Vote" v
+          JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+          WHERE v."userId" IS NOT NULL
+        ),
+        latest_user_page_votes AS (
+          SELECT from_user_id, page_id, direction, timestamp
+          FROM latest_vote_candidates
+          WHERE rn = 1
+            AND direction != 0
+        ),
+        vote_interactions AS (
+          SELECT
+            lupv.from_user_id,
+            a."userId" as to_user_id,
+            lupv.direction,
+            lupv.timestamp
+          FROM latest_user_page_votes lupv
+          JOIN LATERAL (
+            SELECT pv2.id, pv2."isDeleted"
+            FROM "PageVersion" pv2
+            WHERE pv2."pageId" = lupv.page_id
+            ORDER BY
+              (pv2."validTo" IS NULL) DESC,
+              (NOT pv2."isDeleted") DESC,
+              pv2."validFrom" DESC NULLS LAST,
+              pv2.id DESC
+            LIMIT 1
+          ) pv_pick ON TRUE
+          JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
+          WHERE lupv.from_user_id != a."userId"
+            AND pv_pick."isDeleted" = false
+        ),
+        interaction_stats AS (
+          SELECT
+            from_user_id,
+            to_user_id,
+            COUNT(*) FILTER (WHERE direction > 0) as upvote_count,
+            COUNT(*) FILTER (WHERE direction < 0) as downvote_count,
+            COUNT(*) as total_votes,
+            MAX(timestamp) as last_vote_at
+          FROM vote_interactions
+          GROUP BY from_user_id, to_user_id
+        )
+        INSERT INTO "UserVoteInteraction" (
+          "fromUserId",
+          "toUserId",
+          "upvoteCount",
+          "downvoteCount",
+          "totalVotes",
+          "lastVoteAt",
+          "createdAt",
+          "updatedAt"
+        )
+        SELECT
+          from_user_id,
+          to_user_id,
+          upvote_count,
+          downvote_count,
+          total_votes,
+          last_vote_at,
+          NOW(),
+          NOW()
+        FROM interaction_stats
+        WHERE total_votes > 0
+      `
+    ]);
+
+    console.log('  ✓ Rebuilt all vote interaction data');
   }
 
   /**
@@ -282,54 +548,92 @@ export class UserSocialAnalysisJob {
       // 获取所有有投票交互的用户对
       return await this.prisma.$queryRaw<Array<{ fromUserId: number; toUserId: number }>>`
         WITH effective_attributions AS (
-          SELECT a.*
+          SELECT DISTINCT a."pageVerId", a."userId"
           FROM (
-            SELECT 
+            SELECT
               a.*,
               BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a."pageVerId") AS has_non_submitter
             FROM "Attribution" a
           ) a
           WHERE NOT (a.has_non_submitter AND a.type = 'SUBMITTER')
+            AND a."userId" IS NOT NULL
+        ),
+        latest_vote_candidates AS (
+          SELECT
+            v.id,
+            v."userId" AS from_user_id,
+            pv."pageId" AS page_id,
+            v.direction,
+            v.timestamp,
+            ROW_NUMBER() OVER (
+              PARTITION BY v."userId", pv."pageId"
+              ORDER BY v.timestamp DESC, v.id DESC
+            ) AS rn
+          FROM "Vote" v
+          JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+          WHERE v."userId" IS NOT NULL
+        ),
+        latest_user_page_votes AS (
+          SELECT from_user_id, page_id
+          FROM latest_vote_candidates
+          WHERE rn = 1
+            AND direction != 0
         )
-        SELECT DISTINCT 
-          v."userId" as "fromUserId",
+        SELECT DISTINCT
+          lupv.from_user_id as "fromUserId",
           a."userId" as "toUserId"
-        FROM "Vote" v
-        JOIN "PageVersion" pv ON v."pageVersionId" = pv.id
-        JOIN effective_attributions a ON a."pageVerId" = pv.id
-        WHERE v."userId" IS NOT NULL 
-          AND a."userId" IS NOT NULL
-          AND v."userId" != a."userId"
-          AND v.direction != 0
-        ORDER BY v."userId", a."userId"
-        LIMIT ${limit}
+        FROM latest_user_page_votes lupv
+        JOIN LATERAL (
+          SELECT pv2.id, pv2."isDeleted"
+          FROM "PageVersion" pv2
+          WHERE pv2."pageId" = lupv.page_id
+          ORDER BY
+            (pv2."validTo" IS NULL) DESC,
+            (NOT pv2."isDeleted") DESC,
+            pv2."validFrom" DESC NULLS LAST,
+            pv2.id DESC
+          LIMIT 1
+        ) pv_pick ON TRUE
+        JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
+        WHERE lupv.from_user_id != a."userId"
+          AND pv_pick."isDeleted" = false
+        ORDER BY lupv.from_user_id, a."userId"
       `;
     } else {
       // 增量模式：获取最近有新投票的用户对
       return await this.prisma.$queryRaw<Array<{ fromUserId: number; toUserId: number }>>`
         WITH effective_attributions AS (
-          SELECT a.*
+          SELECT DISTINCT a."pageVerId", a."userId"
           FROM (
-            SELECT 
+            SELECT
               a.*,
               BOOL_OR(a.type <> 'SUBMITTER') OVER (PARTITION BY a."pageVerId") AS has_non_submitter
             FROM "Attribution" a
           ) a
           WHERE NOT (a.has_non_submitter AND a.type = 'SUBMITTER')
+            AND a."userId" IS NOT NULL
         ),
         recent_interactions AS (
-          SELECT DISTINCT 
+          SELECT DISTINCT
             v."userId" as "fromUserId",
             a."userId" as "toUserId"
           FROM "Vote" v
-          JOIN "PageVersion" pv ON v."pageVersionId" = pv.id
-          JOIN effective_attributions a ON a."pageVerId" = pv.id
-          WHERE v."userId" IS NOT NULL 
-            AND a."userId" IS NOT NULL
+          JOIN "PageVersion" vote_pv ON vote_pv.id = v."pageVersionId"
+          JOIN LATERAL (
+            SELECT pv2.id, pv2."isDeleted"
+            FROM "PageVersion" pv2
+            WHERE pv2."pageId" = vote_pv."pageId"
+            ORDER BY
+              (pv2."validTo" IS NULL) DESC,
+              (NOT pv2."isDeleted") DESC,
+              pv2."validFrom" DESC NULLS LAST,
+              pv2.id DESC
+            LIMIT 1
+          ) pv_pick ON TRUE
+          JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
+          WHERE v."userId" IS NOT NULL
             AND v."userId" != a."userId"
-            AND v.direction != 0
-            AND pv."validTo" IS NULL
-            AND pv."isDeleted" = false
+            AND pv_pick."isDeleted" = false
             AND v.timestamp >= NOW() - INTERVAL '7 days'
         ),
         outdated_interactions AS (
@@ -351,7 +655,7 @@ export class UserSocialAnalysisJob {
    */
   private async showStatistics(): Promise<void> {
     console.log('\n📊 User social analysis statistics:');
-    
+
     // 标签偏好统计
     const tagStats = await this.prisma.$queryRaw<Array<{
       total_preferences: bigint;
@@ -371,14 +675,14 @@ export class UserSocialAnalysisJob {
           ) s
         ) as avg_tags_per_user
     `;
-    
+
     const tagStat = tagStats[0];
     console.log('\n🏷️ Tag Preferences:');
     console.log(`  Total preference records: ${tagStat.total_preferences}`);
     console.log(`  Users with preferences: ${tagStat.unique_users}`);
     console.log(`  Unique tags tracked: ${tagStat.unique_tags}`);
     console.log(`  Average tags per user: ${tagStat.avg_tags_per_user?.toFixed(1) || '0'}`);
-    
+
     // 投票交互统计
     const interactionStats = await this.prisma.$queryRaw<Array<{
       total_interactions: bigint;
@@ -388,20 +692,20 @@ export class UserSocialAnalysisJob {
       avg_votes_per_interaction: number;
     }>>`
       WITH interaction_pairs AS (
-        SELECT 
+        SELECT
           i1."fromUserId",
           i1."toUserId",
           i1."totalVotes",
-          CASE 
-            WHEN i2."fromUserId" IS NOT NULL THEN 1 
-            ELSE 0 
+          CASE
+            WHEN i2."fromUserId" IS NOT NULL THEN 1
+            ELSE 0
           END as is_mutual
         FROM "UserVoteInteraction" i1
-        LEFT JOIN "UserVoteInteraction" i2 
-          ON i1."fromUserId" = i2."toUserId" 
+        LEFT JOIN "UserVoteInteraction" i2
+          ON i1."fromUserId" = i2."toUserId"
           AND i1."toUserId" = i2."fromUserId"
       )
-      SELECT 
+      SELECT
         COUNT(*) as total_interactions,
         COUNT(DISTINCT "fromUserId") as unique_from_users,
         COUNT(DISTINCT "toUserId") as unique_to_users,
@@ -409,7 +713,7 @@ export class UserSocialAnalysisJob {
         AVG("totalVotes") as avg_votes_per_interaction
       FROM interaction_pairs
     `;
-    
+
     const interactionStat = interactionStats[0];
     console.log('\n🤝 Vote Interactions:');
     console.log(`  Total interaction records: ${interactionStat.total_interactions}`);
@@ -417,7 +721,7 @@ export class UserSocialAnalysisJob {
     console.log(`  Users who received votes: ${interactionStat.unique_to_users}`);
     console.log(`  Mutual interaction pairs: ${interactionStat.mutual_interactions}`);
     console.log(`  Average votes per interaction: ${interactionStat.avg_votes_per_interaction?.toFixed(1) || '0'}`);
-    
+
     // 热门标签统计
     const popularTags = await this.prisma.$queryRaw<Array<{
       tag: string;
@@ -425,15 +729,15 @@ export class UserSocialAnalysisJob {
       total_votes: bigint;
       avg_upvote_ratio: number;
     }>>`
-      SELECT 
+      SELECT
         tag,
         COUNT(DISTINCT "userId") as user_count,
         SUM("totalVotes") as total_votes,
         AVG(
-          CASE 
-            WHEN "totalVotes" > 0 
-            THEN "upvoteCount"::float / "totalVotes"::float 
-            ELSE 0 
+          CASE
+            WHEN "totalVotes" > 0
+            THEN "upvoteCount"::float / "totalVotes"::float
+            ELSE 0
           END
         ) as avg_upvote_ratio
       FROM "UserTagPreference"
@@ -441,7 +745,7 @@ export class UserSocialAnalysisJob {
       ORDER BY total_votes DESC
       LIMIT 10
     `;
-    
+
     console.log('\n🏷️ Top 10 Popular Tags:');
     popularTags.forEach((tag, index) => {
       console.log(`  ${index + 1}. ${tag.tag}: ${tag.total_votes} votes by ${tag.user_count} users (${(tag.avg_upvote_ratio * 100).toFixed(1)}% upvote ratio)`);


### PR DESCRIPTION
## Summary
- Deduplicate user tag preferences, vote interactions, and received vote totals by each voter's latest vote per page.
- Add `repair-user-vote-stats` with `--dry-run`, `--social-only`, and `--user-stats-only` so user vote stats can be repaired without running `analyze` or gacha/category index ticks.
- Rebuild full social-analysis paths with set-based SQL and keep incremental paths aligned with the same vote semantics.

## Root Cause
`Vote` stores vote history/changes. Some user-facing aggregates counted raw vote rows, so changed votes and duplicate attribution rows inflated tag preferences and incoming vote relations.

## Database Repair Performed
- Ran `repair-user-vote-stats` once against the database.
- Re-ran `repair-user-vote-stats --dry-run`; all tracked differences were zero after the repair.
- Confirmed DVA24 original tag stats now read `12754 up / 3 down / 12757 total`.

## Gacha / Market Safety
The repair command does not call `analyzeIncremental`, does not update `AnalysisWatermark`, and does not invoke `category_index_tick` or other gacha market tick jobs.

## Validation
- `node scripts/service-bin-runner.mjs backend tsc -p backend/tsconfig.src.json --noEmit`
- `node ../scripts/service-bin-runner.mjs backend eslint "src/jobs/UserSocialAnalysisJob.ts" "src/jobs/IncrementalAnalyzeJob.ts" "src/jobs/UserRatingJob.ts" "src/cli/index.ts" "src/cli/repair-user-vote-stats.ts"`
- `git diff --check`
- `node scripts/service-bin-runner.mjs backend tsx backend/src/cli/index.ts repair-user-vote-stats --dry-run` after DB repair