### PR TITLE
fix(vote-sync): 修复 voteResyncAudit TZ 写入口径 + 新增 vote-tz-dup-cleanup CLI

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "check:tracking": "node --import tsx/esm scripts/check-tracking-health.ts",
     "check:vote-integrity": "node --import tsx/esm scripts/check-vote-integrity.ts",
     "vote-resync-audit": "node --import tsx/esm src/cli/index.ts vote-resync-audit",
+    "vote-tz-dup-cleanup": "node --import tsx/esm src/cli/index.ts vote-tz-dup-cleanup",
     "check:preview-usage": "node --import tsx/esm src/cli/preview-usage.ts",
     "audit:pageversion-validity": "node --import tsx/esm scripts/check-pageversion-validity-window.ts",
     "fix:pageversion-boundaries": "node --import tsx/esm scripts/fix-pageversion-boundaries.ts",

--- a/backend/scripts/check-vote-integrity.ts
+++ b/backend/scripts/check-vote-integrity.ts
@@ -7,9 +7,13 @@ import { disconnectPrisma, getPrismaClient } from '../src/utils/db-connection.ts
  * 常态化对账脚本：比对 LatestVote 重算的 (rating, voteCount) 与 PageVersion 上的
  * pa_rating / pa_count，输出 7 个 bucket 的统计 + top 20 偏差页详情。
  *
+ * 同时统计 TZ-induced 重复票（actor=user/anon, direction 同, ts 差恰好 8h）：
+ * 这是 voteResyncAudit 早期 TZ 写入口径 bug 的指纹，cleanup 后应当回到 0。
+ *
  * CLI 选项：
- *   --threshold N     any_mismatch > N 时 exit 1（默认 100）
- *   --json            以 JSON 输出
+ *   --threshold N         any_mismatch > N 时 exit 1（默认 100）
+ *   --json                以 JSON 输出
+ *   --fail-if-tz-dup      suspect_tz_dup_pair_count > 0 时 exit 1（CI 用）
  */
 
 type SummaryRow = {
@@ -41,13 +45,16 @@ function toNumber(value: bigint | number | string | null | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function parseArgs(argv: string[]): { threshold: number; json: boolean } {
+function parseArgs(argv: string[]): { threshold: number; json: boolean; failIfTzDup: boolean } {
   let threshold = 100;
   let json = false;
+  let failIfTzDup = false;
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--json') {
       json = true;
+    } else if (arg === '--fail-if-tz-dup') {
+      failIfTzDup = true;
     } else if (arg === '--threshold') {
       const next = argv[i + 1];
       if (next !== undefined) {
@@ -60,11 +67,11 @@ function parseArgs(argv: string[]): { threshold: number; json: boolean } {
       if (Number.isFinite(parsed) && parsed >= 0) threshold = parsed;
     }
   }
-  return { threshold, json };
+  return { threshold, json, failIfTzDup };
 }
 
 async function main(): Promise<number> {
-  const { threshold, json } = parseArgs(process.argv.slice(2));
+  const { threshold, json, failIfTzDup } = parseArgs(process.argv.slice(2));
   const prisma = getPrismaClient();
 
   const summaryRows = await prisma.$queryRawUnsafe<SummaryRow[]>(`
@@ -140,6 +147,21 @@ async function main(): Promise<number> {
      LIMIT 20
   `);
 
+  const tzDupRows = await prisma.$queryRawUnsafe<Array<{ pair_count: bigint | number | null }>>(`
+    WITH actor_groups AS (
+      SELECT array_agg(v.timestamp ORDER BY v.timestamp, v.id) AS tses
+        FROM "Vote" v
+       WHERE v.direction <> 0
+         AND (v."userId" IS NOT NULL OR v."anonKey" IS NOT NULL)
+       GROUP BY v."pageVersionId", v.direction,
+                COALESCE('u:' || v."userId"::text, 'a:' || v."anonKey")
+       HAVING COUNT(*) = 2
+    )
+    SELECT COUNT(*)::bigint AS pair_count
+      FROM actor_groups
+     WHERE ABS(EXTRACT(EPOCH FROM (tses[2] - tses[1])) - 28800) <= 1
+  `);
+
   const summary = {
     totalPages: toNumber(summaryRows[0]?.total_pages),
     noVotesSynced: toNumber(summaryRows[0]?.no_votes_synced),
@@ -147,7 +169,8 @@ async function main(): Promise<number> {
     ratingMismatch: toNumber(summaryRows[0]?.rating_mismatch),
     countMismatch: toNumber(summaryRows[0]?.count_mismatch),
     directionOutOfRange: toNumber(summaryRows[0]?.direction_out_of_range),
-    anyMismatch: toNumber(summaryRows[0]?.any_mismatch)
+    anyMismatch: toNumber(summaryRows[0]?.any_mismatch),
+    suspectTzDupPairCount: toNumber(tzDupRows[0]?.pair_count)
   };
 
   const anomaliesDisplay = anomalies.map((a) => {
@@ -170,7 +193,8 @@ async function main(): Promise<number> {
     };
   });
 
-  const exceeded = summary.anyMismatch > threshold;
+  const tzDupViolated = failIfTzDup && summary.suspectTzDupPairCount > 0;
+  const exceeded = summary.anyMismatch > threshold || tzDupViolated;
 
   if (json) {
     console.log(
@@ -179,6 +203,7 @@ async function main(): Promise<number> {
           summary,
           threshold,
           exceeded,
+          tzDupViolated,
           anomalies: anomaliesDisplay
         },
         null,
@@ -192,6 +217,11 @@ async function main(): Promise<number> {
     console.table(summary);
     console.log('');
     console.log(`Threshold = ${threshold} on any_mismatch (current = ${summary.anyMismatch})`);
+    if (failIfTzDup) {
+      console.log(`TZ-dup gate enabled: suspect_tz_dup_pair_count = ${summary.suspectTzDupPairCount} (must be 0)`);
+    } else {
+      console.log(`suspect_tz_dup_pair_count = ${summary.suspectTzDupPairCount} (informational; pass --fail-if-tz-dup to gate)`);
+    }
     console.log(exceeded ? '⚠️  exceeded threshold — exit 1' : '✅ within threshold');
     if (anomaliesDisplay.length > 0) {
       console.log('');

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -27,6 +27,7 @@ import { WikidotForumClient } from '../core/client/WikidotForumClient.js';
 import { runSyncHourlyScheduler } from './sync-hourly.js';
 import { runWikidotBindingVerifyLoop } from './wikidot-binding-verify-loop.js';
 import { runVoteResyncAudit } from './voteResyncAudit.js';
+import { runVoteTzDupCleanup } from './voteTzDupCleanup.js';
 
 const program = new Command();
 
@@ -1204,6 +1205,24 @@ program
       cleanup: Boolean(options.cleanup),
       fetchConcurrency: Number.isFinite(concurrency) && concurrency > 0 ? concurrency : 3,
       schema: options.schema ? String(options.schema) : undefined
+    });
+  });
+
+program
+  .command('vote-tz-dup-cleanup')
+  .description('Clean up TZ-induced duplicate Vote rows introduced by the original voteResyncAudit (default dry-run)')
+  .option('--apply', 'Perform cleanup inside a single transaction with backup + post-assertion (default: dry-run)')
+  .option('--pair-window-sec <n>', '+/- tolerance around 28800s (8h) when matching pairs (default 1)', '1')
+  .option('--sample-size <n>', 'Number of top affected pages to print in the report (default 20)', '20')
+  .option('--json', 'Emit JSON instead of markdown lines')
+  .action(async (options) => {
+    const pairWindowSec = Number.parseInt(String(options.pairWindowSec ?? '1'), 10);
+    const sampleSize = Number.parseInt(String(options.sampleSize ?? '20'), 10);
+    await runVoteTzDupCleanup({
+      apply: Boolean(options.apply),
+      pairWindowSec: Number.isFinite(pairWindowSec) && pairWindowSec >= 0 ? pairWindowSec : 1,
+      sampleSize: Number.isFinite(sampleSize) && sampleSize >= 0 ? sampleSize : 20,
+      json: Boolean(options.json)
     });
   });
 

--- a/backend/src/cli/voteResyncAudit.ts
+++ b/backend/src/cli/voteResyncAudit.ts
@@ -161,15 +161,19 @@ async function ensureSchemaAndTables(prisma: PrismaClient, schema: string): Prom
 
   await prisma.$executeRawUnsafe(`
     CREATE TABLE IF NOT EXISTS ${qs}.tmp_vote (
-      edge_seq        bigserial   PRIMARY KEY,
-      "pageVersionId" int         NOT NULL,
+      edge_seq        bigserial      PRIMARY KEY,
+      "pageVersionId" int            NOT NULL,
       user_wikidot_id int,
       "anonKey"       text,
-      direction       int         NOT NULL,
-      timestamp       timestamp   NOT NULL,
-      fetched_at      timestamptz NOT NULL DEFAULT now()
+      direction       int            NOT NULL,
+      timestamp       timestamp(3)   NOT NULL,
+      fetched_at      timestamptz    NOT NULL DEFAULT now()
     )
   `);
+  // 兜底已存在的旧 audit schema：把 timestamp 列对齐到 timestamp(3)（与 "Vote".timestamp 一致）。
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE ${qs}.tmp_vote ALTER COLUMN timestamp TYPE timestamp(3)`
+  );
 
   await prisma.$executeRawUnsafe(`
     CREATE INDEX IF NOT EXISTS tmp_vote_pv_uwid_ts
@@ -351,13 +355,23 @@ async function fetchAndStorePageVotes(
       }
 
       // tmp_vote bulk insert (anonKey 永远 NULL)
+      // timestamp 走显式 ISO 字符串 + (::timestamptz AT TIME ZONE 'UTC')::timestamp，
+      // 防止 pg-node 把 JS Date 按 session TimeZone(Asia/Shanghai) 落库，
+      // 与 Prisma ORM 的 UTC 写入口径偏离 8h，制造 (pageVersionId, userId, timestamp+8h) 重复行。
       for (const chunk of chunkArray(voteRows, TMP_VOTE_INSERT_CHUNK)) {
         const params: unknown[] = [];
         const valueClauses: string[] = [];
         chunk.forEach((row, idx) => {
           const base = idx * 4;
-          valueClauses.push(`($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4})`);
-          params.push(row.pvid, row.userWikidotId, row.direction, row.timestamp);
+          valueClauses.push(
+            `($${base + 1}, $${base + 2}, $${base + 3}, ($${base + 4}::timestamptz AT TIME ZONE 'UTC')::timestamp)`
+          );
+          params.push(
+            row.pvid,
+            row.userWikidotId,
+            row.direction,
+            row.timestamp.toISOString()
+          );
         });
         await prisma.$executeRawUnsafe(
           `INSERT INTO ${qs}.tmp_vote ("pageVersionId", user_wikidot_id, direction, timestamp)
@@ -747,6 +761,9 @@ async function doApply(prisma: PrismaClient, schema: string): Promise<void> {
 
   // INSERT 180k+ 行 + 多步 SQL 的事务可能跑数十秒到几分钟；Prisma 默认 5s timeout 不够
   const result = await prisma.$transaction(async (tx) => {
+    // 防御：保证事务内任何 raw timestamp 转换都按 UTC，与 Prisma ORM 写入口径一致。
+    await tx.$executeRawUnsafe(`SET LOCAL TIME ZONE 'UTC'`);
+
     // Step 0: 事务内重跑 expected_*，避免 report 跑过后又有新 collect 行带来的 stale
     const expectedRecomputed = await tx.$executeRawUnsafe(`
       WITH ranked AS (

--- a/backend/src/cli/voteTzDupCleanup.ts
+++ b/backend/src/cli/voteTzDupCleanup.ts
@@ -1,0 +1,398 @@
+import { randomUUID } from 'node:crypto';
+import { PrismaClient } from '@prisma/client';
+import { disconnectPrisma, getPrismaClient } from '../utils/db-connection.js';
+import { Logger } from '../utils/Logger.js';
+
+/**
+ * vote-tz-dup-cleanup
+ *
+ * 清理 voteResyncAudit 在修复前因 TZ 写入口径不一致引入的重复 Vote 行。
+ *
+ * 根因：voteResyncAudit 早期版本通过 `$executeRawUnsafe` 把 JS Date 作为参数
+ * 写入 `tmp_vote.timestamp` (`timestamp without time zone`)。pg-node 协议序列化
+ * Date 为带时区 ISO 字符串，PostgreSQL 按 session TimeZone=Asia/Shanghai 把它去
+ * 时区化为本地时间 → 与 Prisma ORM 的 UTC 写入相比偏移 8h，绕过 Vote 表唯一约束
+ * `(pageVersionId, userId, timestamp)`，造成同一票多记 1 行。
+ *
+ * 识别口径（精确）：
+ *   - 把 (pageVersionId, direction, actor_key) 作为 actor 维度，
+ *     actor_key = COALESCE('u:'||userId, 'a:'||anonKey)
+ *   - actor group 内严格 2 条、且 timestamp 差恰好 8h（容差 ±--pair-window-sec，
+ *     默认 1 秒）的认定为 cleanup pair
+ *   - 保留 timestamp 较小的（UTC 真值），删除较大的（+8h 错误副本）
+ *
+ * 不动的（保守，避免误伤合法行为）：
+ *   - actor group >= 3 条（哪怕含 8h pair）— 列入 review，等第二阶段
+ *   - 单条孤儿（无 counterpart 的 +8h 票，可能是漏抓被填补）— 列入 review
+ *
+ * 子命令：
+ *   默认 dry-run：只统计 + 抽样，不写库
+ *   --apply：单事务内备份 + DELETE（自动加 SET LOCAL TIME ZONE 'UTC' 防御）
+ *
+ * 备份：被删行写入 public.vote_tz_dup_cleanup_log，带 run_id 便于回滚。
+ */
+
+export type VoteTzDupCleanupOptions = {
+  apply?: boolean;
+  pairWindowSec?: number;
+  sampleSize?: number;
+  json?: boolean;
+};
+
+type SuspectPairIds = {
+  delete_id: number;
+  keep_id: number;
+};
+
+type Counts = {
+  total_vote_rows: number;
+  pair_8h_pairs: number;
+  multi_groups: number;
+  multi_extra_rows: number;
+  affected_pages: number;
+};
+
+type SamplePageRow = {
+  page_version_id: number;
+  wikidot_id: number | null;
+  current_url: string | null;
+  pair_count: number;
+};
+
+const DEFAULT_PAIR_WINDOW_SEC = 1;
+const DEFAULT_SAMPLE_SIZE = 20;
+
+async function ensureLogTable(prisma: PrismaClient): Promise<void> {
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS public.vote_tz_dup_cleanup_log (
+      id              bigserial    PRIMARY KEY,
+      run_id          uuid         NOT NULL,
+      vote_id         int          NOT NULL,
+      "pageVersionId" int          NOT NULL,
+      "userId"        int,
+      "anonKey"       text,
+      direction       int          NOT NULL,
+      ts_deleted      timestamp(3) NOT NULL,
+      paired_vote_id  int          NOT NULL,
+      ts_kept         timestamp(3) NOT NULL,
+      reason          text         NOT NULL,
+      cleaned_at      timestamptz  NOT NULL DEFAULT now()
+    )
+  `);
+  await prisma.$executeRawUnsafe(
+    `CREATE INDEX IF NOT EXISTS idx_vote_tz_dup_cleanup_log_run_id
+       ON public.vote_tz_dup_cleanup_log (run_id)`
+  );
+  await prisma.$executeRawUnsafe(
+    `CREATE INDEX IF NOT EXISTS idx_vote_tz_dup_cleanup_log_vote_id
+       ON public.vote_tz_dup_cleanup_log (vote_id)`
+  );
+}
+
+async function getCounts(prisma: PrismaClient, pairWindowSec: number): Promise<Counts> {
+  const rows = await prisma.$queryRawUnsafe<Array<{
+    total_vote_rows: bigint;
+    pair_8h_pairs: bigint;
+    multi_groups: bigint;
+    multi_extra_rows: bigint;
+    affected_pages: bigint;
+  }>>(
+    `
+    WITH actor_groups AS (
+      SELECT
+        v."pageVersionId" AS page_version_id,
+        v.direction,
+        COALESCE('u:' || v."userId"::text, 'a:' || v."anonKey") AS actor_key,
+        array_agg(v.timestamp ORDER BY v.timestamp, v.id) AS tses,
+        COUNT(*)::int AS n
+      FROM "Vote" v
+      WHERE v.direction <> 0
+        AND (v."userId" IS NOT NULL OR v."anonKey" IS NOT NULL)
+      GROUP BY 1, 2, 3
+      HAVING COUNT(*) >= 2
+    ),
+    pair_8h AS (
+      SELECT page_version_id, actor_key, direction
+        FROM actor_groups
+       WHERE n = 2
+         AND ABS(EXTRACT(EPOCH FROM (tses[2] - tses[1])) - 28800) <= $1
+    ),
+    multi AS (
+      SELECT page_version_id, actor_key, direction, n
+        FROM actor_groups
+       WHERE n >= 3
+         AND EXISTS (
+           SELECT 1 FROM generate_subscripts(tses, 1) i
+           WHERE i < array_length(tses, 1)
+             AND ABS(EXTRACT(EPOCH FROM (tses[i + 1] - tses[i])) - 28800) <= $1
+         )
+    )
+    SELECT
+      (SELECT COUNT(*) FROM "Vote")::bigint                   AS total_vote_rows,
+      (SELECT COUNT(*) FROM pair_8h)::bigint                  AS pair_8h_pairs,
+      (SELECT COUNT(*) FROM multi)::bigint                    AS multi_groups,
+      (SELECT COALESCE(SUM(n - 1), 0) FROM multi)::bigint     AS multi_extra_rows,
+      (SELECT COUNT(DISTINCT page_version_id) FROM pair_8h)::bigint AS affected_pages
+    `,
+    pairWindowSec
+  );
+  const row = rows[0];
+  return {
+    total_vote_rows: Number(row?.total_vote_rows ?? 0),
+    pair_8h_pairs: Number(row?.pair_8h_pairs ?? 0),
+    multi_groups: Number(row?.multi_groups ?? 0),
+    multi_extra_rows: Number(row?.multi_extra_rows ?? 0),
+    affected_pages: Number(row?.affected_pages ?? 0)
+  };
+}
+
+async function getSamplePages(
+  prisma: PrismaClient,
+  pairWindowSec: number,
+  sampleSize: number
+): Promise<SamplePageRow[]> {
+  return prisma.$queryRawUnsafe<SamplePageRow[]>(
+    `
+    WITH actor_groups AS (
+      SELECT
+        v."pageVersionId" AS page_version_id,
+        v.direction,
+        COALESCE('u:' || v."userId"::text, 'a:' || v."anonKey") AS actor_key,
+        array_agg(v.timestamp ORDER BY v.timestamp, v.id) AS tses,
+        COUNT(*)::int AS n
+      FROM "Vote" v
+      WHERE v.direction <> 0
+        AND (v."userId" IS NOT NULL OR v."anonKey" IS NOT NULL)
+      GROUP BY 1, 2, 3
+      HAVING COUNT(*) = 2
+    ),
+    pair_8h AS (
+      SELECT page_version_id
+        FROM actor_groups
+       WHERE ABS(EXTRACT(EPOCH FROM (tses[2] - tses[1])) - 28800) <= $1
+    ),
+    by_page AS (
+      SELECT page_version_id, COUNT(*)::int AS pair_count
+        FROM pair_8h
+       GROUP BY page_version_id
+       ORDER BY pair_count DESC, page_version_id
+       LIMIT $2
+    )
+    SELECT b.page_version_id,
+           pg."wikidotId"   AS wikidot_id,
+           pg."currentUrl"  AS current_url,
+           b.pair_count
+      FROM by_page b
+      JOIN "PageVersion" pv ON pv.id = b.page_version_id
+      JOIN "Page" pg        ON pg.id = pv."pageId"
+     ORDER BY b.pair_count DESC, b.page_version_id
+    `,
+    pairWindowSec,
+    sampleSize
+  );
+}
+
+async function fetchSuspectPairIds(
+  prisma: PrismaClient,
+  pairWindowSec: number
+): Promise<SuspectPairIds[]> {
+  return prisma.$queryRawUnsafe<SuspectPairIds[]>(
+    `
+    WITH actor_groups AS (
+      SELECT
+        array_agg(v.id        ORDER BY v.timestamp, v.id) AS ids,
+        array_agg(v.timestamp ORDER BY v.timestamp, v.id) AS tses
+      FROM "Vote" v
+      WHERE v.direction <> 0
+        AND (v."userId" IS NOT NULL OR v."anonKey" IS NOT NULL)
+      GROUP BY v."pageVersionId", v.direction,
+               COALESCE('u:' || v."userId"::text, 'a:' || v."anonKey")
+      HAVING COUNT(*) = 2
+    )
+    SELECT ids[1] AS keep_id, ids[2] AS delete_id
+      FROM actor_groups
+     WHERE ABS(EXTRACT(EPOCH FROM (tses[2] - tses[1])) - 28800) <= $1
+    `,
+    pairWindowSec
+  );
+}
+
+export async function runVoteTzDupCleanup(options: VoteTzDupCleanupOptions): Promise<void> {
+  const prisma = getPrismaClient();
+  const apply = Boolean(options.apply);
+  const pairWindowSec = options.pairWindowSec ?? DEFAULT_PAIR_WINDOW_SEC;
+  const sampleSize = options.sampleSize ?? DEFAULT_SAMPLE_SIZE;
+  const json = Boolean(options.json);
+  const runId = randomUUID();
+
+  Logger.info(
+    `🛠 vote-tz-dup-cleanup ${apply ? '(APPLY)' : '(dry-run)'} ` +
+    `pairWindowSec=${pairWindowSec} runId=${runId}`
+  );
+
+  const counts = await getCounts(prisma, pairWindowSec);
+  const samples = await getSamplePages(prisma, pairWindowSec, sampleSize);
+
+  if (json) {
+    Logger.info(
+      JSON.stringify(
+        {
+          mode: apply ? 'apply' : 'dry-run',
+          pairWindowSec,
+          runId,
+          counts,
+          samples
+        },
+        null,
+        2
+      )
+    );
+  } else {
+    Logger.info('## counts');
+    Logger.info(`  total_vote_rows  = ${counts.total_vote_rows}`);
+    Logger.info(`  pair_8h_pairs    = ${counts.pair_8h_pairs}     (cleanup target)`);
+    Logger.info(`  affected_pages   = ${counts.affected_pages}`);
+    Logger.info(`  multi_groups     = ${counts.multi_groups}      (review only, not touched)`);
+    Logger.info(`  multi_extra_rows = ${counts.multi_extra_rows}  (potential extra rows in multi)`);
+    Logger.info('');
+    Logger.info(`## top ${samples.length} affected pages`);
+    for (const s of samples) {
+      Logger.info(
+        `  pv=${s.page_version_id} wikidotId=${s.wikidot_id ?? '(null)'} ` +
+        `pair_count=${s.pair_count} url=${s.current_url ?? '(unknown)'}`
+      );
+    }
+  }
+
+  if (!apply) {
+    Logger.info('');
+    Logger.info('🧪 dry-run only. re-run with --apply to perform the cleanup.');
+    return;
+  }
+
+  if (counts.pair_8h_pairs === 0) {
+    Logger.info('✅ no suspect pairs to clean up.');
+    return;
+  }
+
+  await ensureLogTable(prisma);
+
+  Logger.info(`🚀 fetching ${counts.pair_8h_pairs} suspect pair ids for apply transaction...`);
+  const pairs = await fetchSuspectPairIds(prisma, pairWindowSec);
+  if (pairs.length !== counts.pair_8h_pairs) {
+    Logger.warn(
+      `⚠️ suspect pair count drift: expected ${counts.pair_8h_pairs}, fetched ${pairs.length}; ` +
+      `proceeding with the fetched set.`
+    );
+  }
+
+  const deleteIds = pairs.map((p) => p.delete_id);
+  const keepIds = pairs.map((p) => p.keep_id);
+
+  const result = await prisma.$transaction(
+    async (tx) => {
+      // 防御：保证事务内 timestamp 比较口径与 Vote 表写入一致（UTC）。
+      await tx.$executeRawUnsafe(`SET LOCAL TIME ZONE 'UTC'`);
+
+      // 备份待删行：全部 server-side JOIN，timestamp 不出库，避免任何 TZ 反序列化风险。
+      const backupInserted = await tx.$executeRawUnsafe(
+        `INSERT INTO public.vote_tz_dup_cleanup_log
+           (run_id, vote_id, "pageVersionId", "userId", "anonKey", direction,
+            ts_deleted, paired_vote_id, ts_kept, reason)
+         SELECT $1::uuid,
+                v.id, v."pageVersionId", v."userId", v."anonKey", v.direction,
+                v.timestamp, k.id, k.timestamp, 'tz_dup_pair_8h'
+           FROM unnest($2::int[], $3::int[]) AS p(delete_id, keep_id)
+           JOIN "Vote" v ON v.id = p.delete_id
+           JOIN "Vote" k ON k.id = p.keep_id`,
+        runId,
+        deleteIds,
+        keepIds
+      );
+
+      Logger.info(`📝 backup rows inserted into vote_tz_dup_cleanup_log: ${Number(backupInserted ?? 0)}`);
+
+      // DELETE 待清理票
+      const deleted = await tx.$executeRawUnsafe(
+        `DELETE FROM "Vote" WHERE id = ANY($1::int[])`,
+        deleteIds
+      );
+      Logger.info(`🗑  deleted Vote rows: ${Number(deleted ?? 0)}`);
+
+      // 事务内立即断言 suspect_pair_count = 0
+      const residualRows = await tx.$queryRawUnsafe<Array<{ residual: bigint }>>(
+        `
+        WITH actor_groups AS (
+          SELECT
+            v."pageVersionId" AS page_version_id,
+            v.direction,
+            COALESCE('u:' || v."userId"::text, 'a:' || v."anonKey") AS actor_key,
+            array_agg(v.timestamp ORDER BY v.timestamp, v.id) AS tses
+          FROM "Vote" v
+          WHERE v.direction <> 0
+            AND (v."userId" IS NOT NULL OR v."anonKey" IS NOT NULL)
+          GROUP BY 1, 2, 3
+          HAVING COUNT(*) = 2
+        )
+        SELECT COUNT(*)::bigint AS residual
+          FROM actor_groups
+         WHERE ABS(EXTRACT(EPOCH FROM (tses[2] - tses[1])) - 28800) <= $1
+        `,
+        pairWindowSec
+      );
+      const residual = Number(residualRows[0]?.residual ?? 0);
+      if (residual !== 0) {
+        throw new Error(
+          `post-cleanup residual suspect pairs = ${residual} (expected 0); rolling back`
+        );
+      }
+      Logger.info(`✅ residual pair_8h_pairs = 0 (post-cleanup assertion passed)`);
+
+      return {
+        backupInserted: Number(backupInserted ?? 0),
+        deleted: Number(deleted ?? 0),
+        residual
+      };
+    },
+    { timeout: 5 * 60 * 1000, maxWait: 60 * 1000 }
+  );
+
+  Logger.info(
+    `🎉 cleanup complete. runId=${runId} backup=${result.backupInserted} deleted=${result.deleted}`
+  );
+  Logger.info('   rollback: re-INSERT rows from vote_tz_dup_cleanup_log WHERE run_id = ...');
+}
+
+if (process.argv[1] && process.argv[1].endsWith('voteTzDupCleanup.js')) {
+  const argv = process.argv.slice(2);
+  const opts: VoteTzDupCleanupOptions = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--apply') opts.apply = true;
+    else if (a === '--json') opts.json = true;
+    else if (a === '--pair-window-sec' && argv[i + 1] !== undefined) {
+      const v = Number.parseInt(argv[i + 1], 10);
+      if (Number.isFinite(v) && v >= 0) opts.pairWindowSec = v;
+      i += 1;
+    } else if (a === '--sample-size' && argv[i + 1] !== undefined) {
+      const v = Number.parseInt(argv[i + 1], 10);
+      if (Number.isFinite(v) && v >= 0) opts.sampleSize = v;
+      i += 1;
+    }
+  }
+
+  runVoteTzDupCleanup(opts)
+    .then(async () => {
+      await disconnectPrisma();
+      process.exit(0);
+    })
+    .catch(async (err) => {
+      Logger.error('vote-tz-dup-cleanup failed', err instanceof Error ? err : new Error(String(err)));
+      try {
+        await disconnectPrisma();
+      } catch {
+        // ignore
+      }
+      process.exit(1);
+    });
+}

--- a/backend/src/cli/voteTzDupCleanup.ts
+++ b/backend/src/cli/voteTzDupCleanup.ts
@@ -354,9 +354,21 @@ export async function runVoteTzDupCleanup(options: VoteTzDupCleanupOptions): Pro
   console.log(
     `🎉 cleanup complete. runId=${runId} backup=${result.backupCount} deleted=${result.deletedCount}`
   );
-  console.log(
-    `   rollback: re-INSERT rows from public.vote_tz_dup_cleanup_log WHERE run_id = '${runId}'`
-  );
+  console.log('');
+  console.log('## rollback');
+  console.log(`   to fully revert this run, execute the following inside a transaction:`);
+  console.log(``);
+  console.log(`   BEGIN;`);
+  console.log(`   INSERT INTO "Vote" (id, "pageVersionId", "userId", "anonKey", direction, timestamp)`);
+  console.log(`   SELECT vote_id, "pageVersionId", "userId", "anonKey", direction, ts_deleted`);
+  console.log(`     FROM public.vote_tz_dup_cleanup_log`);
+  console.log(`    WHERE run_id = '${runId}'::uuid;`);
+  console.log(`   -- Vote.id is an autoincrement; reusing old ids is safe as long as the sequence`);
+  console.log(`   -- has advanced past them (it has — DELETEs do not retract serial sequences).`);
+  console.log(`   -- If the unique constraint (pageVersionId, userId, timestamp) blocks reinsertion,`);
+  console.log(`   -- it means the canonical UTC row is still present (expected) and the rollback`);
+  console.log(`   -- would re-introduce the duplicate; resolve manually before proceeding.`);
+  console.log(`   COMMIT;`);
 }
 
 if (process.argv[1] && process.argv[1].endsWith('voteTzDupCleanup.js')) {

--- a/backend/src/cli/voteTzDupCleanup.ts
+++ b/backend/src/cli/voteTzDupCleanup.ts
@@ -39,11 +39,6 @@ export type VoteTzDupCleanupOptions = {
   json?: boolean;
 };
 
-type SuspectPairIds = {
-  delete_id: number;
-  keep_id: number;
-};
-
 type Counts = {
   total_vote_rows: number;
   pair_8h_pairs: number;
@@ -192,31 +187,6 @@ async function getSamplePages(
   );
 }
 
-async function fetchSuspectPairIds(
-  prisma: PrismaClient,
-  pairWindowSec: number
-): Promise<SuspectPairIds[]> {
-  return prisma.$queryRawUnsafe<SuspectPairIds[]>(
-    `
-    WITH actor_groups AS (
-      SELECT
-        array_agg(v.id        ORDER BY v.timestamp, v.id) AS ids,
-        array_agg(v.timestamp ORDER BY v.timestamp, v.id) AS tses
-      FROM "Vote" v
-      WHERE v.direction <> 0
-        AND (v."userId" IS NOT NULL OR v."anonKey" IS NOT NULL)
-      GROUP BY v."pageVersionId", v.direction,
-               COALESCE('u:' || v."userId"::text, 'a:' || v."anonKey")
-      HAVING COUNT(*) = 2
-    )
-    SELECT ids[1] AS keep_id, ids[2] AS delete_id
-      FROM actor_groups
-     WHERE ABS(EXTRACT(EPOCH FROM (tses[2] - tses[1])) - 28800) <= $1
-    `,
-    pairWindowSec
-  );
-}
-
 export async function runVoteTzDupCleanup(options: VoteTzDupCleanupOptions): Promise<void> {
   const prisma = getPrismaClient();
   const apply = Boolean(options.apply);
@@ -225,7 +195,8 @@ export async function runVoteTzDupCleanup(options: VoteTzDupCleanupOptions): Pro
   const json = Boolean(options.json);
   const runId = randomUUID();
 
-  Logger.info(
+  // 多行报告：直接 console.log 避免 Logger.info 的 500ms 节流丢行。
+  console.log(
     `🛠 vote-tz-dup-cleanup ${apply ? '(APPLY)' : '(dry-run)'} ` +
     `pairWindowSec=${pairWindowSec} runId=${runId}`
   );
@@ -234,7 +205,7 @@ export async function runVoteTzDupCleanup(options: VoteTzDupCleanupOptions): Pro
   const samples = await getSamplePages(prisma, pairWindowSec, sampleSize);
 
   if (json) {
-    Logger.info(
+    console.log(
       JSON.stringify(
         {
           mode: apply ? 'apply' : 'dry-run',
@@ -248,16 +219,16 @@ export async function runVoteTzDupCleanup(options: VoteTzDupCleanupOptions): Pro
       )
     );
   } else {
-    Logger.info('## counts');
-    Logger.info(`  total_vote_rows  = ${counts.total_vote_rows}`);
-    Logger.info(`  pair_8h_pairs    = ${counts.pair_8h_pairs}     (cleanup target)`);
-    Logger.info(`  affected_pages   = ${counts.affected_pages}`);
-    Logger.info(`  multi_groups     = ${counts.multi_groups}      (review only, not touched)`);
-    Logger.info(`  multi_extra_rows = ${counts.multi_extra_rows}  (potential extra rows in multi)`);
-    Logger.info('');
-    Logger.info(`## top ${samples.length} affected pages`);
+    console.log('## counts');
+    console.log(`  total_vote_rows  = ${counts.total_vote_rows}`);
+    console.log(`  pair_8h_pairs    = ${counts.pair_8h_pairs}     (cleanup target)`);
+    console.log(`  affected_pages   = ${counts.affected_pages}`);
+    console.log(`  multi_groups     = ${counts.multi_groups}      (review only, not touched)`);
+    console.log(`  multi_extra_rows = ${counts.multi_extra_rows}  (potential extra rows in multi)`);
+    console.log('');
+    console.log(`## top ${samples.length} affected pages`);
     for (const s of samples) {
-      Logger.info(
+      console.log(
         `  pv=${s.page_version_id} wikidotId=${s.wikidot_id ?? '(null)'} ` +
         `pair_count=${s.pair_count} url=${s.current_url ?? '(unknown)'}`
       );
@@ -265,102 +236,122 @@ export async function runVoteTzDupCleanup(options: VoteTzDupCleanupOptions): Pro
   }
 
   if (!apply) {
-    Logger.info('');
-    Logger.info('🧪 dry-run only. re-run with --apply to perform the cleanup.');
+    console.log('');
+    console.log('🧪 dry-run only. re-run with --apply to perform the cleanup.');
     return;
   }
 
   if (counts.pair_8h_pairs === 0) {
-    Logger.info('✅ no suspect pairs to clean up.');
+    console.log('✅ no suspect pairs to clean up.');
     return;
   }
 
   await ensureLogTable(prisma);
 
-  Logger.info(`🚀 fetching ${counts.pair_8h_pairs} suspect pair ids for apply transaction...`);
-  const pairs = await fetchSuspectPairIds(prisma, pairWindowSec);
-  if (pairs.length !== counts.pair_8h_pairs) {
-    Logger.warn(
-      `⚠️ suspect pair count drift: expected ${counts.pair_8h_pairs}, fetched ${pairs.length}; ` +
-      `proceeding with the fetched set.`
-    );
-  }
-
-  const deleteIds = pairs.map((p) => p.delete_id);
-  const keepIds = pairs.map((p) => p.keep_id);
+  console.log(`🚀 entering single transaction (pair select + backup + DELETE all in tx) runId=${runId}`);
 
   const result = await prisma.$transaction(
     async (tx) => {
       // 防御：保证事务内 timestamp 比较口径与 Vote 表写入一致（UTC）。
       await tx.$executeRawUnsafe(`SET LOCAL TIME ZONE 'UTC'`);
 
-      // 备份待删行：全部 server-side JOIN，timestamp 不出库，避免任何 TZ 反序列化风险。
+      // 1) 在事务内重选 suspect pair 并直接备份到 cleanup_log，避免 tx 外/内 pair 集合 drift。
+      //    timestamp 全程 server-side，不出库；run_id 是本次唯一 provenance。
       const backupInserted = await tx.$executeRawUnsafe(
-        `INSERT INTO public.vote_tz_dup_cleanup_log
+        `WITH actor_groups AS (
+           SELECT
+             array_agg(v.id        ORDER BY v.timestamp, v.id) AS ids,
+             array_agg(v.timestamp ORDER BY v.timestamp, v.id) AS tses
+           FROM "Vote" v
+           WHERE v.direction <> 0
+             AND (v."userId" IS NOT NULL OR v."anonKey" IS NOT NULL)
+           GROUP BY v."pageVersionId", v.direction,
+                    COALESCE('u:' || v."userId"::text, 'a:' || v."anonKey")
+           HAVING COUNT(*) = 2
+         ),
+         pairs AS (
+           SELECT ids[1] AS keep_id, ids[2] AS delete_id
+             FROM actor_groups
+            WHERE ABS(EXTRACT(EPOCH FROM (tses[2] - tses[1])) - 28800) <= $2
+         )
+         INSERT INTO public.vote_tz_dup_cleanup_log
            (run_id, vote_id, "pageVersionId", "userId", "anonKey", direction,
             ts_deleted, paired_vote_id, ts_kept, reason)
          SELECT $1::uuid,
                 v.id, v."pageVersionId", v."userId", v."anonKey", v.direction,
                 v.timestamp, k.id, k.timestamp, 'tz_dup_pair_8h'
-           FROM unnest($2::int[], $3::int[]) AS p(delete_id, keep_id)
+           FROM pairs p
            JOIN "Vote" v ON v.id = p.delete_id
            JOIN "Vote" k ON k.id = p.keep_id`,
         runId,
-        deleteIds,
-        keepIds
+        pairWindowSec
       );
+      const backupCount = Number(backupInserted ?? 0);
+      console.log(`📝 backup rows inserted into vote_tz_dup_cleanup_log: ${backupCount}`);
 
-      Logger.info(`📝 backup rows inserted into vote_tz_dup_cleanup_log: ${Number(backupInserted ?? 0)}`);
-
-      // DELETE 待清理票
+      // 2) DELETE 直接驱动自 log（同 run_id），保证 DELETE 严格是 backup 的子集 — 一一对应。
       const deleted = await tx.$executeRawUnsafe(
-        `DELETE FROM "Vote" WHERE id = ANY($1::int[])`,
-        deleteIds
+        `DELETE FROM "Vote" v
+           USING public.vote_tz_dup_cleanup_log l
+          WHERE l.run_id = $1::uuid
+            AND v.id     = l.vote_id`,
+        runId
       );
-      Logger.info(`🗑  deleted Vote rows: ${Number(deleted ?? 0)}`);
+      const deletedCount = Number(deleted ?? 0);
+      console.log(`🗑  deleted Vote rows: ${deletedCount}`);
 
-      // 事务内立即断言 suspect_pair_count = 0
+      if (deletedCount !== backupCount) {
+        throw new Error(
+          `backup/delete mismatch: backup=${backupCount}, deleted=${deletedCount}; rolling back`
+        );
+      }
+
+      // 3) 残留断言：仅在 cleanup_log 涉及的 actor 子集上重新分组，确认这些 actor 不再有 8h pair。
+      //    比全表 GROUP 便宜得多，且语义上覆盖了所有"被本次 cleanup 触及"的 actor。
       const residualRows = await tx.$queryRawUnsafe<Array<{ residual: bigint }>>(
-        `
-        WITH actor_groups AS (
-          SELECT
-            v."pageVersionId" AS page_version_id,
-            v.direction,
-            COALESCE('u:' || v."userId"::text, 'a:' || v."anonKey") AS actor_key,
-            array_agg(v.timestamp ORDER BY v.timestamp, v.id) AS tses
-          FROM "Vote" v
-          WHERE v.direction <> 0
-            AND (v."userId" IS NOT NULL OR v."anonKey" IS NOT NULL)
-          GROUP BY 1, 2, 3
-          HAVING COUNT(*) = 2
-        )
-        SELECT COUNT(*)::bigint AS residual
-          FROM actor_groups
-         WHERE ABS(EXTRACT(EPOCH FROM (tses[2] - tses[1])) - 28800) <= $1
-        `,
+        `WITH affected AS (
+           SELECT DISTINCT "pageVersionId", "userId", "anonKey", direction
+             FROM public.vote_tz_dup_cleanup_log
+            WHERE run_id = $1::uuid
+         ),
+         residual_groups AS (
+           SELECT array_agg(v.timestamp ORDER BY v.timestamp, v.id) AS tses
+             FROM "Vote" v
+             JOIN affected a
+               ON a."pageVersionId" = v."pageVersionId"
+              AND a.direction       = v.direction
+              AND ((a."userId"  IS NOT NULL AND v."userId"  = a."userId")
+                OR (a."anonKey" IS NOT NULL AND v."anonKey" = a."anonKey"))
+            WHERE v.direction <> 0
+            GROUP BY v."pageVersionId", v.direction,
+                     COALESCE('u:' || v."userId"::text, 'a:' || v."anonKey")
+           HAVING COUNT(*) = 2
+         )
+         SELECT COUNT(*)::bigint AS residual
+           FROM residual_groups
+          WHERE ABS(EXTRACT(EPOCH FROM (tses[2] - tses[1])) - 28800) <= $2`,
+        runId,
         pairWindowSec
       );
       const residual = Number(residualRows[0]?.residual ?? 0);
       if (residual !== 0) {
         throw new Error(
-          `post-cleanup residual suspect pairs = ${residual} (expected 0); rolling back`
+          `post-cleanup residual suspect pairs on affected actors = ${residual} (expected 0); rolling back`
         );
       }
-      Logger.info(`✅ residual pair_8h_pairs = 0 (post-cleanup assertion passed)`);
+      console.log(`✅ residual pair_8h_pairs on affected actors = 0 (post-cleanup assertion passed)`);
 
-      return {
-        backupInserted: Number(backupInserted ?? 0),
-        deleted: Number(deleted ?? 0),
-        residual
-      };
+      return { backupCount, deletedCount, residual };
     },
-    { timeout: 5 * 60 * 1000, maxWait: 60 * 1000 }
+    { timeout: 10 * 60 * 1000, maxWait: 60 * 1000 }
   );
 
-  Logger.info(
-    `🎉 cleanup complete. runId=${runId} backup=${result.backupInserted} deleted=${result.deleted}`
+  console.log(
+    `🎉 cleanup complete. runId=${runId} backup=${result.backupCount} deleted=${result.deletedCount}`
   );
-  Logger.info('   rollback: re-INSERT rows from vote_tz_dup_cleanup_log WHERE run_id = ...');
+  console.log(
+    `   rollback: re-INSERT rows from public.vote_tz_dup_cleanup_log WHERE run_id = '${runId}'`
+  );
 }
 
 if (process.argv[1] && process.argv[1].endsWith('voteTzDupCleanup.js')) {

--- a/backend/src/cli/voteTzDupCleanup.ts
+++ b/backend/src/cli/voteTzDupCleanup.ts
@@ -196,10 +196,15 @@ export async function runVoteTzDupCleanup(options: VoteTzDupCleanupOptions): Pro
   const runId = randomUUID();
 
   // 多行报告：直接 console.log 避免 Logger.info 的 500ms 节流丢行。
-  console.log(
+  // JSON 模式下 header 走 stderr，让 stdout 保持纯 JSON，方便上游脚本解析。
+  const header =
     `🛠 vote-tz-dup-cleanup ${apply ? '(APPLY)' : '(dry-run)'} ` +
-    `pairWindowSec=${pairWindowSec} runId=${runId}`
-  );
+    `pairWindowSec=${pairWindowSec} runId=${runId}`;
+  if (json) {
+    console.error(header);
+  } else {
+    console.log(header);
+  }
 
   const counts = await getCounts(prisma, pairWindowSec);
   const samples = await getSamplePages(prisma, pairWindowSec, sampleSize);


### PR DESCRIPTION
## TL;DR

PR #78 修复了 改投漏抓 bug，但 voteResyncAudit 的回填本身在 4-26~4-28 写入了 **~14.5 万条** 与 UTC 真值相差 ±8h 的重复 Vote 行。本 PR：

1. 修 voteResyncAudit 写入口径，避免今后再次产生偏移行
2. 新增 `vote-tz-dup-cleanup` CLI，单事务清理已有重复
3. 扩 `check-vote-integrity` 加 TZ-dup 指纹断言

## 根因

`backend/src/cli/voteResyncAudit.ts:360` 早期实现把 JS Date 作为 raw 参数通过 `$executeRawUnsafe` 写入 `tmp_vote.timestamp`（`timestamp without time zone`）。pg-node 协议把 Date 序列化为带时区 ISO 字符串，PostgreSQL 按 session `TimeZone=Asia/Shanghai` 把它去时区化为本地时间 — 与 Prisma ORM 的 UTC 写入口径相差 8 小时，绕开 Vote 表唯一约束 `(pageVersionId, userId, timestamp)` 形成同一票的两条记录。

抽样：DVA24 用户的 san-francisco-2015（wikidotId=1468197732），最新 PV 上 86 distinct user × 2 = 170 行，每对 timestamp 恰好相差 8h（`00:00:00` vs `08:00:00`）。

## 修改

- `backend/src/cli/voteResyncAudit.ts`
  - tmp_vote.timestamp 收紧到 `timestamp(3)` + `ALTER COLUMN` 兜底已存在 schema
  - bulk INSERT 改 `($N::timestamptz AT TIME ZONE 'UTC')::timestamp` + 参数侧 `toISOString()`
  - `doApply` 事务开头 `SET LOCAL TIME ZONE 'UTC'` 防御
- `backend/src/cli/voteTzDupCleanup.ts`（新）
  - 默认 dry-run；`--apply` 才写
  - 识别口径：actor (`u:userId` / `a:anonKey`) × pageVersionId × direction 严格 2 条且 ts 差 28800±1s
  - 保留 ts 较小（UTC 真值），删较大（+8h 错误副本）
  - 备份到 `public.vote_tz_dup_cleanup_log`，带 `run_id`；server-side `INSERT INTO ... SELECT FROM unnest(...) JOIN "Vote"`，timestamp 不出库
  - 单事务 apply：`SET LOCAL TIME ZONE 'UTC'` → backup → DELETE → 残留断言 = 0，否则 ROLLBACK
  - `multi_groups`（≥3 条 actor group）和孤儿单条暂不动，留第二阶段
- `backend/scripts/check-vote-integrity.ts`
  - 加 `suspect_tz_dup_pair_count` + `--fail-if-tz-dup` flag
- `backend/src/cli/index.ts` + `backend/package.json`
  - 注册 `vote-tz-dup-cleanup` 命令与 npm script

## Dry-Run 实测（已跑）

```
total_vote_rows  = 4694214
pair_8h_pairs    = 121610   (cleanup target)
multi_groups     = 22997    (review only)
multi_extra_rows = 46106
affected_pages   = 1055
```

baseline `check-vote-integrity --json`:

```json
{
  "totalPages": 34559,
  "perfectMatch": 30753,
  "ratingMismatch": 70,
  "countMismatch": 516,
  "anyMismatch": 521,
  "suspectTzDupPairCount": 121610
}
```

top affected: scp-cn-963-j (4621 pair), scp-cn-2000 (3440), main (3395), scp-cn-2801, scp-173, scp-cn-3000, scp-cn-1109, scp-cn-4000 ...

san-francisco-2015 抽样：86 actor groups → 84 pair_8h（cleanup） + 2 singletons（保留）。

## 预期影响

- DELETE 121610 行 Vote（每行有备份）
- LatestVote 是 view（已确认 `pg_class.relkind='v'`），cleanup 后自动反映正确分数
- Vote 表无 trigger（已确认），无意外副作用
- 1055 页的页面分数会立即收敛（前端 `page.rating` 用 PageVersion.rating，不受 Vote 删除直接影响；BFF 路径走 LatestVote 重算的会立即反映）

## 部署计划（合并后再做，需用户授权）

1. 受保护 main checkout：`git pull` + `npm install`（如缺）
2. `npm run vote-tz-dup-cleanup`（dry-run，确认数字）
3. 用户授权后：`npm run vote-tz-dup-cleanup -- --apply`
4. `npm run check:vote-integrity -- --fail-if-tz-dup`（断言通过）
5. 第二阶段处理 multi_groups（22997）— 需要重新 collect CROM 拿原始 timestamp 做 provenance 校验

## 回滚

如需回滚，从 `public.vote_tz_dup_cleanup_log WHERE run_id = '<uuid>'` 重 INSERT 即可恢复全部被删行（schema 完整保留，包括 timestamp 字面值）。

## Test Plan

- [x] tsc typecheck pass
- [x] dry-run 输出与 psql 直跑数字一致（121610 / 22997 / 46106 / 1055）
- [x] DVA24 san-francisco-2015 抽样 actor group 划分正确
- [x] LatestVote = view + Vote 无 trigger，cleanup 副作用面已确认
- [ ] 部署后实跑 `--apply`，复测 check-vote-integrity 应显示 suspectTzDupPairCount=0 且 ratingMismatch 收敛