### PR TITLE
fix(bff): prefer active pages for tracking URL lookup

### DIFF
--- a/bff/src/web/routes/tracking.ts
+++ b/bff/src/web/routes/tracking.ts
@@ -477,6 +477,10 @@ export function trackingRouter(pool: Pool) {
                FROM unnest("urlHistory") AS hist(url)
                WHERE lower(hist.url) = ANY($1)
              )
+          ORDER BY "isDeleted" ASC,
+                   CASE WHEN lower("currentUrl") = ANY($1) THEN 0 ELSE 1 END ASC,
+                   "updatedAt" DESC,
+                   id DESC
           LIMIT 1`,
         [candidateUrls]
       );

--- a/bff/tests/tracking-pixel.test.ts
+++ b/bff/tests/tracking-pixel.test.ts
@@ -1,13 +1,15 @@
 import request from 'supertest';
-import { createServer } from '../src/start';
+import express from 'express';
+import { trackingRouter } from '../src/web/routes/tracking';
 
 const queryMock = jest.fn();
 
-jest.mock('pg', () => ({
-  Pool: jest.fn().mockImplementation(() => ({
-    query: queryMock
-  }))
-}));
+function createTrackingTestServer() {
+  const app = express();
+  app.set('trust proxy', 1);
+  app.use('/tracking', trackingRouter({ query: queryMock } as any));
+  return app;
+}
 
 describe('Tracking pixel endpoint', () => {
   beforeEach(() => {
@@ -31,7 +33,7 @@ describe('Tracking pixel endpoint', () => {
       return Promise.resolve({ rows: [] });
     });
 
-    const app = await createServer();
+    const app = createTrackingTestServer();
     const res = await request(app)
       .get('/tracking/pixel')
       .set('User-Agent', 'jest-agent')
@@ -63,7 +65,7 @@ describe('Tracking pixel endpoint', () => {
       return Promise.resolve({ rows: [] });
     });
 
-    const app = await createServer();
+    const app = createTrackingTestServer();
     const target = 'scp-173';
     const res = await request(app)
       .get('/tracking/pixel/by-url')
@@ -78,6 +80,42 @@ describe('Tracking pixel endpoint', () => {
     const arrParam = historyCalls?.[1]?.[0] as string[] | undefined;
     expect(Array.isArray(arrParam)).toBe(true);
     expect((arrParam || [])).toContain(`http://scp-wiki-cn.wikidot.com/${target}`);
+  });
+
+  test('prefers active current-url page when url lookup has deleted duplicates', async () => {
+    queryMock.mockImplementation((sql: string) => {
+      if (sql.includes('FROM "Page"') && sql.includes('urlHistory')) {
+        return Promise.resolve({ rows: [{ id: 103731, wikidotId: 1468359417 }] });
+      }
+      if (sql.includes('FROM "PageViewEvent"') && sql.includes('"clientIp"')) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('INSERT INTO "PageViewEvent"')) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('INSERT INTO "PageDailyStats"')) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const app = createTrackingTestServer();
+    const res = await request(app)
+      .get('/tracking/pixel/by-url')
+      .set('User-Agent', 'jest-agent')
+      .set('X-Forwarded-For', '203.0.113.42')
+      .query({ url: 'scp-cn-4042' })
+      .expect(200);
+
+    expect(res.headers['x-tracking-counted']).toBe('1');
+    const lookupCall = queryMock.mock.calls.find(([sql]) => sql.includes('FROM "Page"') && sql.includes('urlHistory'));
+    expect(lookupCall?.[0]).toContain('ORDER BY "isDeleted" ASC');
+    expect(lookupCall?.[0]).toContain('CASE WHEN lower("currentUrl") = ANY($1) THEN 0 ELSE 1 END ASC');
+
+    const insertCall = queryMock.mock.calls.find(([sql]) => sql.includes('INSERT INTO "PageViewEvent"'));
+    const insertParams = insertCall?.[1] as unknown[] | undefined;
+    expect(insertParams?.[0]).toBe(103731);
+    expect(insertParams?.[1]).toBe(1468359417);
   });
 
   test('skips increment when recently counted', async () => {
@@ -99,7 +137,7 @@ describe('Tracking pixel endpoint', () => {
       return Promise.resolve({ rows: [] });
     });
 
-    const app = await createServer();
+    const app = createTrackingTestServer();
     const res = await request(app)
       .get('/tracking/pixel')
       .set('User-Agent', 'jest-agent')
@@ -112,7 +150,7 @@ describe('Tracking pixel endpoint', () => {
   });
 
   test('handles missing wikidotId gracefully', async () => {
-    const app = await createServer();
+    const app = createTrackingTestServer();
     const res = await request(app)
       .get('/tracking/pixel')
       .expect(200);
@@ -122,7 +160,7 @@ describe('Tracking pixel endpoint', () => {
   });
 
   test('rejects absolute url in by-url endpoint', async () => {
-    const app = await createServer();
+    const app = createTrackingTestServer();
     const res = await request(app)
       .get('/tracking/pixel/by-url')
       .query({ url: 'http://scp-wiki-cn.wikidot.com/scp-173' })
@@ -146,7 +184,7 @@ describe('Tracking pixel endpoint', () => {
       return Promise.resolve({ rows: [] });
     });
 
-    const app = await createServer();
+    const app = createTrackingTestServer();
     const res = await request(app)
       .get('/tracking/pixel/by-username')
       .set('User-Agent', 'jest-agent')
@@ -180,7 +218,7 @@ describe('Tracking pixel endpoint', () => {
       return Promise.resolve({ rows: [] });
     });
 
-    const app = await createServer();
+    const app = createTrackingTestServer();
     const res = await request(app)
       .get('/tracking/pixel/by-username')
       .set('User-Agent', 'jest-agent')
@@ -192,7 +230,7 @@ describe('Tracking pixel endpoint', () => {
   });
 
   test('handles missing username gracefully', async () => {
-    const app = await createServer();
+    const app = createTrackingTestServer();
     const res = await request(app)
       .get('/tracking/pixel/by-username')
       .expect(200);
@@ -209,7 +247,7 @@ describe('Tracking pixel endpoint', () => {
       return Promise.resolve({ rows: [] });
     });
 
-    const app = await createServer();
+    const app = createTrackingTestServer();
     const res = await request(app)
       .get('/tracking/pixel/by-username')
       .query({ wikidotId: '999999' })


### PR DESCRIPTION
## Summary

Fixes `/tracking/pixel/by-url` page resolution when multiple `Page` rows share the same Wikidot URL because older rows are deleted/recreated.

- Prefer non-deleted `Page` rows before deleted rows.
- Prefer current URL matches before `urlHistory` matches.
- Add deterministic tie-breakers using `updatedAt DESC, id DESC`.
- Add a regression test covering the `scp-cn-4042` style duplicate/deleted URL case.

## Root Cause

The by-url tracking endpoint resolved URL candidates with `LIMIT 1` and no ordering. When a page had deleted historical records with the same `currentUrl`, PostgreSQL could return a deleted page first, causing `PageViewEvent`, `PageDailyStats.views`, and tracking debug rows to be attributed to stale `pageId` / `wikidotId` values.

## Data Repair

Production data has already been repaired separately:

- `10,115` `PageViewEvent` rows moved from deleted duplicate URL pages to current active pages.
- `722` `tracking_debug_event` rows moved for consistency.
- `2,498` affected `PageDailyStats.views` rows recomputed from migrated raw events.
- `SCP-CN-4042` old deleted page `103410` is now zeroed; active page `103731` now owns its tracking data.
- Remaining duplicate-URL deleted-page misattribution after repair: `0`.

Backup files are in `/tmp/tracking-page-repair-2026-04-30T11-19-28-753Z-*.json` on the production host.

## Validation

- `npm test -- tracking-pixel.test.ts --runInBand`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Production read-only verification that the new ordering picks `SCP-CN-4042` active page `pageId=103731`, `wikidotId=1468359417`.

## Notes

`npm run lint` is currently blocked because the BFF package does not install an `eslint` binary even though the script exists. This is pre-existing and unrelated to this hotfix.
