### PR TITLE
fix(gacha): 锻造面板分页取尽 + PICKER 高稀有度优先，修复检索不到紫卡 (Phase 2A)

### DIFF
--- a/frontend/composables/useGachaDraw.ts
+++ b/frontend/composables/useGachaDraw.ts
@@ -18,6 +18,7 @@ import {
   toTimestamp
 } from '~/utils/gachaFormatters'
 import { resolveAffixSignatureFromSource } from '~/utils/gachaAffix'
+import { paginatedLoadAll } from '~/utils/gachaPagination'
 import {
   poolPriorityMap
 } from '~/utils/gachaConstants'
@@ -350,10 +351,17 @@ export function useGachaDraw(page: GachaPageContext) {
       }).catch(() => new Map<string, number>())
 
       const activeAffixFilter = reforgeAffixFilter.value || undefined
-      // Single large request instead of paginated loading to avoid multiple slow fetches
-      const res = await gacha.getInventory({ limit: 5000, offset: 0, affixFilter: activeAffixFilter })
-      if (!res.ok) throw new Error(res.error || '加载改造候选卡片失败')
-      const allItems: InventoryItem[] = res.data ?? []
+      // 分页取尽全部库存：服务端单页上限为 1000，单次大请求(limit:5000)会被钳到 1000，
+      // 按稀有度排序时截断点正好落在紫卡区间，导致重库存用户检索不到紫卡。
+      // 与放置面板一致改用 paginatedLoadAll 翻到底。
+      const allItems: InventoryItem[] = await paginatedLoadAll<InventoryItem>({
+        fetchPage: async (offset, limit, skipTotal) => {
+          const res = await gacha.getInventory({ limit, offset, skipTotal, affixFilter: activeAffixFilter })
+          if (!res.ok) throw new Error(res.error || '加载改造候选卡片失败')
+          return { items: res.data ?? [], total: res.total ?? 0, pageRows: Number(res.pageRows ?? 0) }
+        },
+        pageSize: 1000
+      })
       seedAuthorCacheFromInventory(allItems)
       queueAuthorHydration(allItems.map((item) => item.wikidotId))
       const grouped = new Map<string, ReforgeCardOption>()

--- a/user-backend/src/routes/gacha/core.routes.ts
+++ b/user-backend/src/routes/gacha/core.routes.ts
@@ -756,9 +756,12 @@ export function registerCoreRoutes(router: Router) {
         });
       }
 
+      // PICKER 模式：高稀有度优先（GachaRarity 枚举物理序为 WHITE<GREEN<BLUE<PURPLE<GOLD，
+      // 故用 desc 让 GOLD/PURPLE 排在前面），与 /inventory 的稀有度优先口径一致，
+      // 避免紫/金卡被分页上限截断而检索不到。
       const orderBy: Prisma.GachaCardInstanceOrderByWithRelationInput[] = sortMode === 'PICKER'
         ? [
-            { card: { rarity: 'asc' } },
+            { card: { rarity: 'desc' } },
             { card: { title: 'asc' } },
             { obtainedAt: 'desc' }
           ]


### PR DESCRIPTION
## 目的（Phase 2A：Gacha 紫卡快修，立即见效）

修复重库存用户在锻造/词条改造面板**检索不到紫卡**（及更低稀有度卡）。

## 改动

- **前端 reforge 分页取尽**：选项加载原为单次 `getInventory({ limit: 5000 })`，被服务端硬钳到 1000 行，按稀有度排序时截断点正好落在紫卡区间。改用与放置面板一致的 `paginatedLoadAll`（pageSize=1000）翻到底，透传 `affixFilter`。
- **后端 PICKER 高稀有度优先**：`/instances/free` 的 PICKER 排序由 `rarity asc`（白卡在前）改为 `desc`（GOLD/PURPLE 在前），与 `/inventory` 的稀有度优先口径一致，避免高稀有度卡被分页上限截断。

## 验证

- frontend / user-backend typecheck 均通过。
- 不涉及数据变更，纯查询/加载行为修复。

Refs #93 #94
