### PR TITLE
fix(forum-sync): 水位移到抓帖成功后 + 讨论帖按标题匹配(仅补空不覆盖) (Phase 4A)

### DIFF
--- a/backend/src/core/processors/ForumSyncProcessor.ts
+++ b/backend/src/core/processors/ForumSyncProcessor.ts
@@ -222,21 +222,22 @@ export class ForumSyncProcessor {
     remoteThread: ForumThreadDTO,
     result: ForumSyncResult
   ): Promise<boolean> {
-    // Incremental check: compare postCount
-    if (!this.options.full) {
-      const localThread = await this.prisma.forumThread.findUnique({
-        where: { id: remoteThread.id },
-        select: { postCountAtSync: true },
-      });
+    // 读取本地 thread 现状（水位 + 已有 pageId 链接），全量/增量模式都需要。
+    const localThread = await this.prisma.forumThread.findUnique({
+      where: { id: remoteThread.id },
+      select: { postCountAtSync: true, pageId: true },
+    });
 
-      if (localThread && localThread.postCountAtSync === remoteThread.postCount) {
-        result.threadsSkipped++;
-        return false;
-      }
+    // Incremental check: compare postCount
+    if (!this.options.full && localThread && localThread.postCountAtSync === remoteThread.postCount) {
+      result.threadsSkipped++;
+      return false;
     }
 
-    // Try to resolve pageId for page discussion threads
-    const pageId = await this.resolvePageId(remoteThread);
+    // 仅在尚未链接时解析 pageId（NULL→resolved）；不在同步路径覆盖已有非空链接。
+    // 对已有链接的纠正（含标题匹配与现状不一致的约 140 例）交由 dry-run 修复 CLI
+    // 输出 old/new/confidence 后人工复核，避免同步时盲目改链。
+    const pageId = localThread?.pageId ?? await this.resolvePageId(remoteThread);
 
     // Upsert thread
     if (!this.options.dryRun) {
@@ -251,7 +252,9 @@ export class ForumSyncProcessor {
           createdByWikidotId: remoteThread.createdByWikidotId,
           createdAt: remoteThread.createdAt ? new Date(remoteThread.createdAt) : null,
           postCount: remoteThread.postCount,
-          postCountAtSync: remoteThread.postCount,
+          // 水位哨兵：抓帖+落库成功后才把 postCountAtSync 推进为真实值，
+          // 避免抓帖失败却已推进水位导致该 thread 被增量永久跳过（显示有帖实际 0 帖）。
+          postCountAtSync: 0,
           pageId,
           lastSyncedAt: new Date(),
         },
@@ -259,7 +262,7 @@ export class ForumSyncProcessor {
           title: remoteThread.title,
           description: remoteThread.description,
           postCount: remoteThread.postCount,
-          postCountAtSync: remoteThread.postCount,
+          // postCountAtSync 不在此处推进，保留旧水位；抓帖成功后再更新，失败则下轮重试。
           pageId,
           lastSyncedAt: new Date(),
           isDeleted: false,
@@ -312,6 +315,13 @@ export class ForumSyncProcessor {
       }
 
       result.postsSynced += posts.length;
+
+      // 抓帖与落库都成功后，才把水位 postCountAtSync 推进为远端 postCount，
+      // 确保失败路径（catch）保留旧水位，下一轮增量会重试而非永久跳过。
+      await this.prisma.forumThread.update({
+        where: { id: remoteThread.id },
+        data: { postCountAtSync: remoteThread.postCount },
+      });
     } catch (err: any) {
       Logger.error(`[ForumSync]   Failed to fetch posts for thread ${remoteThread.id}: ${err.message}`);
       result.errors.push(`Posts fetch failed for thread ${remoteThread.id}: ${err.message}`);
@@ -373,22 +383,46 @@ export class ForumSyncProcessor {
     // Only attempt page-thread linking for "单页讨论" category (per-page discussions)
     // This category ID is specific to scp-wiki-cn
     if (thread.categoryId !== 675245) return null;
-    if (!thread.title) return null;
+    const title = thread.title?.trim();
+    if (!title) return null;
 
-    // In "单页讨论", thread titles usually match the page URL slug exactly
-    const slug = thread.title.toLowerCase().trim();
-    if (!slug) return null;
+    // 单页讨论的 thread.title 实为页面标题（非 URL slug）。旧实现把 title 当 slug
+    // 匹配 currentUrl，仅编号页(title==slug)能解析，约 57% 中文标题讨论帖 pageId 为 NULL。
+    // 改为按当前有效版本标题精确匹配；take:2 用于区分唯一/歧义，歧义(>1)一律返回 NULL 不猜。
 
-    // Try exact match: Page.currentUrl ends with the slug
-    const page = await this.prisma.page.findFirst({
+    // Primary: 当前版本主标题精确匹配
+    const byTitle = await this.prisma.page.findMany({
       where: {
-        currentUrl: { endsWith: `/${slug}` },
         isDeleted: false,
+        versions: { some: { validTo: null, isDeleted: false, title } },
       },
       select: { id: true },
+      take: 2,
     });
+    if (byTitle.length === 1) return byTitle[0].id;
+    if (byTitle.length > 1) return null;
 
-    return page?.id ?? null;
+    // Secondary: 当前版本副标题精确匹配
+    const byAlt = await this.prisma.page.findMany({
+      where: {
+        isDeleted: false,
+        versions: { some: { validTo: null, isDeleted: false, alternateTitle: title } },
+      },
+      select: { id: true },
+      take: 2,
+    });
+    if (byAlt.length === 1) return byAlt[0].id;
+    if (byAlt.length > 1) return null;
+
+    // Fallback: URL slug 精确匹配（覆盖标题漂移但 URL 保留的少数页面）
+    const slug = title.toLowerCase();
+    const bySlug = await this.prisma.page.findMany({
+      where: { isDeleted: false, currentUrl: { endsWith: `/${slug}` } },
+      select: { id: true },
+      take: 2,
+    });
+    if (bySlug.length === 1) return bySlug[0].id;
+    return null;
   }
 
   private async markDeletedThreads(categoryIds: number[], syncStartedAt: Date): Promise<void> {


### PR DESCRIPTION
## 目的（Phase 4A：论坛同步代码快修，止住"持续制造错误"）

修复论坛同步两处会**持续制造错误**的 bug。本 PR 只改同步代码（停止新错误），**存量数据的修复**（63 个卡住线程、约 1.8 万 NULL pageId、140 个争议链接）由后续 4C 的 dry-run 修复 CLI 完成。

## 改动

### #113 水位推进时机（postCountAtSync）
原逻辑在**抓帖之前**就把 `postCountAtSync` 推进为远端 postCount，抓帖失败只 log 不回滚 → 下一轮增量 `postCountAtSync === postCount` 判定跳过 → **约 63 个线程被永久跳过**（显示有回复实际 0 帖）。
- create 用哨兵 `postCountAtSync: 0`；update 不再推进水位（保留旧值）。
- 抓帖 + 落库都成功后才把水位推进为真实值；失败路径保留旧水位，下轮重试。

### #112 讨论帖↔页面关联（resolvePageId）
原逻辑把讨论帖 `title` 当 URL slug 匹配 `currentUrl`，仅编号页（title==slug）能解析 → **约 57% 中文标题帖 pageId 为 NULL**。
- 改为按当前有效版本 **标题 → 副标题 → slug** 三级精确匹配，每级 `take:2`，歧义（>1）一律返回 NULL 不猜。
- 只读验证：19226 个 NULL 帖中 **17996（93.6%）可唯一解析**，719 歧义 + 511 无匹配正确保持 NULL。

## 安全设计（关键）

- 同步路径**仅在 pageId 为 NULL 时解析**（NULL→resolved），**绝不覆盖已有非空链接**。
- 回归检查发现新标题匹配与现状有 **140 例（1%）不一致**——这些争议改链不在同步路径自动执行，交由后续 dry-run 修复 CLI 输出 `old/new/confidence` 人工复核。
- 存量 63 个卡住线程、17996 个可解析 NULL 的修复同样由 4C repair CLI（默认 `--dry-run` + `--no-alerts`）完成；本 PR 仅让永久路径不再制造新错误。

## 验证

- backend typecheck 通过。
- 全部解析率/回归数据均来自只读 SQL（未改任何数据）。

Refs #112 #113
