### PR TITLE
fix(analyze): full 分析默认保留 Gacha 股市 Tick，不再清空重算

### DIFF
--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -197,11 +197,12 @@ program
   .description('Calculate Wilson scores and controversy metrics')
   .option('--since <date>', 'Only analyze pages updated since date (YYYY-MM-DD)')
   .option('--full', 'Force full analysis instead of incremental')
+  .option('--rebuild-index-ticks', '危险：清空并重建 Gacha 股市指数 Tick（默认保留已有 Tick 续接生成）。会用当前公式/数据重算整段历史价格，影响存续合约参考价，仅在确需重建时使用')
   .action(async (options) => {
     // Note: --since option is not directly supported by IncrementalAnalyzeJob
     // but --full forces a complete analysis which is equivalent to the old behavior
     const forceFullAnalysis = options.full || options.since;
-    await analyzeIncremental({ forceFullAnalysis });
+    await analyzeIncremental({ forceFullAnalysis, rebuildIndexTicks: Boolean(options.rebuildIndexTicks) });
   });
 
 program

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -202,6 +202,11 @@ program
     // Note: --since option is not directly supported by IncrementalAnalyzeJob
     // but --full forces a complete analysis which is equivalent to the old behavior
     const forceFullAnalysis = options.full || options.since;
+    if (options.rebuildIndexTicks && !forceFullAnalysis) {
+      // tick 清空仅在全量重建路径(cleanAnalysisData)中执行，单独 --rebuild-index-ticks 不会生效，避免误导。
+      console.error('❌ --rebuild-index-ticks 必须配合 --full（或 --since）使用：tick 清空/重建仅在全量重建路径中执行。');
+      process.exit(1);
+    }
     await analyzeIncremental({ forceFullAnalysis, rebuildIndexTicks: Boolean(options.rebuildIndexTicks) });
   });
 

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -31,7 +31,7 @@ export class IncrementalAnalyzeJob {
   /**
    * 主分析入口点 - 增量模式
    */
-  async analyze(options: { forceFullAnalysis?: boolean; forceFullHistory?: boolean; tasks?: string[] } = {}) {
+  async analyze(options: { forceFullAnalysis?: boolean; forceFullHistory?: boolean; tasks?: string[]; rebuildIndexTicks?: boolean } = {}) {
     console.log('🔄 Starting incremental analysis...');
 
     try {
@@ -91,7 +91,7 @@ export class IncrementalAnalyzeJob {
       // 如果是强制全量分析，先清理相关分析数据
       if (options.forceFullAnalysis) {
         console.log('🧹 Cleaning analysis data for full rebuild...');
-        await this.cleanAnalysisData(tasksToRun);
+        await this.cleanAnalysisData(tasksToRun, { rebuildIndexTicks: options.rebuildIndexTicks });
       }
 
       const failedTasks: Array<{ name: string; error: unknown }> = [];
@@ -123,7 +123,7 @@ export class IncrementalAnalyzeJob {
   /**
    * 清理分析数据（用于全量重建）
    */
-  private async cleanAnalysisData(tasks: string[]) {
+  private async cleanAnalysisData(tasks: string[], opts: { rebuildIndexTicks?: boolean } = {}) {
     console.log('🗑️ Cleaning analysis data for tasks:', tasks.join(', '));
 
     for (const taskName of tasks) {
@@ -220,12 +220,23 @@ export class IncrementalAnalyzeJob {
             console.log('  ✓ Category benchmarks cache cleared');
             break;
           case 'category_index_tick':
-            await this.prisma.categoryIndexTick.deleteMany({});
-            console.log('  ✓ Category index ticks cleared');
+            // 默认保留已生成的股市 Tick：TickJob 是追加式的（从最新 tick 续接生成），
+            // 全量重算会清空整段历史价格并用当前公式/数据重算，导致存续合约参考价剧变。
+            // 仅在显式 rebuildIndexTicks 时才清空重建。
+            if (opts.rebuildIndexTicks) {
+              await this.prisma.categoryIndexTick.deleteMany({});
+              console.log('  ✓ Category index ticks cleared (rebuildIndexTicks)');
+            } else {
+              console.log('  ⏭️ Category index ticks PRESERVED (append-only resume; 用 --rebuild-index-ticks 才会清空)');
+            }
             break;
           case 'category_index_forecast':
-            await (this.prisma as any).categoryIndexForecastTick?.deleteMany?.({});
-            console.log('  ✓ Category index forecast ticks cleared');
+            if (opts.rebuildIndexTicks) {
+              await (this.prisma as any).categoryIndexForecastTick?.deleteMany?.({});
+              console.log('  ✓ Category index forecast ticks cleared (rebuildIndexTicks)');
+            } else {
+              console.log('  ⏭️ Category index forecast ticks PRESERVED');
+            }
             break;
           case 'tag_validation_cache':
             try {
@@ -2995,7 +3006,7 @@ export class IncrementalAnalyzeJob {
 /**
  * 便捷的分析入口函数
  */
-export async function analyzeIncremental(options: { forceFullAnalysis?: boolean; forceFullHistory?: boolean; tasks?: string[] } = {}) {
+export async function analyzeIncremental(options: { forceFullAnalysis?: boolean; forceFullHistory?: boolean; tasks?: string[]; rebuildIndexTicks?: boolean } = {}) {
   const job = new IncrementalAnalyzeJob();
   await job.analyze(options);
 }


### PR DESCRIPTION
## 目的：analyze full 默认保留 Gacha 股市 Tick

`analyze:full`（及生产 sync 的 `forceFullAnalysis` 路径）在清理阶段对 `category_index_tick` / `category_index_forecast` 执行 `deleteMany({})` **清空整段历史价格**，随后 `forceFullBackfill` 用**当前公式 + 当前数据**重算整段历史 → **存续合约参考价剧变**（用户已根据旧价格做过交互/交易）。

## 改动

- `CategoryIndexTickJob` 本身是**追加式**的（`run()` 从最新 tick 的 `asOfTs + 1h` 向前续接生成，`forceFullBackfill` 仅影响"无 tick 时"的回溯起点）。因此**清空并非必需**——不删除已有 tick 时，full 重算会自动续接而非重写历史。
- 把 tick / forecast 的清除改为**显式 opt-in**：仅当传 `--rebuild-index-ticks` 时才 `deleteMany` 重建；默认**保留**（续接生成）。
- 新增 CLI flag `analyze --full --rebuild-index-ticks`（带危险提示），供确需完全重建时使用。
- 生产 sync 的 `forceFullAnalysis` 路径现默认保留 Tick。

## 影响

- 默认行为变更：`analyze:full` 不再清空股市 Tick → 存续合约价格稳定。
- 其它 full 重算数据（页面/用户/日聚合等）行为不变。
- backend typecheck 通过。

## 相关诊断（另附）

排查"全品类下跌"时发现：源活动信号（投票/修订）Feb→May 大幅单调下滑（投票 −53%、修订 −90%），而不同投票者/创作者数稳定 → 疑似近期活动**捕获不全**而非真实腰斩；且投票时间戳 99.9% 为午夜（仅日期粒度）。指数公式忠实反映了这份数据。详见 PR 讨论（需进一步验证捕获完整性）。
