### PR TITLE
fix(analytics): 时区换算改为 UTC→上海，修正按日聚合错位一天 (Phase 5A)

### DIFF
--- a/bff/src/web/routes/analytics.ts
+++ b/bff/src/web/routes/analytics.ts
@@ -65,13 +65,13 @@ export function analyticsRouter(pool: Pool, redis: RedisClientType | null) {
             WHERE pv."validTo" IS NULL
           ), base AS (
             SELECT 
-              timezone('Asia/Shanghai', p."firstPublishedAt") AS local_ts,
+              ((p."firstPublishedAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai') AS local_ts,
               ${CATEGORY_CASE_SQL} AS category
             FROM "Page" p
             JOIN pv ON pv."pageId" = p.id
             WHERE p."firstPublishedAt" IS NOT NULL
-              AND ($1::date IS NULL OR (timezone('Asia/Shanghai', p."firstPublishedAt")::date >= $1::date))
-              AND ($2::date IS NULL OR (timezone('Asia/Shanghai', p."firstPublishedAt")::date <= $2::date))
+              AND ($1::date IS NULL OR (((p."firstPublishedAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai')::date >= $1::date))
+              AND ($2::date IS NULL OR (((p."firstPublishedAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai')::date <= $2::date))
           )
           SELECT category, COUNT(*)::int AS count
           FROM base
@@ -115,13 +115,13 @@ export function analyticsRouter(pool: Pool, redis: RedisClientType | null) {
           ), base AS (
             -- Use Asia/Shanghai local time for bucketing
             SELECT 
-              date_trunc($3::text, timezone('Asia/Shanghai', p."firstPublishedAt"))::date AS bucket,
+              date_trunc($3::text, ((p."firstPublishedAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai'))::date AS bucket,
               ${CATEGORY_CASE_SQL} AS category
             FROM "Page" p
             JOIN pv ON pv."pageId" = p.id
             WHERE p."firstPublishedAt" IS NOT NULL
-              AND ($1::date IS NULL OR (timezone('Asia/Shanghai', p."firstPublishedAt")::date >= $1::date))
-              AND ($2::date IS NULL OR (timezone('Asia/Shanghai', p."firstPublishedAt")::date <= $2::date))
+              AND ($1::date IS NULL OR (((p."firstPublishedAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai')::date >= $1::date))
+              AND ($2::date IS NULL OR (((p."firstPublishedAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai')::date <= $2::date))
           )
           SELECT bucket AS date, category, COUNT(*)::int AS count
           FROM base
@@ -205,12 +205,12 @@ export function analyticsRouter(pool: Pool, redis: RedisClientType | null) {
           ), base AS (
             SELECT 
               -- Use Asia/Shanghai local time for bucketing
-              date_trunc($3::text, timezone('Asia/Shanghai', p."firstPublishedAt"))::date AS bucket
+              date_trunc($3::text, ((p."firstPublishedAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai'))::date AS bucket
             FROM "Page" p
             JOIN pv ON pv."pageId" = p.id
             WHERE p."firstPublishedAt" IS NOT NULL
-              AND ($1::date IS NULL OR (timezone('Asia/Shanghai', p."firstPublishedAt")::date >= $1::date))
-             	AND ($2::date IS NULL OR (timezone('Asia/Shanghai', p."firstPublishedAt")::date <= $2::date))
+              AND ($1::date IS NULL OR (((p."firstPublishedAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai')::date >= $1::date))
+              AND ($2::date IS NULL OR (((p."firstPublishedAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai')::date <= $2::date))
               AND (
                 ($4::text = 'all' AND pv.e_tags @> $5::text[])
                 OR
@@ -303,8 +303,8 @@ export function analyticsRouter(pool: Pool, redis: RedisClientType | null) {
         FROM base b
         WHERE b.category = $1
           AND b."firstRevisionAt" IS NOT NULL
-          AND ($2::date IS NULL OR (timezone('Asia/Shanghai', b."firstRevisionAt")::date >= $2::date))
-          AND ($3::date IS NULL OR (timezone('Asia/Shanghai', b."firstRevisionAt")::date <= $3::date))
+          AND ($2::date IS NULL OR (((b."firstRevisionAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai')::date >= $2::date))
+          AND ($3::date IS NULL OR (((b."firstRevisionAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai')::date <= $3::date))
         ORDER BY 
           CASE WHEN $4 = 'rating' THEN b.rating END DESC NULLS LAST,
           CASE WHEN $4 = 'recent' THEN COALESCE(b."firstRevisionAt", b."validFrom") END DESC,
@@ -340,8 +340,8 @@ export function analyticsRouter(pool: Pool, redis: RedisClientType | null) {
         FROM base b
         WHERE b.category = $1
           AND b."firstRevisionAt" IS NOT NULL
-          AND ($2::date IS NULL OR (timezone('Asia/Shanghai', b."firstRevisionAt")::date >= $2::date))
-          AND ($3::date IS NULL OR (timezone('Asia/Shanghai', b."firstRevisionAt")::date <= $3::date))
+          AND ($2::date IS NULL OR (((b."firstRevisionAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai')::date >= $2::date))
+          AND ($3::date IS NULL OR (((b."firstRevisionAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai')::date <= $3::date))
       `;
 
       const params = [category, startDate || null, endDate || null, normalizedOrder, limitInt, offsetInt];


### PR DESCRIPTION
## 目的（Phase 5A：时区 fix-forward，低风险纯读查询）

修复 `analytics` 路由按日聚合/日期过滤**整体错位一天**（#119）。

## 根因

`timezone('Asia/Shanghai', X)`（X 为 `timestamp without time zone` 存的 UTC 值）= `X AT TIME ZONE 'Asia/Shanghai'`，单参数形式作用于 naive 值是**"假定它就是上海时间"**，方向反了。要把 UTC 转上海必须先声明它是 UTC：`(X AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai'`。

## 改动

- 13 处 `timezone('Asia/Shanghai', p."firstPublishedAt" / b."firstRevisionAt")` → `((... AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai')`。

## 验证

- bff typecheck 通过。
- 只读实测：34,982 个页面中 **5,562（16%）** 被原表达式分到错误本地日；样本 UTC `2026-05-31 22:59:51` 原归 `05-31`，修复后正确归 `06-01`。
- 纯读查询 fix-forward，无数据变更、无 schema 变更，部署即生效。

## 边界

- 本 PR 仅修 `analytics.ts`。`stats.ts` 日活、`pages.ts` 投票日界仍是 UTC 口径；后端日聚合表（PageDailyStats 等）的时区统一需配合数据重算，留待后续 5A-extended + 5D 协调批次。

Refs #119
