### PR TITLE
feat(social): 标签偏好/粉丝统计纳入已删除页面 + 入库排除原创标签

### DIFF
--- a/backend/src/cli/repair-user-vote-stats.ts
+++ b/backend/src/cli/repair-user-vote-stats.ts
@@ -47,18 +47,18 @@ async function dryRunTagPreferences(prisma: PrismaClient) {
         lupv.timestamp
       FROM latest_user_page_votes lupv
       JOIN LATERAL (
-        SELECT pv2.tags, pv2."isDeleted"
+        -- 纳入已删除页面：取最后一个【未删除】版本的标签（当前未删优先，否则历史末个未删版本）
+        SELECT pv2.tags
         FROM "PageVersion" pv2
         WHERE pv2."pageId" = lupv."pageId"
+          AND pv2."isDeleted" = false
         ORDER BY
           (pv2."validTo" IS NULL) DESC,
-          (NOT pv2."isDeleted") DESC,
           pv2."validFrom" DESC NULLS LAST,
           pv2.id DESC
         LIMIT 1
       ) pv_pick ON TRUE
-      WHERE pv_pick."isDeleted" = false
-        AND pv_pick.tags IS NOT NULL
+      WHERE pv_pick.tags IS NOT NULL
         AND array_length(pv_pick.tags, 1) > 0
     ),
     recomputed AS (
@@ -69,7 +69,7 @@ async function dryRunTagPreferences(prisma: PrismaClient) {
         COUNT(*) FILTER (WHERE direction < 0)::int AS downvote_count,
         COUNT(*)::int AS total_votes
       FROM user_tag_votes
-      WHERE tag NOT IN ('页面', '重定向', '管理', '_cc')
+      WHERE tag NOT IN ('原创', '页面', '重定向', '管理', '_cc')
       GROUP BY "userId", tag
       HAVING COUNT(*) >= 3
     ),
@@ -157,19 +157,19 @@ async function dryRunVoteInteractions(prisma: PrismaClient) {
         lupv.direction
       FROM latest_user_page_votes lupv
       JOIN LATERAL (
-        SELECT pv2.id, pv2."isDeleted"
+        -- 纳入已删除页面：取最后一个【未删除】版本做作者映射（当前未删优先，否则历史末个未删版本）
+        SELECT pv2.id
         FROM "PageVersion" pv2
         WHERE pv2."pageId" = lupv.page_id
+          AND pv2."isDeleted" = false
         ORDER BY
           (pv2."validTo" IS NULL) DESC,
-          (NOT pv2."isDeleted") DESC,
           pv2."validFrom" DESC NULLS LAST,
           pv2.id DESC
         LIMIT 1
       ) pv_pick ON TRUE
       JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
       WHERE lupv.from_user_id != a."userId"
-        AND pv_pick."isDeleted" = false
     ),
     recomputed AS (
       SELECT

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -1253,18 +1253,18 @@ export class IncrementalAnalyzeJob {
           lupv.timestamp
         FROM latest_user_page_votes lupv
         JOIN LATERAL (
-          SELECT pv2.tags, pv2."isDeleted"
+          -- 纳入已删除页面：取最后一个【未删除】版本的标签（当前未删优先，否则历史末个未删版本）
+          SELECT pv2.tags
           FROM "PageVersion" pv2
           WHERE pv2."pageId" = lupv."pageId"
+            AND pv2."isDeleted" = false
           ORDER BY
             (pv2."validTo" IS NULL) DESC,
-            (NOT pv2."isDeleted") DESC,
             pv2."validFrom" DESC NULLS LAST,
             pv2.id DESC
           LIMIT 1
         ) pv_pick ON TRUE
-        WHERE pv_pick."isDeleted" = false
-          AND pv_pick.tags IS NOT NULL
+        WHERE pv_pick.tags IS NOT NULL
           AND array_length(pv_pick.tags, 1) > 0
       ),
       tag_stats AS (
@@ -1276,7 +1276,7 @@ export class IncrementalAnalyzeJob {
           COUNT(*) as total_votes,
           MAX(timestamp) as last_vote_at
         FROM user_tag_votes
-        WHERE tag NOT IN ('页面', '重定向', '管理', '_cc')
+        WHERE tag NOT IN ('原创', '页面', '重定向', '管理', '_cc')
         GROUP BY "userId", tag
         HAVING COUNT(*) >= 3
       )
@@ -1349,19 +1349,19 @@ export class IncrementalAnalyzeJob {
           lupv.timestamp
         FROM latest_user_page_votes lupv
         JOIN LATERAL (
-          SELECT pv2.id, pv2."isDeleted"
+          -- 纳入已删除页面：取最后一个【未删除】版本做作者映射（当前未删优先，否则历史末个未删版本）
+          SELECT pv2.id
           FROM "PageVersion" pv2
           WHERE pv2."pageId" = lupv.page_id
+            AND pv2."isDeleted" = false
           ORDER BY
             (pv2."validTo" IS NULL) DESC,
-            (NOT pv2."isDeleted") DESC,
             pv2."validFrom" DESC NULLS LAST,
             pv2.id DESC
           LIMIT 1
         ) pv_pick ON TRUE
         JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
         WHERE lupv.from_user_id != a."userId"
-          AND pv_pick."isDeleted" = false
       ),
       interaction_stats AS (
         SELECT 

--- a/backend/src/jobs/UserSocialAnalysisJob.ts
+++ b/backend/src/jobs/UserSocialAnalysisJob.ts
@@ -106,18 +106,19 @@ export class UserSocialAnalysisJob {
             lupv.timestamp
           FROM latest_user_page_votes lupv
           JOIN LATERAL (
-            SELECT pv2.tags, pv2."isDeleted"
+            -- 纳入已删除页面：取最后一个【未删除】版本的标签（当前未删优先，否则历史末个未删版本）。
+            -- 全版本皆删的页面 LATERAL 返回空行，被 INNER JOIN 自然排除。
+            SELECT pv2.tags
             FROM "PageVersion" pv2
             WHERE pv2."pageId" = lupv."pageId"
+              AND pv2."isDeleted" = false
             ORDER BY
               (pv2."validTo" IS NULL) DESC,
-              (NOT pv2."isDeleted") DESC,
               pv2."validFrom" DESC NULLS LAST,
               pv2.id DESC
             LIMIT 1
           ) pv_pick ON TRUE
-          WHERE pv_pick."isDeleted" = false
-            AND pv_pick.tags IS NOT NULL
+          WHERE pv_pick.tags IS NOT NULL
             AND array_length(pv_pick.tags, 1) > 0
         ),
         tag_stats AS (
@@ -129,7 +130,7 @@ export class UserSocialAnalysisJob {
             COUNT(*) as total_votes,
             MAX(timestamp) as last_vote_at
           FROM user_tag_votes
-          WHERE tag NOT IN ('页面', '重定向', '管理', '_cc')
+          WHERE tag NOT IN ('原创', '页面', '重定向', '管理', '_cc')
           GROUP BY "userId", tag
           HAVING COUNT(*) >= 3  -- 至少投过3次票的标签才记录
         )
@@ -206,18 +207,19 @@ export class UserSocialAnalysisJob {
             lupv.timestamp
           FROM latest_user_page_votes lupv
           JOIN LATERAL (
-            SELECT pv2.tags, pv2."isDeleted"
+            -- 纳入已删除页面：取最后一个【未删除】版本的标签（当前未删优先，否则历史末个未删版本）。
+            -- 全版本皆删的页面 LATERAL 返回空行，被 INNER JOIN 自然排除。
+            SELECT pv2.tags
             FROM "PageVersion" pv2
             WHERE pv2."pageId" = lupv."pageId"
+              AND pv2."isDeleted" = false
             ORDER BY
               (pv2."validTo" IS NULL) DESC,
-              (NOT pv2."isDeleted") DESC,
               pv2."validFrom" DESC NULLS LAST,
               pv2.id DESC
             LIMIT 1
           ) pv_pick ON TRUE
-          WHERE pv_pick."isDeleted" = false
-            AND pv_pick.tags IS NOT NULL
+          WHERE pv_pick.tags IS NOT NULL
             AND array_length(pv_pick.tags, 1) > 0
         ),
         tag_stats AS (
@@ -229,7 +231,7 @@ export class UserSocialAnalysisJob {
             COUNT(*) as total_votes,
             MAX(timestamp) as last_vote_at
           FROM user_tag_votes
-          WHERE tag NOT IN ('页面', '重定向', '管理', '_cc')
+          WHERE tag NOT IN ('原创', '页面', '重定向', '管理', '_cc')
           GROUP BY "userId", tag
           HAVING COUNT(*) >= 3
         )
@@ -339,12 +341,13 @@ export class UserSocialAnalysisJob {
             lupv.timestamp
           FROM latest_user_page_votes lupv
           JOIN LATERAL (
-            SELECT pv2.id, pv2."isDeleted"
+            -- 纳入已删除页面：取最后一个【未删除】版本做作者映射（当前未删优先，否则历史末个未删版本）
+            SELECT pv2.id
             FROM "PageVersion" pv2
             WHERE pv2."pageId" = lupv.page_id
+              AND pv2."isDeleted" = false
             ORDER BY
               (pv2."validTo" IS NULL) DESC,
-              (NOT pv2."isDeleted") DESC,
               pv2."validFrom" DESC NULLS LAST,
               pv2.id DESC
             LIMIT 1
@@ -352,7 +355,6 @@ export class UserSocialAnalysisJob {
           JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
           JOIN pair_list pl ON pl.from_user_id = lupv.from_user_id AND pl.to_user_id = a."userId"
           WHERE lupv.from_user_id != a."userId"
-            AND pv_pick."isDeleted" = false
         ),
         interaction_stats AS (
           SELECT
@@ -453,19 +455,19 @@ export class UserSocialAnalysisJob {
             lupv.timestamp
           FROM latest_user_page_votes lupv
           JOIN LATERAL (
-            SELECT pv2.id, pv2."isDeleted"
+            -- 纳入已删除页面：取最后一个【未删除】版本做作者映射（当前未删优先，否则历史末个未删版本）
+            SELECT pv2.id
             FROM "PageVersion" pv2
             WHERE pv2."pageId" = lupv.page_id
+              AND pv2."isDeleted" = false
             ORDER BY
               (pv2."validTo" IS NULL) DESC,
-              (NOT pv2."isDeleted") DESC,
               pv2."validFrom" DESC NULLS LAST,
               pv2.id DESC
             LIMIT 1
           ) pv_pick ON TRUE
           JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
           WHERE lupv.from_user_id != a."userId"
-            AND pv_pick."isDeleted" = false
         ),
         interaction_stats AS (
           SELECT
@@ -584,19 +586,19 @@ export class UserSocialAnalysisJob {
           a."userId" as "toUserId"
         FROM latest_user_page_votes lupv
         JOIN LATERAL (
-          SELECT pv2.id, pv2."isDeleted"
+          -- 纳入已删除页面：取最后一个【未删除】版本做作者映射
+          SELECT pv2.id
           FROM "PageVersion" pv2
           WHERE pv2."pageId" = lupv.page_id
+            AND pv2."isDeleted" = false
           ORDER BY
             (pv2."validTo" IS NULL) DESC,
-            (NOT pv2."isDeleted") DESC,
             pv2."validFrom" DESC NULLS LAST,
             pv2.id DESC
           LIMIT 1
         ) pv_pick ON TRUE
         JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
         WHERE lupv.from_user_id != a."userId"
-          AND pv_pick."isDeleted" = false
         ORDER BY lupv.from_user_id, a."userId"
       `;
     } else {
@@ -620,12 +622,13 @@ export class UserSocialAnalysisJob {
           FROM "Vote" v
           JOIN "PageVersion" vote_pv ON vote_pv.id = v."pageVersionId"
           JOIN LATERAL (
-            SELECT pv2.id, pv2."isDeleted"
+            -- 纳入已删除页面：取最后一个【未删除】版本做作者映射
+            SELECT pv2.id
             FROM "PageVersion" pv2
             WHERE pv2."pageId" = vote_pv."pageId"
+              AND pv2."isDeleted" = false
             ORDER BY
               (pv2."validTo" IS NULL) DESC,
-              (NOT pv2."isDeleted") DESC,
               pv2."validFrom" DESC NULLS LAST,
               pv2.id DESC
             LIMIT 1
@@ -633,7 +636,6 @@ export class UserSocialAnalysisJob {
           JOIN effective_attributions a ON a."pageVerId" = pv_pick.id
           WHERE v."userId" IS NOT NULL
             AND v."userId" != a."userId"
-            AND pv_pick."isDeleted" = false
             AND v.timestamp >= NOW() - INTERVAL '7 days'
         ),
         outdated_interactions AS (


### PR DESCRIPTION
## 目的（产品决策：偏好/粉丝统计纳入已删除页面）

此前 UTP（标签偏好）/ UVI（粉丝/互投）用 LATERAL re-pick + `pv_pick.isDeleted=false` **整页排除当前版本已删除的页面**，而 votesCast 不排除 → 口径割裂（DVA24 域差 94 票；全站 150,971 票 / 11,438 用户）。本 PR 让 UTP/UVI 也纳入删除页，统一口径。

## 改动

- **删除页纳入**（8 处 LATERAL）：re-pick 改为在 LATERAL 内 `WHERE pv2.isDeleted=false` 过滤，取「当前未删优先、否则最后一个历史未删版本」。删除页用其**最后未删版本的真实标签/归属**计入；全版本皆删的页 LATERAL 空行 → INNER JOIN 自然排除。
  - `UserSocialAnalysisJob.ts`：UTP 增量+全量、UVI 增量+全量、pair-selection 全量+增量
  - `IncrementalAnalyzeJob.ts`：内嵌 UTP + UVI
  - `repair-user-vote-stats.ts`：dry-run 的 UTP + UVI 副本（保证预估一致）
- **原创标签入库排除**：stopword 加 `'原创'`（USA×2 + IAJ + repair CLI），修复 UTP 表合计(69014) vs `/relations/tags` 实际服务(56020) 的不一致。
- **不在范围**：`votes_received`（UserRatingJob / repair 的 pv3 块）保持不动（用户只选了 UTP+UVI，未选 votesCast/收到票对齐）。
- **BFF `users.ts:1334` 的 `tag<>'原创'` 展示过滤暂留**：重算后无原创行，该过滤变无操作；现在删会在"部署后-重算前"过渡期短暂露出旧原创行，故留待重算后再清理。

## 验证

- backend typecheck 通过。
- 只读验证（DVA24, id=14130）：去重非零投票页 15532；旧口径解析 15438；**新口径 15532（+94 删除页全部纳入）**；删除页恢复出真实标签（`故事`/`creepypasta`/`crossover项目` 等）。

## 部署后必做

- 全量 social 重算（`repair-user-vote-stats --social-only`，会走改后的 `UserSocialAnalysisJob`），回填历史删除页 + 移除原创行。预期 UTP/UVI 行数与票数上升（删除页纳入），UTP 因原创排除抵消一部分。

Refs #89
