### PR TITLE
fix(user-backend): 精简 pino 日志 + Tokio 线程数 + 全局异常兜底 (5B, 关 #122/#123/#127)

### DIFF
--- a/user-backend/ecosystem.config.cjs
+++ b/user-backend/ecosystem.config.cjs
@@ -11,6 +11,9 @@ module.exports = {
       max_memory_restart: '1G',
       env: {
         NODE_ENV: 'production',
+        // 限制 Prisma 查询引擎(Rust/Tokio)在高核数机器上拉起的 worker 线程数，
+        // 默认按 CPU 核数(本机 56 核)拉起 ~56 线程，空闲即占用约 700MB+。
+        TOKIO_WORKER_THREADS: process.env.TOKIO_WORKER_THREADS || '8',
         USER_BACKEND_PORT: process.env.USER_BACKEND_PORT || '4455',
         USER_DATABASE_URL: process.env.USER_DATABASE_URL,
         MAIL_AGENT_BASE_URL: process.env.MAIL_AGENT_BASE_URL || 'http://127.0.0.1:3110',

--- a/user-backend/src/app.ts
+++ b/user-backend/src/app.ts
@@ -29,6 +29,13 @@ export function createApp() {
     autoLogging: {
       ignore: (req) => req.url === '/healthz'
     },
+    // 精简请求/响应日志：只记 method/url/远端地址 + 状态码，不落盘完整 header。
+    // 默认 serializer 会把每个请求的全部 header 写入，导致 out 日志数小时打满数十 MB。
+    serializers: {
+      req: (req) => ({ id: req.id, method: req.method, url: req.url, remoteAddress: req.remoteAddress }),
+      res: (res) => ({ statusCode: res.statusCode })
+    },
+    // 防御性保留：即使将来 serializer 改回包含 header，也不落盘敏感字段。
     redact: {
       paths: [
         'req.headers.authorization',

--- a/user-backend/src/server.ts
+++ b/user-backend/src/server.ts
@@ -25,7 +25,10 @@ async function main() {
   buyReqTimer.unref();
   marketTimer.unref();
 
-  const shutdown = (signal: string) => {
+  let isShuttingDown = false;
+  const shutdown = (signal: string, exitCode = 0) => {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
     // eslint-disable-next-line no-console
     console.log(`Received ${signal}, shutting down...`);
     clearInterval(tradeTimer);
@@ -35,7 +38,7 @@ async function main() {
     const forceTimer = setTimeout(() => {
       // eslint-disable-next-line no-console
       console.error('Graceful shutdown timed out after 10s, forcing exit');
-      process.exit(1);
+      process.exit(exitCode || 1);
     }, 10_000);
     forceTimer.unref();
 
@@ -51,13 +54,25 @@ async function main() {
         })
         .finally(() => {
           clearTimeout(forceTimer);
-          process.exit(err ? 1 : 0);
+          process.exit(err ? 1 : exitCode);
         });
     });
   };
 
   process.on('SIGINT', () => void shutdown('SIGINT'));
   process.on('SIGTERM', () => void shutdown('SIGTERM'));
+
+  // 全局兜底：未处理的 Promise rejection 仅记录(不退出,避免单个失败拖垮服务)；
+  // 未捕获异常视为进程已处于不可知状态，记录后优雅关闭(由 PM2 拉起新进程)。
+  process.on('unhandledRejection', (reason) => {
+    // eslint-disable-next-line no-console
+    console.error('[user-backend] Unhandled promise rejection:', reason);
+  });
+  process.on('uncaughtException', (err) => {
+    // eslint-disable-next-line no-console
+    console.error('[user-backend] Uncaught exception, shutting down:', err);
+    void shutdown('uncaughtException', 1);
+  });
 }
 
 main().catch(async (error) => {


### PR DESCRIPTION
## 目的（Phase 5B：user-backend 服务健康，关 #122 #123 #127）

修复 user-backend 的日志膨胀 / 高内存 / 缺兜底（对应早期发现的 288 重启 / ~700MB）。

## 改动

- **#122 pino 日志精简**：`pinoHttp` 加自定义 serializer，只记 `method/url/remoteAddress + statusCode`，**不再落盘完整 header**（原默认 serializer 把每请求全部 header 写入，out 日志数小时打满数十 MB）。保留 redact 作防御。
- **#123 Tokio 线程数**：`ecosystem.config.cjs` 加 `TOKIO_WORKER_THREADS=8`，限制 Prisma 查询引擎(Rust/Tokio)在 56 核机上的 worker 线程数（默认按核数拉 ~56 线程，空闲即占 ~700MB+，逼近重启阈值）。
- **#127 全局异常兜底**：`server.ts` 加 `unhandledRejection`（仅记录，不退出）/ `uncaughtException`（记录后走既有 `shutdown()` 优雅关闭，由 PM2 拉起）。

## 验证

- user-backend typecheck 通过。
- 部署：需 rebuild user-backend + `pm2 restart scpper-user-backend`（ecosystem 的 TOKIO_WORKER_THREADS 需 `pm2 restart --update-env` 或 delete+start 生效）。

Refs #122 #123 #127
