### PR TITLE
feat(forum): repair-forum-stuck-threads 重抓卡住线程 (4C-2, 关 #113)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "query:rankings": "node --import tsx/esm src/cli/index.ts query --user-rank",
     "repair:user-vote-stats": "node --import tsx/esm src/cli/index.ts repair-user-vote-stats",
     "repair:forum-page-links": "node --import tsx/esm src/cli/index.ts repair-forum-page-links",
+    "repair:forum-stuck-threads": "node --import tsx/esm src/cli/index.ts repair-forum-stuck-threads",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy",

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -30,6 +30,7 @@ import { runVoteResyncAudit } from './voteResyncAudit.js';
 import { runVoteTzDupCleanup } from './voteTzDupCleanup.js';
 import { runRepairUserVoteStats } from './repair-user-vote-stats.js';
 import { runRepairForumPageLinks } from './repair-forum-page-links.js';
+import { runRepairForumStuckThreads } from './repair-forum-stuck-threads.js';
 
 const program = new Command();
 
@@ -241,6 +242,19 @@ program
     const prisma = getPrismaClient();
     try {
       await runRepairForumPageLinks(prisma, { apply: Boolean(options.apply) });
+    } finally {
+      await disconnectPrisma();
+    }
+  });
+
+program
+  .command('repair-forum-stuck-threads')
+  .description('定向重抓"有帖实际0帖"的卡住线程(#113;不触发提醒;默认 dry-run,--apply 才联网重抓)')
+  .option('--apply', '实际联网重抓并落库(默认仅 dry-run 列出,不联网)')
+  .action(async (options) => {
+    const prisma = getPrismaClient();
+    try {
+      await runRepairForumStuckThreads(prisma, { apply: Boolean(options.apply) });
     } finally {
       await disconnectPrisma();
     }

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -255,12 +255,20 @@ program
   .action(async (options) => {
     const prisma = getPrismaClient();
     try {
-      const threadIds = options.threads
-        ? String(options.threads)
-            .split(',')
-            .map((s: string) => Number.parseInt(s.trim(), 10))
-            .filter((n: number) => Number.isInteger(n) && n > 0)
-        : undefined;
+      let threadIds: number[] | undefined;
+      if (options.threads !== undefined) {
+        // 显式传了 --threads：解析为空(非法/全过滤)必须报错退出,绝不回退到自动检测,
+        // 否则 `--threads abc --apply` 会从"精确重试"误变成"apply 所有检测命中的线程"。
+        threadIds = String(options.threads)
+          .split(',')
+          .map((s: string) => Number.parseInt(s.trim(), 10))
+          .filter((n: number) => Number.isInteger(n) && n > 0);
+        if (threadIds.length === 0) {
+          console.error('--threads 未解析出有效 thread id(应为逗号分隔的正整数)。已中止。');
+          process.exitCode = 1;
+          return;
+        }
+      }
       await runRepairForumStuckThreads(prisma, { apply: Boolean(options.apply), threadIds });
     } finally {
       await disconnectPrisma();

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -251,10 +251,17 @@ program
   .command('repair-forum-stuck-threads')
   .description('定向重抓"有帖实际0帖"的卡住线程(#113;不触发提醒;默认 dry-run,--apply 才联网重抓)')
   .option('--apply', '实际联网重抓并落库(默认仅 dry-run 列出,不联网)')
+  .option('--threads <ids>', '逗号分隔的 thread id,直接重抓这些线程(绕过自动检测,用于精确重试失败线程)')
   .action(async (options) => {
     const prisma = getPrismaClient();
     try {
-      await runRepairForumStuckThreads(prisma, { apply: Boolean(options.apply) });
+      const threadIds = options.threads
+        ? String(options.threads)
+            .split(',')
+            .map((s: string) => Number.parseInt(s.trim(), 10))
+            .filter((n: number) => Number.isInteger(n) && n > 0)
+        : undefined;
+      await runRepairForumStuckThreads(prisma, { apply: Boolean(options.apply), threadIds });
     } finally {
       await disconnectPrisma();
     }

--- a/backend/src/cli/repair-forum-stuck-threads.ts
+++ b/backend/src/cli/repair-forum-stuck-threads.ts
@@ -7,27 +7,35 @@ import { ForumSyncProcessor } from '../core/processors/ForumSyncProcessor.js';
  * - 复用 ForumSyncProcessor.resyncThreads：连接 → getPosts → upsertPost → 推进水位。
  * - 【不触发任何论坛提醒】(不喂 newPostIds 给 ForumInteractionAlertJob)。
  * - 默认 dry-run(只列出,不联网)；需显式 apply=true 才网络重抓。
+ * - 自动检测口径刻意收窄为"本地 0 帖"(审计确认的 63 个卡住线程签名)，避免把"有已删帖
+ *   的健康线程"误判为卡住而反复重抓；失败线程的 id 会逐条打印，可用 threadIds 精确重试。
  */
 export async function runRepairForumStuckThreads(
   prisma: PrismaClient,
-  opts: { apply?: boolean } = {}
+  opts: { apply?: boolean; threadIds?: number[] } = {}
 ): Promise<void> {
   const apply = Boolean(opts.apply);
   console.log(apply ? '🔧 APPLY: 网络重抓卡住线程并落库' : '🔍 DRY RUN: 仅列出卡住线程,不重抓(加 --apply 执行)');
 
-  const rows = await prisma.$queryRaw<Array<{ id: number }>>`
-    SELECT t.id
-    FROM "ForumThread" t
-    WHERE t."postCount" > 0
-      AND t."isDeleted" = false
-      AND t."postCountAtSync" = t."postCount"
-      AND NOT EXISTS (
-        SELECT 1 FROM "ForumPost" p WHERE p."threadId" = t.id AND p."isDeleted" = false
-      )
-    ORDER BY t.id
-  `;
-  const ids = rows.map((r) => Number(r.id));
-  console.log(`卡住线程(postCount>0 但本地 0 帖且会被增量跳过): ${ids.length}`);
+  let ids: number[];
+  if (opts.threadIds && opts.threadIds.length > 0) {
+    ids = Array.from(new Set(opts.threadIds)).sort((a, b) => a - b);
+    console.log(`显式指定 thread id(绕过自动检测): ${ids.length}`);
+  } else {
+    const rows = await prisma.$queryRaw<Array<{ id: number }>>`
+      SELECT t.id
+      FROM "ForumThread" t
+      WHERE t."postCount" > 0
+        AND t."isDeleted" = false
+        AND t."postCountAtSync" = t."postCount"
+        AND NOT EXISTS (
+          SELECT 1 FROM "ForumPost" p WHERE p."threadId" = t.id AND p."isDeleted" = false
+        )
+      ORDER BY t.id
+    `;
+    ids = rows.map((r) => Number(r.id));
+    console.log(`卡住线程(postCount>0 但本地 0 帖且会被增量跳过): ${ids.length}`);
+  }
   if (ids.length === 0) {
     console.log('无卡住线程,无需处理。');
     return;

--- a/backend/src/cli/repair-forum-stuck-threads.ts
+++ b/backend/src/cli/repair-forum-stuck-threads.ts
@@ -1,0 +1,47 @@
+import type { PrismaClient } from '@prisma/client';
+import { ForumSyncProcessor } from '../core/processors/ForumSyncProcessor.js';
+
+/**
+ * 修复"卡住线程"(#113)：历史抓帖失败但水位 postCountAtSync 已推进到 postCount，
+ * 导致增量同步永久跳过、显示有帖实际 0 帖。本 CLI 定向网络重抓这些线程的帖子。
+ * - 复用 ForumSyncProcessor.resyncThreads：连接 → getPosts → upsertPost → 推进水位。
+ * - 【不触发任何论坛提醒】(不喂 newPostIds 给 ForumInteractionAlertJob)。
+ * - 默认 dry-run(只列出,不联网)；需显式 apply=true 才网络重抓。
+ */
+export async function runRepairForumStuckThreads(
+  prisma: PrismaClient,
+  opts: { apply?: boolean } = {}
+): Promise<void> {
+  const apply = Boolean(opts.apply);
+  console.log(apply ? '🔧 APPLY: 网络重抓卡住线程并落库' : '🔍 DRY RUN: 仅列出卡住线程,不重抓(加 --apply 执行)');
+
+  const rows = await prisma.$queryRaw<Array<{ id: number }>>`
+    SELECT t.id
+    FROM "ForumThread" t
+    WHERE t."postCount" > 0
+      AND t."isDeleted" = false
+      AND t."postCountAtSync" = t."postCount"
+      AND NOT EXISTS (
+        SELECT 1 FROM "ForumPost" p WHERE p."threadId" = t.id AND p."isDeleted" = false
+      )
+    ORDER BY t.id
+  `;
+  const ids = rows.map((r) => Number(r.id));
+  console.log(`卡住线程(postCount>0 但本地 0 帖且会被增量跳过): ${ids.length}`);
+  if (ids.length === 0) {
+    console.log('无卡住线程,无需处理。');
+    return;
+  }
+  console.log('样本 id(最多 20):', ids.slice(0, 20).join(', '));
+
+  if (!apply) {
+    console.log('DRY RUN: 未重抓(加 --apply 执行网络重抓)。');
+    return;
+  }
+
+  const processor = new ForumSyncProcessor({ dryRun: false });
+  const summary = await processor.resyncThreads(ids);
+  console.log(
+    `✓ 完成:重抓 ${summary.succeeded}/${summary.threads} 线程,落库 ${summary.postsUpserted} 帖,失败 ${summary.failed}。`
+  );
+}

--- a/backend/src/core/processors/ForumSyncProcessor.ts
+++ b/backend/src/core/processors/ForumSyncProcessor.ts
@@ -148,6 +148,49 @@ export class ForumSyncProcessor {
     return result;
   }
 
+  /**
+   * 定向重抓指定 thread 的帖子（修复历史抓帖失败导致"有帖实际0帖"的卡住线程，#113）。
+   * 复用同步的 client + upsertPost，但【不收集 newPostIds、不触发任何论坛提醒】
+   * （ForumInteractionAlertJob 只处理显式传入的 newPostIds，本路径不喂它，故旧帖不会误触发提醒）。
+   * 成功后把 postCount/postCountAtSync 推进为实际抓到的帖数，使线程内部一致并不再被增量跳过。
+   */
+  async resyncThreads(
+    threadIds: number[]
+  ): Promise<{ threads: number; succeeded: number; failed: number; postsUpserted: number }> {
+    const summary = { threads: threadIds.length, succeeded: 0, failed: 0, postsUpserted: 0 };
+    if (threadIds.length === 0) return summary;
+
+    await this.client.connect();
+    try {
+      for (const threadId of threadIds) {
+        try {
+          const posts = await this.client.getPosts(threadId);
+          for (const post of posts) {
+            await this.upsertPost(threadId, post);
+            summary.postsUpserted++;
+          }
+          await this.prisma.forumThread.update({
+            where: { id: threadId },
+            data: {
+              postCount: posts.length,
+              postCountAtSync: posts.length,
+              lastSyncedAt: new Date(),
+            },
+          });
+          summary.succeeded++;
+          Logger.info(`[ForumResync] thread ${threadId}: 重抓 ${posts.length} 帖,已落库`);
+        } catch (err: any) {
+          summary.failed++;
+          Logger.error(`[ForumResync] thread ${threadId} 重抓失败: ${err.message}`);
+        }
+        await this.client.delay();
+      }
+    } finally {
+      await this.client.close();
+    }
+    return summary;
+  }
+
   private async processCategory(
     remoteCat: ForumCategoryDTO,
     rawCatObj: any,

--- a/backend/src/core/processors/ForumSyncProcessor.ts
+++ b/backend/src/core/processors/ForumSyncProcessor.ts
@@ -160,8 +160,10 @@ export class ForumSyncProcessor {
     const summary = { threads: threadIds.length, succeeded: 0, failed: 0, postsUpserted: 0 };
     if (threadIds.length === 0) return summary;
 
-    await this.client.connect();
+    // 与主同步流程一致：联网前装载论坛代理/IP 池（FORUM_HTTP_PROXY 未配置时为安全空操作）。
+    WikidotForumClient.setupProxy();
     try {
+      await this.client.connect();
       for (const threadId of threadIds) {
         try {
           const posts = await this.client.getPosts(threadId);


### PR DESCRIPTION
## 目的（Phase 4C-2：重抓卡住线程，关闭 #113）

#131 已部署的水位修复阻止了**新**卡住，但**存量 63 个**线程（抓帖失败但 postCountAtSync 已推进到 postCount，被增量永久跳过，显示有帖实际 0 帖）需要一次性重抓。

## 改动

- **`ForumSyncProcessor.resyncThreads(threadIds)`**（public）：复用 `client.connect/getPosts/close` + `upsertPost`，逐线程重抓帖子并落库，成功后把 `postCount/postCountAtSync` 推进为实际抓到的帖数（使线程内部一致、不再被增量跳过）。
- **提醒安全**：本路径**不收集 newPostIds、不调用 ForumInteractionAlertJob**。该 job 只处理显式传入的 `newPostIds`，故重抓的旧帖**不会误触发"回复提醒"**（避免给用户推送一年前的旧帖）。
- **新增 CLI `repair-forum-stuck-threads`**：DB 查卡住线程（postCount>0 且本地 0 帖且会被跳过），**默认 dry-run**（只列出，不联网），`--apply` 才联网重抓。

## 验证

- backend typecheck 通过。
- 识别查询命中 **63** 个卡住线程（与审计一致）。
- dry-run 不联网；`--apply` 的网络重抓在部署后执行验证。

## 部署后

- `npm run repair:forum-stuck-threads`（dry-run 列出）→ `-- --apply`（联网重抓）→ 验证这些线程现有帖、postCountAtSync 一致 → 关闭 #113。
- 注：若部分线程在 Wikidot 上确已空/删除，重抓得 0 帖，postCount 会被校正为 0（一致）。

Refs #113
