### PR TITLE
fix(forum): resyncThreads 对 no_thread 标记 isDeleted (收尾 #113)

### DIFF
--- a/backend/src/cli/repair-forum-stuck-threads.ts
+++ b/backend/src/cli/repair-forum-stuck-threads.ts
@@ -50,6 +50,7 @@ export async function runRepairForumStuckThreads(
   const processor = new ForumSyncProcessor({ dryRun: false });
   const summary = await processor.resyncThreads(ids);
   console.log(
-    `✓ 完成:重抓 ${summary.succeeded}/${summary.threads} 线程,落库 ${summary.postsUpserted} 帖,失败 ${summary.failed}。`
+    `✓ 完成:重抓 ${summary.succeeded}/${summary.threads} 线程,落库 ${summary.postsUpserted} 帖,` +
+    `远端已删除 ${summary.remoteDeleted}(标记 isDeleted),失败 ${summary.failed}。`
   );
 }

--- a/backend/src/core/processors/ForumSyncProcessor.ts
+++ b/backend/src/core/processors/ForumSyncProcessor.ts
@@ -187,12 +187,19 @@ export class ForumSyncProcessor {
           // 远端返回 no_thread：线程在 Wikidot 已删除（页面被删/重建致旧 thread id 失效）。
           // 本地 0 帖即真实状态，标记 isDeleted=true 让其退出卡住检测，不再当作可重试失败。
           if (/no_thread/i.test(String(err?.message ?? ''))) {
-            await this.prisma.forumThread.update({
-              where: { id: threadId },
-              data: { isDeleted: true, lastSyncedAt: new Date() },
-            });
-            summary.remoteDeleted++;
-            Logger.warn(`[ForumResync] thread ${threadId} 远端已删除(no_thread),标记 isDeleted=true`);
+            // update 本身失败(如 --threads 传入本地不存在的 id 触发 P2025)只计入该线程,
+            // 不让异常冒出 catch 中断整批(catch 体抛出不会被同一 try 捕获)。
+            try {
+              await this.prisma.forumThread.update({
+                where: { id: threadId },
+                data: { isDeleted: true, lastSyncedAt: new Date() },
+              });
+              summary.remoteDeleted++;
+              Logger.warn(`[ForumResync] thread ${threadId} 远端已删除(no_thread),标记 isDeleted=true`);
+            } catch (markErr: any) {
+              summary.failed++;
+              Logger.error(`[ForumResync] thread ${threadId} no_thread 但标记 isDeleted 失败: ${markErr.message}`);
+            }
           } else {
             summary.failed++;
             Logger.error(`[ForumResync] thread ${threadId} 重抓失败: ${err.message}`);

--- a/backend/src/core/processors/ForumSyncProcessor.ts
+++ b/backend/src/core/processors/ForumSyncProcessor.ts
@@ -153,11 +153,13 @@ export class ForumSyncProcessor {
    * 复用同步的 client + upsertPost，但【不收集 newPostIds、不触发任何论坛提醒】
    * （ForumInteractionAlertJob 只处理显式传入的 newPostIds，本路径不喂它，故旧帖不会误触发提醒）。
    * 成功后把 postCount/postCountAtSync 推进为实际抓到的帖数，使线程内部一致并不再被增量跳过。
+   * 若远端返回 no_thread（线程在 Wikidot 已删除/页面被删），标记 isDeleted=true 收敛，
+   * 计入 remoteDeleted（与可重试的网络 failed 区分），避免这类线程永久滞留在卡住检测里。
    */
   async resyncThreads(
     threadIds: number[]
-  ): Promise<{ threads: number; succeeded: number; failed: number; postsUpserted: number }> {
-    const summary = { threads: threadIds.length, succeeded: 0, failed: 0, postsUpserted: 0 };
+  ): Promise<{ threads: number; succeeded: number; failed: number; remoteDeleted: number; postsUpserted: number }> {
+    const summary = { threads: threadIds.length, succeeded: 0, failed: 0, remoteDeleted: 0, postsUpserted: 0 };
     if (threadIds.length === 0) return summary;
 
     // 与主同步流程一致：联网前装载论坛代理/IP 池（FORUM_HTTP_PROXY 未配置时为安全空操作）。
@@ -182,8 +184,19 @@ export class ForumSyncProcessor {
           summary.succeeded++;
           Logger.info(`[ForumResync] thread ${threadId}: 重抓 ${posts.length} 帖,已落库`);
         } catch (err: any) {
-          summary.failed++;
-          Logger.error(`[ForumResync] thread ${threadId} 重抓失败: ${err.message}`);
+          // 远端返回 no_thread：线程在 Wikidot 已删除（页面被删/重建致旧 thread id 失效）。
+          // 本地 0 帖即真实状态，标记 isDeleted=true 让其退出卡住检测，不再当作可重试失败。
+          if (/no_thread/i.test(String(err?.message ?? ''))) {
+            await this.prisma.forumThread.update({
+              where: { id: threadId },
+              data: { isDeleted: true, lastSyncedAt: new Date() },
+            });
+            summary.remoteDeleted++;
+            Logger.warn(`[ForumResync] thread ${threadId} 远端已删除(no_thread),标记 isDeleted=true`);
+          } else {
+            summary.failed++;
+            Logger.error(`[ForumResync] thread ${threadId} 重抓失败: ${err.message}`);
+          }
         }
         await this.client.delay();
       }


### PR DESCRIPTION
## 背景（#113 收尾）

#137 部署后首轮 `--apply` 重抓 **59/63** 卡住线程（落库 228 帖），其余 **4** 个远端返回 AMC `no_thread`——即这些讨论线程对应的页面已被删除/重建，旧 thread id 失效。已核对：4 个均为单页讨论线程，对应页面在本库当前版本多为 isDeleted（其中一个页面被删后重建、获得新 thread id）。本地 0 帖对这些线程而言就是**真实状态**。

## 问题

原 `resyncThreads` 把 `no_thread`（远端已删）和真正的网络失败混为一谈，都计入 `failed`。后果：这类线程 `postCount>0 / 0 帖 / postCountAtSync==postCount` 永远匹配卡住检测，每次 dry-run 都复现为噪音，且永远"修不好"（远端确实没有帖子可抓）。

## 改动

- `resyncThreads` catch 中识别 `no_thread`：标记该线程 `isDeleted=true`（退出卡住检测），计入独立的 `remoteDeleted`，与可重试的网络 `failed` 区分。
- CLI 汇总输出新增 `远端已删除 N(标记 isDeleted)`。

## 影响

- 仅对**远端确认不存在**的线程设 `isDeleted=true`（非破坏性标志，不删数据）；语义与主同步 `markDeletedThreads` 一致。
- 真实网络失败仍计入 `failed`、不被误标删除（可重试）。
- 未来任何远端删除的卡住线程都会被自动收敛，不再人工介入。

## 部署后

用 `--threads` 精确处理首轮残留的 4 个：`repair:forum-stuck-threads -- --apply --threads <4 ids>` → 预期 `remoteDeleted=4` → dry-run 卡住数归 0 → 关闭 #113。

Refs #113
