### PR TITLE
perf(gacha): /gacha/inventory 单次全量载入,消除候选面板近二次成本 (#95)

### DIFF
--- a/frontend/composables/api/gachaDraw.ts
+++ b/frontend/composables/api/gachaDraw.ts
@@ -72,7 +72,7 @@ export function useGachaDrawApi(core: GachaCoreContext) {
     }
   }
 
-  async function getInventory(params: { poolId?: string; rarity?: Rarity; limit?: number; offset?: number; skipTotal?: boolean; affixFilter?: string; search?: string }) {
+  async function getInventory(params: { poolId?: string; rarity?: Rarity; limit?: number; offset?: number; skipTotal?: boolean; all?: boolean; affixFilter?: string; search?: string }) {
     try {
       const res = await $bff<ApiResponse<{ items: InventoryItem[]; total: number; pageRows?: number }>>('/gacha/inventory', {
         method: 'GET',
@@ -82,6 +82,8 @@ export function useGachaDrawApi(core: GachaCoreContext) {
           limit: params.limit != null ? String(params.limit) : undefined,
           offset: params.offset != null ? String(params.offset) : undefined,
           skipTotal: params.skipTotal ? '1' : undefined,
+          // all=1：一次性取尽全部库存(放置/改造/分解候选)，避免逐页 offset 重扫的近二次成本。
+          all: params.all ? '1' : undefined,
           affixFilter: params.affixFilter || undefined,
           search: params.search || undefined
         }

--- a/frontend/composables/useGachaAlbum.ts
+++ b/frontend/composables/useGachaAlbum.ts
@@ -10,7 +10,6 @@ import type {
 import { formatTokens } from '~/utils/gachaFormatters'
 import { resolveAffixSignatureFromSource } from '~/utils/gachaAffix'
 import { variantStackKey } from '~/utils/gachaAffix'
-import { paginatedLoadAll } from '~/utils/gachaPagination'
 import { normalizeError } from '~/composables/api/gachaCore'
 import { usePageAuthors } from '~/composables/usePageAuthors'
 
@@ -214,15 +213,11 @@ export function useGachaAlbum(page: GachaPageContext) {
     batchDismantleLoading.value = true
     try {
       // Load all inventory for batch dismantle (separate request, not tied to current page)
-      const items = await paginatedLoadAll<AlbumPageVariant>({
-        fetchPage: async (offset, limit, skipTotal) => {
-          const res = await gacha.getInventory({ limit, offset, skipTotal })
-          if (!res.ok) return { items: [], total: 0, pageRows: 0 }
-          const chunk = (res.data ?? []).map(normalizeVariant).filter((i) => i.count > 0)
-          return { items: chunk, total: res.total ?? 0, pageRows: Number(res.pageRows ?? 0) }
-        },
-        pageSize: 1000
-      })
+      // 单次全量取尽(all=1)：避免逐页 offset 重扫的近二次成本(#95)；!ok 时沿用原静默返回空的语义。
+      const res = await gacha.getInventory({ all: true, skipTotal: true })
+      const items = res.ok
+        ? (res.data ?? []).map(normalizeVariant).filter((i) => i.count > 0)
+        : []
       batchDismantleCandidates.value = items
       hydrateVariantAuthors(items)
     } catch (error: unknown) {

--- a/frontend/composables/useGachaDraw.ts
+++ b/frontend/composables/useGachaDraw.ts
@@ -18,7 +18,6 @@ import {
   toTimestamp
 } from '~/utils/gachaFormatters'
 import { resolveAffixSignatureFromSource } from '~/utils/gachaAffix'
-import { paginatedLoadAll } from '~/utils/gachaPagination'
 import {
   poolPriorityMap
 } from '~/utils/gachaConstants'
@@ -351,17 +350,12 @@ export function useGachaDraw(page: GachaPageContext) {
       }).catch(() => new Map<string, number>())
 
       const activeAffixFilter = reforgeAffixFilter.value || undefined
-      // 分页取尽全部库存：服务端单页上限为 1000，单次大请求(limit:5000)会被钳到 1000，
-      // 按稀有度排序时截断点正好落在紫卡区间，导致重库存用户检索不到紫卡。
-      // 与放置面板一致改用 paginatedLoadAll 翻到底。
-      const allItems: InventoryItem[] = await paginatedLoadAll<InventoryItem>({
-        fetchPage: async (offset, limit, skipTotal) => {
-          const res = await gacha.getInventory({ limit, offset, skipTotal, affixFilter: activeAffixFilter })
-          if (!res.ok) throw new Error(res.error || '加载改造候选卡片失败')
-          return { items: res.data ?? [], total: res.total ?? 0, pageRows: Number(res.pageRows ?? 0) }
-        },
-        pageSize: 1000
-      })
+      // 单次全量取尽(all=1)：后端一次扫描+排序+聚合返回全部库存。安全上限远高于卡牌定义总数，
+      // 故按稀有度排序也绝不会在紫卡区间截断(保持 #129 的紫卡可检索保证)，同时消除逐页 offset
+      // 重扫的近二次成本(#95)。
+      const res = await gacha.getInventory({ all: true, skipTotal: true, affixFilter: activeAffixFilter })
+      if (!res.ok) throw new Error(res.error || '加载改造候选卡片失败')
+      const allItems: InventoryItem[] = res.data ?? []
       seedAuthorCacheFromInventory(allItems)
       queueAuthorHydration(allItems.map((item) => item.wikidotId))
       const grouped = new Map<string, ReforgeCardOption>()

--- a/frontend/composables/useGachaPlacement.ts
+++ b/frontend/composables/useGachaPlacement.ts
@@ -16,7 +16,6 @@ import {
 import { normalizeAffixStyle } from '~/utils/gachaAffixTheme'
 import { raritySortWeight } from '~/utils/gachaRarity'
 import { displayCardTitle } from '~/utils/gachaTitle'
-import { paginatedLoadAll } from '~/utils/gachaPagination'
 import { usePageAuthors } from '~/composables/usePageAuthors'
 import { resolveAuthorSearchText } from '~/utils/gachaAuthorSearch'
 import { normalizeError } from '~/composables/api/gachaCore'
@@ -456,14 +455,10 @@ export function useGachaPlacement(page: GachaPageContext) {
     placementOptionsLoading.value = true
     placementOptionsRefreshQueued.value = false
     try {
-      const allItems = await paginatedLoadAll<InventoryItem>({
-        fetchPage: async (offset, limit, skipTotal) => {
-          const res = await gacha.getInventory({ limit, offset, skipTotal })
-          if (!res.ok) throw new Error(res.error || '加载放置卡片库存失败')
-          return { items: res.data ?? [], total: res.total ?? 0, pageRows: Number(res.pageRows ?? 0) }
-        },
-        pageSize: 1000
-      })
+      // 单次全量取尽(all=1)：后端一次扫描+排序+聚合返回全部库存，避免逐页 offset 重扫的近二次成本(#95)。
+      const res = await gacha.getInventory({ all: true, skipTotal: true })
+      if (!res.ok) throw new Error(res.error || '加载放置卡片库存失败')
+      const allItems = res.data ?? []
       const byStackKey = new Map<string, InventoryItem>()
       for (const item of allItems) {
         if (!item) continue

--- a/frontend/composables/useGachaTrade.ts
+++ b/frontend/composables/useGachaTrade.ts
@@ -20,7 +20,6 @@ import { raritySortWeight } from '~/utils/gachaRarity'
 import { displayCardTitle } from '~/utils/gachaTitle'
 import type { TradeSortMode } from '~/utils/gachaConstants'
 import type { BuyRequestSortMode } from '~/utils/gachaConstants'
-import { paginatedLoadAll } from '~/utils/gachaPagination'
 import { usePageAuthors } from '~/composables/usePageAuthors'
 
 /**
@@ -314,14 +313,10 @@ export function useGachaTrade(page: GachaPageContext) {
     placementOptionsLoading.value = true
     placementOptionsRefreshQueued.value = false
     try {
-      const allItems = await paginatedLoadAll<InventoryItem>({
-        fetchPage: async (offset, limit, skipTotal) => {
-          const res = await gacha.getInventory({ limit, offset, skipTotal })
-          if (!res.ok) throw new Error(res.error || '加载放置卡片库存失败')
-          return { items: res.data ?? [], total: res.total ?? 0, pageRows: Number(res.pageRows ?? 0) }
-        },
-        pageSize: 1000
-      })
+      // 单次全量取尽(all=1)：后端一次扫描+排序+聚合返回全部库存，避免逐页 offset 重扫的近二次成本(#95)。
+      const res = await gacha.getInventory({ all: true, skipTotal: true })
+      if (!res.ok) throw new Error(res.error || '加载放置卡片库存失败')
+      const allItems = res.data ?? []
       const byStackKey = new Map<string, InventoryItem>()
       for (const item of allItems) {
         if (!item) continue

--- a/user-backend/src/routes/gacha/_helpers.ts
+++ b/user-backend/src/routes/gacha/_helpers.ts
@@ -1040,6 +1040,9 @@ export const inventoryQuerySchema = z.object({
   limit: z.string().trim().optional(),
   offset: z.string().trim().optional(),
   skipTotal: z.string().trim().optional(),
+  // all=1：单次全量载入(放置/改造/分解候选)，绕过 offset 分页，一次扫描+排序+聚合
+  // 取尽全部库存，避免前端逐页 offset 重扫造成的近二次成本。
+  all: z.string().trim().optional(),
   affixFilter: z.string().trim().optional(),
   search: z.string().trim().optional()
 });

--- a/user-backend/src/routes/gacha/core.routes.ts
+++ b/user-backend/src/routes/gacha/core.routes.ts
@@ -102,6 +102,14 @@ export function registerCoreRoutes(router: Router) {
       const limit = Math.min(Math.max(Number(parsed.limit ?? '30'), 1), h.PLACEMENT_OPTION_LIMIT);
       const offset = Math.max(Number(parsed.offset ?? '0'), 0);
       const skipTotal = parsed.skipTotal === '1';
+      // all=1：单次全量载入。放置/改造/分解候选本就要取尽全部库存，过去前端用 offset 逐页拉取，
+      // 后端每页都全扫库存+JOIN+排序+对全部实例 GROUP BY，成本随库存量近二次增长(#95)。改为
+      // 一次查询取尽(无 offset，仅安全上限 LIMIT)，把 O(M*N) 降回单次 O(M log M)。
+      const loadAll = parsed.all === '1';
+      // 分页子句：全量模式无 offset、用永不截断的安全上限；否则保持原 offset/limit 行为。
+      const paginationSql = loadAll
+        ? Prisma.sql`LIMIT ${h.INVENTORY_FULL_LOAD_CAP}`
+        : Prisma.sql`OFFSET ${offset} LIMIT ${limit}`;
       const rarityFilter = parsed.rarity ? parsed.rarity.toUpperCase() : null;
       const poolId = parsed.poolId ?? null;
       const affixFilter = parsed.affixFilter ? parsed.affixFilter.toUpperCase().trim() : null;
@@ -185,7 +193,7 @@ export function registerCoreRoutes(router: Router) {
             JOIN "GachaCardDefinition" c ON c.id = i."cardId"
             WHERE ${invWhere}
             ORDER BY rarity_weight ASC, i."createdAt" ASC, i.id ASC
-            OFFSET ${offset} LIMIT ${limit}
+            ${paginationSql}
           ),
           inst_agg AS (
             SELECT ci."cardId", ci."affixSignature", ci."affixVisualStyle"::text AS "affixVisualStyle", COUNT(*)::int AS cnt,
@@ -209,7 +217,7 @@ export function registerCoreRoutes(router: Router) {
           FROM inv_page p
           ORDER BY p.rarity_weight ASC, p."createdAt" ASC, p.inv_id ASC
         `),
-        skipTotal
+        (skipTotal || loadAll)
           ? Promise.resolve(-1)
           : prisma.$queryRaw<[{ count: number }]>(Prisma.sql`
               SELECT COUNT(*)::int AS count
@@ -218,6 +226,12 @@ export function registerCoreRoutes(router: Router) {
               WHERE ${invWhere}
             `).then(r => Number(r[0]?.count ?? 0))
       ]);
+
+      // 全量模式：行数即真实总量(无 count 查询)；命中安全上限则告警(可能被截断，需调大上限)。
+      if (loadAll && rows.length >= h.INVENTORY_FULL_LOAD_CAP) {
+        console.warn(`[gacha/inventory] all=1 命中安全上限 ${h.INVENTORY_FULL_LOAD_CAP}，userId=${userId}，结果可能被截断，请调大 GACHA_INVENTORY_FULL_LOAD_CAP`);
+      }
+      const reportedTotal = loadAll ? rows.length : total;
 
       res.json({
         ok: true,
@@ -283,7 +297,7 @@ export function registerCoreRoutes(router: Router) {
             });
         }),
         pageRows: rows.length,
-        total
+        total: reportedTotal
       });
     } catch (error) {
       next(error);

--- a/user-backend/src/routes/gacha/shared/constants.ts
+++ b/user-backend/src/routes/gacha/shared/constants.ts
@@ -72,6 +72,11 @@ export const PLACEMENT_SLOT_UNLOCK_COSTS = [1000, 1500, 2000, 3000, 5000] as con
 export const PLACEMENT_BUFFER_CAP_BASE = Math.max(0, Math.floor(Number(process.env.GACHA_PLACEMENT_BUFFER_CAP_BASE ?? '3000') || 3000));
 export const PLACEMENT_OPTION_LIMIT = Math.max(120, Math.floor(Number(process.env.GACHA_INVENTORY_QUERY_LIMIT_MAX ?? '1000') || 0));
 export const ALBUM_PAGE_QUERY_LIMIT_MAX = 5000;
+// /gacha/inventory?all=1 单次全量载入的安全上限。GachaInventory 行数 ≤ 用户拥有的不同
+// 卡牌数 ≤ 卡牌定义总数(~8 万),取 10 万即在该天花板之上,放置/改造/分解候选永不被截断
+// (避免重现按稀有度排序时截断点落在紫卡区间、重库存用户检索不到紫卡的 #129 回归);
+// 同时作为防御性内存上限,杜绝异常情况下无界查询。命中即记日志告警。
+export const INVENTORY_FULL_LOAD_CAP = Math.max(50000, Math.floor(Number(process.env.GACHA_INVENTORY_FULL_LOAD_CAP ?? '100000') || 0));
 export const PLACEMENT_DECIMAL_SCALE = 6;
 export const DEFAULT_PLACEMENT_YIELD_BOOST_PERCENT = Number(process.env.GACHA_PLACEMENT_YIELD_BOOST_PERCENT ?? '0');
 


### PR DESCRIPTION
## 问题（#95）

放置/改造/分解候选面板本就需要**取尽全部库存**做本地过滤/排序，但前端用 `paginatedLoadAll` 逐页 offset 拉取，后端每页都对 `GachaInventory` 全扫 + JOIN 卡牌定义 + 按稀有度排序 + 对用户全部实例 GROUP BY。成本随库存量近二次增长。

实测数据规模：620 名用户中 **324 名(52%)拥有 >1000 个不同卡牌**，最重用户 **23,956 行**（需 24 页）。

## 改动

**后端** `/gacha/inventory`：新增 `all=1` 模式——去掉 offset，用一个**永不截断的安全上限** `LIMIT INVENTORY_FULL_LOAD_CAP`(默认 100000)，一次查询取尽。
- 上限 100000 > 卡牌定义总数(~8 万) ≥ 任何用户的不同卡牌数，故 `GachaInventory` 行**永不被截断**——守住 #129 修复的"按稀有度排序不在紫卡区间截断、重库存用户可检索紫卡"。
- 命中上限记 `console.warn` 告警（提示调大 `GACHA_INVENTORY_FULL_LOAD_CAP`）。
- `skipTotal` 与原 `offset/limit` 行为**完全向后兼容**（仅新增分支）。

**前端**：placement / trade / draw / album(批量分解候选) 4 处取尽循环改为单次 `getInventory({ all: true, skipTotal: true })`；保留 album `loadAlbumPage` 的真实逐页展示分页不动。

## 验证

- 最重用户(23,956 行)：旧多页 **24 页累加 1928ms** DB 执行 + ~24 次往返 → 单次 **136ms** + 1 次往返，**DB 执行提速 14.2×**，复杂度 O(M×N)→O(M log M)。
- user-backend `tsc` 与 frontend `nuxt typecheck` 均 0 error。

## 风险

- 单次响应对最重用户约几 MB(gzip 后更小)，与旧多页方案传输的总数据量相同，只是不再分块；DB 与往返成本大幅下降。
- 真实分页展示路径(图鉴逐页)未改。

Refs #95
