### PR TITLE
perf(gacha): 批量分解集合化,单原子短事务消除串行化重试风暴 (#96)

### DIFF
--- a/user-backend/scripts/verify-dismantle-planner.ts
+++ b/user-backend/scripts/verify-dismantle-planner.ts
@@ -1,0 +1,201 @@
+/**
+ * Golden 对比验证（#96）：证明 planBatchSelectiveDismantle（基于快照的纯规划器）与
+ * "直接在原始实例列表上逐字跑旧 /dismantle/batch-selective 循环语义"的参考实现，在大量
+ * 随机输入下【选中的实例完全一致】。选择一致 ⇒ 奖励/日志/汇总一致（均为选择的确定性函数）。
+ *
+ * 运行：cd user-backend && npx tsx scripts/verify-dismantle-planner.ts
+ * 退出码 0 = 全部通过；非 0 = 发现分歧（打印首个反例）。
+ */
+import {
+  planBatchSelectiveDismantle,
+  type DismantleSnapshot,
+  type DismantleSnapshotInstance,
+  type DismantlePlanItem
+} from '../src/routes/gacha/_dismantlePlanner.js';
+
+// ─── 确定性伪随机（可复现反例）────────────────────────────────
+let seed = 0x1234abcd;
+function rnd(): number {
+  // xorshift32
+  seed ^= seed << 13; seed ^= seed >>> 17; seed ^= seed << 5;
+  return ((seed >>> 0) % 1_000_000) / 1_000_000;
+}
+function randint(lo: number, hi: number): number { return lo + Math.floor(rnd() * (hi - lo + 1)); }
+function pick<T>(arr: T[]): T { return arr[randint(0, arr.length - 1)]; }
+
+// ─── 原始实例模型（含全部影响"自由/留存"判定的字段）──────────────
+interface RawInstance {
+  id: string;
+  cardId: string;
+  affixSignature: string;
+  obtainedAt: number;       // 唯一，避免并列排序歧义
+  isLocked: boolean;
+  placed: boolean;          // placementSlot 是否存在
+  showcased: boolean;       // showcaseSlot 是否存在
+  traded: boolean;          // tradeListingId 非空
+  buyReq: boolean;          // buyRequestId 非空
+}
+
+const SIGS = ['NONE', 'PRISM', 'COLORLESS', 'FOIL'];
+const CARDS = ['c1', 'c2', 'c3', 'c4'];
+
+function genInstances(obtainedSeq: { v: number }): RawInstance[] {
+  const n = randint(0, 40);
+  const out: RawInstance[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push({
+      id: `i${out.length}_${randint(0, 99999)}`,
+      cardId: pick(CARDS),
+      affixSignature: pick(SIGS),
+      obtainedAt: obtainedSeq.v++,
+      isLocked: rnd() < 0.2,
+      placed: rnd() < 0.15,
+      showcased: rnd() < 0.1,
+      traded: rnd() < 0.1,
+      buyReq: rnd() < 0.1
+    });
+  }
+  // 打乱 id 唯一性
+  return out;
+}
+
+function genItems(): DismantlePlanItem[] {
+  const n = randint(1, 8);
+  const out: DismantlePlanItem[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push({
+      cardId: pick(CARDS),
+      affixSignature: rnd() < 0.5 ? pick(SIGS) : undefined,
+      count: randint(1, 6)
+    });
+  }
+  return out;
+}
+
+// ─── 参考实现：逐字复刻旧端点循环（直接在 live 列表上 count/findFree/delete）──────
+function referenceSelect(
+  instances: RawInstance[],
+  items: DismantlePlanItem[],
+  keepAtLeast: number,
+  cardExists: Set<string>
+): Array<{ cardId: string; selectedIds: string[] }> {
+  const live = new Set(instances.map((x) => x.id));
+  const byId = new Map(instances.map((x) => [x.id, x]));
+  const result: Array<{ cardId: string; selectedIds: string[] }> = [];
+
+  const matchInstanceWhere = (x: RawInstance, cardId: string, sig?: string) =>
+    live.has(x.id) && x.cardId === cardId && !x.traded && !x.buyReq &&
+    (sig == null || x.affixSignature === sig);
+
+  for (const item of items) {
+    const sig = item.affixSignature;
+    const owned = instances.filter((x) => matchInstanceWhere(x, item.cardId, sig));
+    const totalOwned = owned.length;
+    const lockedOwned = owned.filter((x) => x.isLocked).length;
+    const minKeep = Math.max(lockedOwned, keepAtLeast);
+    const maxDeletable = Math.max(0, totalOwned - minKeep);
+    const targetDelete = Math.min(item.count, maxDeletable);
+    if (targetDelete <= 0) continue;
+
+    // findFreeInstances: 自由白名单 + orderBy obtainedAt asc + take targetDelete
+    const free = instances
+      .filter((x) => matchInstanceWhere(x, item.cardId, sig) && !x.isLocked && !x.placed && !x.showcased)
+      .sort((a, b) => a.obtainedAt - b.obtainedAt)
+      .slice(0, targetDelete);
+    const dismantleCount = Math.min(free.length, targetDelete);
+    if (dismantleCount <= 0) continue;
+    const toDelete = free.slice(0, dismantleCount);
+
+    if (!cardExists.has(item.cardId)) continue; // 缺定义：不删、不记录
+
+    for (const x of toDelete) live.delete(x.id);
+    result.push({ cardId: item.cardId, selectedIds: toDelete.map((x) => x.id) });
+  }
+  // 防御：byId 仅为对称占位，避免未用告警
+  void byId;
+  return result;
+}
+
+// ─── 由原始列表构造 planner 快照（镜像端点的 groupBy/findMany 查询语义）────────
+function buildSnapshot(instances: RawInstance[], cardExists: Set<string>): DismantleSnapshot {
+  const totalByCard = new Map<string, number>();
+  const totalByCardSig = new Map<string, Map<string, number>>();
+  const lockedByCard = new Map<string, number>();
+  const lockedByCardSig = new Map<string, Map<string, number>>();
+  const freeByCard = new Map<string, DismantleSnapshotInstance[]>();
+
+  const bump = (m: Map<string, number>, k: string, d = 1) => m.set(k, (m.get(k) ?? 0) + d);
+  const bump2 = (m: Map<string, Map<string, number>>, c: string, s: string, d = 1) => {
+    let inner = m.get(c); if (!inner) { inner = new Map(); m.set(c, inner); }
+    inner.set(s, (inner.get(s) ?? 0) + d);
+  };
+
+  for (const x of instances) {
+    // 留存口径：排除交易/求购，包含锁定/放置/展示
+    if (x.traded || x.buyReq) continue;
+    bump(totalByCard, x.cardId);
+    bump2(totalByCardSig, x.cardId, x.affixSignature);
+    if (x.isLocked) { bump(lockedByCard, x.cardId); bump2(lockedByCardSig, x.cardId, x.affixSignature); }
+  }
+  // 自由池：完整白名单 + obtainedAt 升序
+  const freeSorted = instances
+    .filter((x) => !x.traded && !x.buyReq && !x.isLocked && !x.placed && !x.showcased)
+    .sort((a, b) => a.obtainedAt - b.obtainedAt);
+  for (const x of freeSorted) {
+    let list = freeByCard.get(x.cardId); if (!list) { list = []; freeByCard.set(x.cardId, list); }
+    list.push({ id: x.id, cardId: x.cardId, affixSignature: x.affixSignature, obtainedAt: x.obtainedAt });
+  }
+
+  return { totalByCard, totalByCardSig, lockedByCard, lockedByCardSig, freeByCard, cardExists };
+}
+
+// ─── 主循环 ────────────────────────────────────────────────
+const ITERATIONS = 20000;
+let failures = 0;
+const obtainedSeq = { v: 1 };
+
+for (let iter = 0; iter < ITERATIONS; iter++) {
+  const instances = genInstances(obtainedSeq);
+  const items = genItems();
+  const keepAtLeast = randint(0, 4);
+  // 随机让某些 card 缺定义（测试 skip 路径）
+  const cardExists = new Set(CARDS.filter(() => rnd() < 0.85));
+
+  const ref = referenceSelect(instances, items, keepAtLeast, cardExists);
+  const plan = planBatchSelectiveDismantle(items, keepAtLeast, buildSnapshot(instances, cardExists));
+
+  // 对齐比较：planner.perItem（仅 dismantleCount>0）应与 ref 的 (cardId, selectedIds) 序列逐项一致
+  let mismatch = false;
+  if (plan.perItem.length !== ref.length) mismatch = true;
+  if (!mismatch) {
+    for (let k = 0; k < ref.length; k++) {
+      const a = ref[k];
+      const b = plan.perItem[k];
+      if (a.cardId !== b.cardId) { mismatch = true; break; }
+      // 选中 id 集合必须完全一致（顺序无关，因均来自同一最早集合）
+      const sa = [...a.selectedIds].sort().join(',');
+      const sb = [...b.selectedIds].sort().join(',');
+      if (sa !== sb) { mismatch = true; break; }
+    }
+  }
+
+  if (mismatch) {
+    failures++;
+    if (failures === 1) {
+      console.error('❌ 发现首个反例:');
+      console.error('keepAtLeast=', keepAtLeast, ' cardExists=', [...cardExists]);
+      console.error('items=', JSON.stringify(items));
+      console.error('instances=', JSON.stringify(instances));
+      console.error('reference=', JSON.stringify(ref));
+      console.error('planner.perItem=', JSON.stringify(plan.perItem.map((p) => ({ cardId: p.cardId, selectedIds: p.selectedIds }))));
+    }
+  }
+}
+
+if (failures === 0) {
+  console.log(`✓ planner 与参考实现在 ${ITERATIONS} 个随机用例下完全一致（选中实例逐项相同）。`);
+  process.exit(0);
+} else {
+  console.error(`✗ ${failures}/${ITERATIONS} 个用例分歧。`);
+  process.exit(1);
+}

--- a/user-backend/scripts/verify-dismantle-realdata.ts
+++ b/user-backend/scripts/verify-dismantle-realdata.ts
@@ -1,0 +1,117 @@
+/**
+ * 只读真实数据校验（#96）：对若干真实用户，用【新端点的批量查询】构造快照，跑 planner，
+ * 并用【逐字复刻旧端点的逐 item 只读查询(count + findFree，把"已删"在内存里排除后续查询)】
+ * 独立选择，断言两者选中的实例完全一致。纯读，不写库。
+ *
+ * 运行：cd user-backend && npx tsx scripts/verify-dismantle-realdata.ts
+ */
+import { prisma } from '../src/db.js';
+import { planBatchSelectiveDismantle, type DismantlePlanItem } from '../src/routes/gacha/_dismantlePlanner.js';
+
+let seed = 0xC0FFEE;
+function rnd() { seed ^= seed << 13; seed ^= seed >>> 17; seed ^= seed << 5; return ((seed >>> 0) % 1_000_000) / 1_000_000; }
+function randint(lo: number, hi: number) { return lo + Math.floor(rnd() * (hi - lo + 1)); }
+
+async function buildSnapshotQueries(userId: string, cardIds: string[]) {
+  const [cardDefs, totalGroups, lockedGroups, freeInstances] = await Promise.all([
+    prisma.gachaCardDefinition.findMany({ where: { id: { in: cardIds } } }),
+    prisma.gachaCardInstance.groupBy({ by: ['cardId', 'affixSignature'], where: { userId, cardId: { in: cardIds }, tradeListingId: null, buyRequestId: null }, _count: { _all: true } }),
+    prisma.gachaCardInstance.groupBy({ by: ['cardId', 'affixSignature'], where: { userId, cardId: { in: cardIds }, tradeListingId: null, buyRequestId: null, isLocked: true }, _count: { _all: true } }),
+    prisma.gachaCardInstance.findMany({ where: { userId, cardId: { in: cardIds }, tradeListingId: null, buyRequestId: null, placementSlot: { is: null }, showcaseSlot: { is: null }, isLocked: false }, select: { id: true, cardId: true, affixSignature: true }, orderBy: [{ obtainedAt: 'asc' }, { id: 'asc' }] })
+  ]);
+  const cardExists = new Set(cardDefs.map((c) => c.id));
+  const totalByCard = new Map<string, number>(); const totalByCardSig = new Map<string, Map<string, number>>();
+  const lockedByCard = new Map<string, number>(); const lockedByCardSig = new Map<string, Map<string, number>>();
+  const acc = (flat: Map<string, number>, nest: Map<string, Map<string, number>>, gs: any[]) => {
+    for (const g of gs) { const c = g._count._all; flat.set(g.cardId, (flat.get(g.cardId) ?? 0) + c); let inner = nest.get(g.cardId); if (!inner) { inner = new Map(); nest.set(g.cardId, inner); } inner.set(g.affixSignature, (inner.get(g.affixSignature) ?? 0) + c); }
+  };
+  acc(totalByCard, totalByCardSig, totalGroups); acc(lockedByCard, lockedByCardSig, lockedGroups);
+  const freeByCard = new Map<string, Array<{ id: string; cardId: string; affixSignature: string }>>();
+  let nullSig = 0;
+  for (const inst of freeInstances) {
+    if ((inst.affixSignature as any) == null) nullSig++;
+    let list = freeByCard.get(inst.cardId); if (!list) { list = []; freeByCard.set(inst.cardId, list); } list.push(inst);
+  }
+  return { snapshot: { totalByCard, totalByCardSig, lockedByCard, lockedByCardSig, freeByCard, cardExists }, nullSig };
+}
+
+// 逐字复刻旧端点：逐 item count + findFree，把已"删"的 id 在内存里排除后续查询。
+async function referenceSelectRealData(userId: string, items: DismantlePlanItem[], keepAtLeast: number) {
+  const deleted = new Set<string>();
+  const result: Array<{ cardId: string; selectedIds: string[] }> = [];
+  for (const item of items) {
+    const sig = item.affixSignature;
+    const baseWhere: any = { userId, cardId: item.cardId, tradeListingId: null, buyRequestId: null, id: { notIn: [...deleted] } };
+    if (sig != null) baseWhere.affixSignature = sig;
+    const [totalOwned, lockedOwned] = await Promise.all([
+      prisma.gachaCardInstance.count({ where: baseWhere }),
+      prisma.gachaCardInstance.count({ where: { ...baseWhere, isLocked: true } })
+    ]);
+    const minKeep = Math.max(lockedOwned, keepAtLeast);
+    const targetDelete = Math.min(item.count, Math.max(0, totalOwned - minKeep));
+    if (targetDelete <= 0) continue;
+    const free = await prisma.gachaCardInstance.findMany({
+      where: { ...baseWhere, placementSlot: { is: null }, showcaseSlot: { is: null }, isLocked: false },
+      orderBy: [{ obtainedAt: 'asc' }, { id: 'asc' }], take: targetDelete, select: { id: true }
+    });
+    if (free.length <= 0) continue;
+    const card = await prisma.gachaCardDefinition.findUnique({ where: { id: item.cardId } });
+    if (!card) continue;
+    free.forEach((f) => deleted.add(f.id));
+    result.push({ cardId: item.cardId, selectedIds: free.map((f) => f.id) });
+  }
+  return result;
+}
+
+async function main() {
+  // 取库存最多的若干用户
+  const heavy = await prisma.gachaInventory.groupBy({ by: ['userId'], where: { count: { gt: 0 } }, _count: { _all: true }, orderBy: { _count: { userId: 'desc' } }, take: 8 });
+  let totalCases = 0; let mismatches = 0; let nullSigTotal = 0;
+  for (const u of heavy) {
+    const userId = u.userId;
+    const inv = await prisma.gachaInventory.findMany({ where: { userId, count: { gt: 0 } }, select: { cardId: true }, take: 1000 });
+    if (inv.length === 0) continue;
+    // 采样该用户实际存在的 affixSignature，用于覆盖"指定 sig"过滤路径。
+    const sigGroups = await prisma.gachaCardInstance.groupBy({ by: ['affixSignature'], where: { userId }, _count: { _all: true } });
+    const realSigs = sigGroups.map((g) => g.affixSignature).filter((s): s is string => s != null).slice(0, 20);
+    // 跑 12 个随机 items 批次
+    for (let t = 0; t < 12; t++) {
+      const k = randint(1, Math.min(40, inv.length));
+      const items: DismantlePlanItem[] = [];
+      for (let j = 0; j < k; j++) {
+        const card = inv[randint(0, inv.length - 1)].cardId;
+        // 40% 概率指定一个真实存在的 sig（可能与该卡不匹配→选 0，亦是有效的过滤路径测试）。
+        const sig = (realSigs.length > 0 && rnd() < 0.4) ? realSigs[randint(0, realSigs.length - 1)] : undefined;
+        items.push({ cardId: card, affixSignature: sig, count: randint(1, 5) });
+      }
+      const keepAtLeast = randint(0, 3);
+      const cardIds = [...new Set(items.map((i) => i.cardId))];
+      const { snapshot, nullSig } = await buildSnapshotQueries(userId, cardIds);
+      nullSigTotal += nullSig;
+      const plan = planBatchSelectiveDismantle(items, keepAtLeast, snapshot);
+      const ref = await referenceSelectRealData(userId, items, keepAtLeast);
+      totalCases++;
+      let bad = false;
+      if (plan.perItem.length !== ref.length) bad = true;
+      if (!bad) for (let i = 0; i < ref.length; i++) {
+        if (ref[i].cardId !== plan.perItem[i].cardId) { bad = true; break; }
+        const sa = [...ref[i].selectedIds].sort().join(','); const sb = [...plan.perItem[i].selectedIds].sort().join(',');
+        if (sa !== sb) { bad = true; break; }
+      }
+      if (bad) {
+        mismatches++;
+        if (mismatches <= 2) {
+          console.error(`❌ mismatch user=${userId} keepAtLeast=${keepAtLeast}`);
+          console.error('items=', JSON.stringify(items));
+          console.error('ref=', JSON.stringify(ref.map((r) => ({ c: r.cardId, n: r.selectedIds.length }))));
+          console.error('plan=', JSON.stringify(plan.perItem.map((p) => ({ c: p.cardId, n: p.selectedIds.length }))));
+        }
+      }
+    }
+  }
+  console.log(`用户数=${heavy.length} 用例=${totalCases} 分歧=${mismatches} 自由实例 affixSignature 为 null 的行数=${nullSigTotal}`);
+  await prisma.$disconnect();
+  process.exit(mismatches === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error(e); process.exit(2); });

--- a/user-backend/src/routes/gacha/_dismantlePlanner.ts
+++ b/user-backend/src/routes/gacha/_dismantlePlanner.ts
@@ -1,0 +1,142 @@
+/**
+ * 批量分解（/dismantle/batch-selective）的纯选择规划器（#96）。
+ *
+ * 背景：原实现把 ≤500 个 item 的选择/删除全塞进一个 Serializable 长事务，每个 item 串行
+ * 发起 ~8-9 次 DB 往返（2×count + findFreeInstances + findUnique + deleteCardInstances +
+ * create log），共约 4000 次串行往返、持锁数十秒，高并发下串行化冲突重试风暴。
+ *
+ * 修复（方案 D，单原子事务）：把"选哪些实例、删多少、各自属哪个 affix 组"的决策抽成这个
+ * 【纯函数】，在内存里【逐字复刻】原 for 循环的顺序语义（含重复 item、同 card 同 affix、
+ * 混合"指定/不指定 affix"、obtainedAt 先后、按已删后的状态续算），然后由调用方一次性
+ * deleteMany / createMany / count 同步 / 钱包结算。奖励仍由现有 computeDismantleRewardByAffix
+ * 计算，故只要"选择"与旧逻辑一致，奖励/日志/汇总即逐字一致。
+ *
+ * 正确性由 scripts/verify-dismantle-planner.ts 的 golden 对比保证（随机快照下 planner 输出
+ * 与"直接在原始实例列表上跑旧循环语义"的参考实现完全一致）。
+ */
+
+/** 自由实例快照行（已通过自由白名单：未交易/未求购/未锁/未放置/未展示）。 */
+export interface DismantleSnapshotInstance {
+  id: string;
+  cardId: string;
+  affixSignature: string;
+  /** 仅用于稳定排序的占位；快照里 freeByCard 数组本身已按 obtainedAt 升序。 */
+  obtainedAt?: number;
+}
+
+/** 单个待分解 item（affixSignature 必须已规范化，或为 undefined 表示整卡不限 affix）。 */
+export interface DismantlePlanItem {
+  cardId: string;
+  affixSignature?: string;
+  count: number;
+}
+
+export interface DismantleSnapshot {
+  /** 留存护栏分母：排除交易/求购，但【包含】锁定/放置/展示的实例计数。cardId -> sig -> count。 */
+  totalByCardSig: Map<string, Map<string, number>>;
+  /** 同上按整卡聚合。cardId -> count。 */
+  totalByCard: Map<string, number>;
+  /** 同 totalBy* 口径再加 isLocked=true。 */
+  lockedByCardSig: Map<string, Map<string, number>>;
+  lockedByCard: Map<string, number>;
+  /** 自由实例池，按 cardId 分组，每组已按 obtainedAt 升序（与 findFreeInstances 一致）。 */
+  freeByCard: Map<string, DismantleSnapshotInstance[]>;
+  /** 存在卡牌定义的 cardId 集合（缺定义的 item 跳过，且不消耗自由池——与原逻辑一致）。 */
+  cardExists: Set<string>;
+}
+
+export interface DismantlePlanItemResult {
+  cardId: string;
+  dismantleCount: number;
+  selectedIds: string[];
+  /** sig -> 该 sig 被选中的数量，用于构造 computeDismantleRewardByAffix 的 consumed。 */
+  consumeGroups: Map<string, number>;
+}
+
+export interface DismantlePlan {
+  /** 仅含真正产生删除（dismantleCount>0）的 item，顺序与输入一致。 */
+  perItem: DismantlePlanItemResult[];
+  /** 所有被选中的实例 id（去重前的全集；各 item 互不重叠，因消耗即移除）。 */
+  selectedIds: string[];
+  /** cardId -> 本次删除总数，用于库存 count 同步。 */
+  deletedCountByCard: Map<string, number>;
+}
+
+function cloneSigMap(src: Map<string, Map<string, number>>): Map<string, Map<string, number>> {
+  const out = new Map<string, Map<string, number>>();
+  for (const [card, inner] of src) out.set(card, new Map(inner));
+  return out;
+}
+
+/**
+ * 纯选择规划：在内存里复刻原 for 循环（每 item 用"删除后的当前状态"重新评估留存护栏与自由池）。
+ * 不做任何 IO，不改入参快照（内部克隆可变部分）。
+ */
+export function planBatchSelectiveDismantle(
+  items: DismantlePlanItem[],
+  keepAtLeast: number,
+  snapshot: DismantleSnapshot
+): DismantlePlan {
+  // 克隆需要随删除递减的可变状态；lockedBy* 不变（锁定实例永不删除）。
+  const totalByCard = new Map(snapshot.totalByCard);
+  const totalByCardSig = cloneSigMap(snapshot.totalByCardSig);
+  const freeByCard = new Map<string, DismantleSnapshotInstance[]>();
+  for (const [card, list] of snapshot.freeByCard) freeByCard.set(card, list.slice());
+
+  const perItem: DismantlePlanItemResult[] = [];
+  const selectedIds: string[] = [];
+  const deletedCountByCard = new Map<string, number>();
+
+  for (const item of items) {
+    const sig = item.affixSignature; // 已规范化或 undefined
+    // 卡牌定义缺失：原逻辑 continue 且不调用 deleteCardInstances，故不消耗自由池。
+    if (!snapshot.cardExists.has(item.cardId)) continue;
+
+    const totalOwned = sig != null
+      ? (totalByCardSig.get(item.cardId)?.get(sig) ?? 0)
+      : (totalByCard.get(item.cardId) ?? 0);
+    const lockedOwned = sig != null
+      ? (snapshot.lockedByCardSig.get(item.cardId)?.get(sig) ?? 0)
+      : (snapshot.lockedByCard.get(item.cardId) ?? 0);
+    const minKeep = Math.max(lockedOwned, keepAtLeast);
+    const maxDeletable = Math.max(0, totalOwned - minKeep);
+    const targetDelete = Math.min(item.count, maxDeletable);
+    if (targetDelete <= 0) continue;
+
+    const pool = freeByCard.get(item.cardId);
+    if (!pool || pool.length === 0) continue;
+
+    // 池已按 obtainedAt 升序；指定 sig 时只取该 sig，否则跨 sig 取最早的；消耗即从池中移除，
+    // 使后续 item 看到删除后的池（复刻原逐 item 重新 findFreeInstances 的行为）。
+    const selected: DismantleSnapshotInstance[] = [];
+    for (let i = 0; i < pool.length && selected.length < targetDelete; ) {
+      const inst = pool[i];
+      if (sig == null || inst.affixSignature === sig) {
+        selected.push(inst);
+        pool.splice(i, 1);
+      } else {
+        i++;
+      }
+    }
+    const dismantleCount = selected.length;
+    if (dismantleCount <= 0) continue;
+
+    const consumeGroups = new Map<string, number>();
+    for (const inst of selected) {
+      consumeGroups.set(inst.affixSignature, (consumeGroups.get(inst.affixSignature) ?? 0) + 1);
+    }
+
+    // 递减留存分母：整卡 -dismantleCount；按实际消耗的 sig 分别递减 sig 维度。
+    totalByCard.set(item.cardId, (totalByCard.get(item.cardId) ?? 0) - dismantleCount);
+    const sigMap = totalByCardSig.get(item.cardId);
+    if (sigMap) {
+      for (const [s, c] of consumeGroups) sigMap.set(s, (sigMap.get(s) ?? 0) - c);
+    }
+
+    for (const inst of selected) selectedIds.push(inst.id);
+    deletedCountByCard.set(item.cardId, (deletedCountByCard.get(item.cardId) ?? 0) + dismantleCount);
+    perItem.push({ cardId: item.cardId, dismantleCount, selectedIds: selected.map((s) => s.id), consumeGroups });
+  }
+
+  return { perItem, selectedIds, deletedCountByCard };
+}

--- a/user-backend/src/routes/gacha/_helpers.ts
+++ b/user-backend/src/routes/gacha/_helpers.ts
@@ -2012,9 +2012,12 @@ export async function findFreeInstances(
   if (opts?.affixSignature) {
     where.affixSignature = affixSignatureFromStyles(parseAffixSignature(opts.affixSignature));
   }
+  // id 次级排序：消除同一 obtainedAt（如十连同刻获得）的并列歧义，使自由实例选择【确定性】。
+  // 这是全站自由实例选择（单张/批量分解、放置、交易、求购履约）共享的稳定排序契约，保证
+  // 批量分解的全池一次查询与各处逐次查询在并列时解析一致。
   return tx.gachaCardInstance.findMany({
     where,
-    orderBy: { obtainedAt: 'asc' },
+    orderBy: [{ obtainedAt: 'asc' }, { id: 'asc' }],
     ...(opts?.limit ? { take: opts.limit } : {})
   });
 }

--- a/user-backend/src/routes/gacha/draw.routes.ts
+++ b/user-backend/src/routes/gacha/draw.routes.ts
@@ -3,6 +3,7 @@ import { Prisma, GachaRarity } from '@prisma/client';
 import { z } from 'zod';
 import { prisma } from '../../db.js';
 import * as h from './_helpers.js';
+import { planBatchSelectiveDismantle } from './_dismantlePlanner.js';
 
 export function registerDrawRoutes(router: Router) {
   router.post('/draw', async (req, res, next) => {
@@ -583,72 +584,128 @@ export function registerDrawRoutes(router: Router) {
         const byRarityCount: Record<GachaRarity, number> = { WHITE: 0, GREEN: 0, BLUE: 0, PURPLE: 0, GOLD: 0 };
         const byRarityReward: Record<GachaRarity, number> = { WHITE: 0, GREEN: 0, BLUE: 0, PURPLE: 0, GOLD: 0 };
 
-        for (const item of payload.items) {
-          const normalizedSignature = item.affixSignature
+        // ── #96 集合化：原实现对 ≤500 个 item 在单个长事务里逐个串行查询/删除(~4000 次往返、
+        // 持锁数十秒、串行化冲突重试风暴)。改为单次批量读取快照 → 纯函数规划器复刻旧 per-item
+        // 顺序语义(planBatchSelectiveDismantle，由 scripts/verify-dismantle-planner.ts golden 验证
+        // 与旧循环逐项等价) → 一次性 deleteMany/createMany/count 同步/钱包结算。仍是单原子事务，
+        // 外部"全成或全不成"契约与幂等不变；事务大幅变短，冲突窗口骤降。
+        const planItems = payload.items.map((item) => ({
+          cardId: item.cardId,
+          affixSignature: item.affixSignature
             ? h.affixSignatureFromStyles(h.parseAffixSignature(item.affixSignature))
-            : undefined;
-          const instanceWhere: Prisma.GachaCardInstanceWhereInput = {
-            userId,
-            cardId: item.cardId,
-            tradeListingId: null,
-            buyRequestId: null
-          };
-          if (normalizedSignature) {
-            instanceWhere.affixSignature = normalizedSignature;
+            : undefined,
+          count: item.count
+        }));
+        const cardIds = [...new Set(planItems.map((it) => it.cardId))];
+
+        // 快照：一次性批量读取（替代每 item 的 2×count + findFreeInstances + findUnique）。
+        const [cardDefs, totalGroups, lockedGroups, freeInstances] = await Promise.all([
+          tx.gachaCardDefinition.findMany({ where: { id: { in: cardIds } } }),
+          // 留存护栏分母：排除交易/求购，但包含锁定/放置/展示。
+          tx.gachaCardInstance.groupBy({
+            by: ['cardId', 'affixSignature'],
+            where: { userId, cardId: { in: cardIds }, tradeListingId: null, buyRequestId: null },
+            _count: { _all: true }
+          }),
+          tx.gachaCardInstance.groupBy({
+            by: ['cardId', 'affixSignature'],
+            where: { userId, cardId: { in: cardIds }, tradeListingId: null, buyRequestId: null, isLocked: true },
+            _count: { _all: true }
+          }),
+          // 自由实例池（完整白名单），按 obtainedAt 升序；加 id 次级排序消除 obtainedAt 并列
+          // （如十连同一时刻获得）的歧义，使批量选择【确定性】，并保证一次全池查询与逐 item
+          // 查询的并列解析一致。
+          tx.gachaCardInstance.findMany({
+            where: {
+              userId, cardId: { in: cardIds },
+              tradeListingId: null, buyRequestId: null,
+              placementSlot: { is: null }, showcaseSlot: { is: null }, isLocked: false
+            },
+            select: { id: true, cardId: true, affixSignature: true },
+            orderBy: [{ obtainedAt: 'asc' }, { id: 'asc' }]
+          })
+        ]);
+
+        const cardById = new Map(cardDefs.map((c) => [c.id, c]));
+        const cardExists = new Set(cardById.keys());
+
+        const totalByCard = new Map<string, number>();
+        const totalByCardSig = new Map<string, Map<string, number>>();
+        const lockedByCard = new Map<string, number>();
+        const lockedByCardSig = new Map<string, Map<string, number>>();
+        const accumulate = (
+          flat: Map<string, number>,
+          nested: Map<string, Map<string, number>>,
+          groups: Array<{ cardId: string; affixSignature: string; _count: { _all: number } }>
+        ) => {
+          for (const g of groups) {
+            const cnt = g._count._all;
+            flat.set(g.cardId, (flat.get(g.cardId) ?? 0) + cnt);
+            let inner = nested.get(g.cardId);
+            if (!inner) { inner = new Map(); nested.set(g.cardId, inner); }
+            inner.set(g.affixSignature, (inner.get(g.affixSignature) ?? 0) + cnt);
           }
+        };
+        accumulate(totalByCard, totalByCardSig, totalGroups);
+        accumulate(lockedByCard, lockedByCardSig, lockedGroups);
 
-          // Server-side retention guard: destructive count must always respect keepAtLeast
-          // against the current instance set, not just the stale client snapshot.
-          // We must preserve at least `keepAtLeast` instances OR all locked instances,
-          // whichever is greater. Locked instances are never deletable anyway, so the
-          // effective minimum to keep = max(lockedOwnedCount, keepAtLeast).
-          const [totalOwnedCount, lockedOwnedCount] = await Promise.all([
-            tx.gachaCardInstance.count({ where: instanceWhere }),
-            tx.gachaCardInstance.count({ where: { ...instanceWhere, isLocked: true } })
-          ]);
-          const minKeep = Math.max(lockedOwnedCount, payload.keepAtLeast);
-          const maxDeletableCount = Math.max(0, totalOwnedCount - minKeep);
-          const targetDeleteCount = Math.min(item.count, maxDeletableCount);
-          if (targetDeleteCount <= 0) continue;
+        const freeByCard = new Map<string, Array<{ id: string; cardId: string; affixSignature: string }>>();
+        for (const inst of freeInstances) {
+          let list = freeByCard.get(inst.cardId);
+          if (!list) { list = []; freeByCard.set(inst.cardId, list); }
+          list.push(inst);
+        }
 
-          // eslint-disable-next-line no-await-in-loop
-          const freeInstances = await h.findFreeInstances(tx, userId, item.cardId, {
-            affixSignature: normalizedSignature,
-            limit: targetDeleteCount
-          });
-          const dismantleCount = Math.min(freeInstances.length, targetDeleteCount);
-          if (dismantleCount <= 0) continue;
+        // 纯规划：复刻旧 per-item 顺序语义（按已删后的状态续算，含重复 item/混合 affix）。
+        const plan = planBatchSelectiveDismantle(planItems, payload.keepAtLeast, {
+          totalByCard, totalByCardSig, lockedByCard, lockedByCardSig, freeByCard, cardExists
+        });
 
-          const toDelete = freeInstances.slice(0, dismantleCount);
-          const consumeGroups = new Map<string, number>();
-          for (const inst of toDelete) {
-            consumeGroups.set(inst.affixSignature, (consumeGroups.get(inst.affixSignature) ?? 0) + 1);
-          }
-
-          // eslint-disable-next-line no-await-in-loop
-          const card = await tx.gachaCardDefinition.findUnique({ where: { id: item.cardId } });
-          if (!card) continue;
-
+        const logRows: Prisma.GachaDismantleLogCreateManyInput[] = [];
+        for (const it of plan.perItem) {
+          const card = cardById.get(it.cardId);
+          if (!card) continue; // planner 已按 cardExists 过滤，此处仅防御
           const consumed: Array<{ affixVisualStyle: h.AffixVisualStyle; affixSignature: string; affixStyles: h.AffixVisualStyle[]; count: number }> = [];
-          for (const [signature, count] of consumeGroups) {
+          for (const [signature, count] of it.consumeGroups) {
             const fp = h.buildAffixFingerprintFromSignature(signature);
             consumed.push({ affixVisualStyle: fp.affixVisualStyle, affixSignature: fp.affixSignature, affixStyles: fp.affixStyles, count });
           }
-
-          // eslint-disable-next-line no-await-in-loop
-          await h.deleteCardInstances(tx, toDelete.map((inst) => inst.id));
-
           const rewardDetail = h.computeDismantleRewardByAffix(card, consumed);
           cardsAffected += 1;
-          totalCount += dismantleCount;
+          totalCount += it.dismantleCount;
           totalReward += rewardDetail.totalReward;
-          byRarityCount[card.rarity] += dismantleCount;
+          byRarityCount[card.rarity] += it.dismantleCount;
           byRarityReward[card.rarity] += rewardDetail.totalReward;
+          logRows.push({ userId, cardId: it.cardId, count: it.dismantleCount, tokensEarned: rewardDetail.totalReward });
+        }
 
-          // eslint-disable-next-line no-await-in-loop
-          await tx.gachaDismantleLog.create({
-            data: { userId, cardId: item.cardId, count: dismantleCount, tokensEarned: rewardDetail.totalReward }
+        // 批量写入：一次 deleteMany（再次套白名单兜底并发）+ createMany 日志 + 库存 count 同步。
+        if (plan.selectedIds.length > 0) {
+          const deleted = await tx.gachaCardInstance.deleteMany({
+            where: {
+              id: { in: plan.selectedIds },
+              userId,
+              tradeListingId: null, buyRequestId: null,
+              placementSlot: { is: null }, showcaseSlot: { is: null }, isLocked: false
+            }
           });
+          // 同一 Serializable 事务内快照一致，理论上必相等；不等说明并发改动，抛出使整事务回滚重试。
+          if (deleted.count !== plan.selectedIds.length) {
+            throw new Error(`dismantle_selection_changed: expected ${plan.selectedIds.length}, deleted ${deleted.count}`);
+          }
+          if (logRows.length > 0) {
+            await tx.gachaDismantleLog.createMany({ data: logRows });
+          }
+          // 受影响卡牌库存 count 按删除后真实实例数重算（自愈式，含归零）。
+          const affectedCardIds = [...plan.deletedCountByCard.keys()];
+          await tx.$executeRaw(Prisma.sql`
+            UPDATE "GachaInventory" gi
+            SET count = (
+              SELECT COUNT(*)::int FROM "GachaCardInstance" ci
+              WHERE ci."userId" = gi."userId" AND ci."cardId" = gi."cardId"
+            )
+            WHERE gi."userId" = ${userId} AND gi."cardId" IN (${Prisma.join(affectedCardIds)})
+          `);
         }
 
         let updatedWallet = wallet;

--- a/user-backend/src/routes/gacha/draw.routes.ts
+++ b/user-backend/src/routes/gacha/draw.routes.ts
@@ -689,7 +689,10 @@ export function registerDrawRoutes(router: Router) {
               placementSlot: { is: null }, showcaseSlot: { is: null }, isLocked: false
             }
           });
-          // 同一 Serializable 事务内快照一致，理论上必相等；不等说明并发改动，抛出使整事务回滚重试。
+          // 同一 Serializable 事务内快照一致，此断言理论上恒真；万一不等（并发把实例改为
+          // 已锁/已放置/上架等），抛出使整事务【回滚】——请求以错误失败、无任何部分副作用
+          // （非自动重试：普通 Error 不被 runSerializableTransaction 当 DB 序列化错误重试，
+          // 客户端可凭同一幂等键安全重试）。
           if (deleted.count !== plan.selectedIds.length) {
             throw new Error(`dismantle_selection_changed: expected ${plan.selectedIds.length}, deleted ${deleted.count}`);
           }
@@ -697,13 +700,18 @@ export function registerDrawRoutes(router: Router) {
             await tx.gachaDismantleLog.createMany({ data: logRows });
           }
           // 受影响卡牌库存 count 按删除后真实实例数重算（自愈式，含归零）。
+          // 注意 count 口径：排除已上架交易/求购抵押的实例（与 draw +1 / 上架·求购 -1 的维护
+          // 口径、以及库存聚合的 tradeListingId/buyRequestId IS NULL 一致），否则会把在售/抵押中
+          // 的实例错误加回库存。手动 updatedAt=NOW() 以匹配 @updatedAt（raw SQL 不触发 Prisma）。
           const affectedCardIds = [...plan.deletedCountByCard.keys()];
           await tx.$executeRaw(Prisma.sql`
             UPDATE "GachaInventory" gi
             SET count = (
               SELECT COUNT(*)::int FROM "GachaCardInstance" ci
               WHERE ci."userId" = gi."userId" AND ci."cardId" = gi."cardId"
-            )
+                AND ci."tradeListingId" IS NULL AND ci."buyRequestId" IS NULL
+            ),
+            "updatedAt" = NOW()
             WHERE gi."userId" = ${userId} AND gi."cardId" IN (${Prisma.join(affectedCardIds)})
           `);
         }


### PR DESCRIPTION
## 问题（#96）

`/dismantle/batch-selective`（前端唯一在用的批量分解端点，≤500 items）原本把所有 item 的选择/删除塞进**单个 Serializable 长事务**，循环内每个 item 串行发起 ~8-9 次 DB 往返（2×count + findFreeInstances + findUnique + deleteCardInstances + 逐条 create log），共约 **4000 次串行往返、持锁数十秒**。高并发下串行化冲突重试风暴，事务时长与内存双高（生产日志可见同用户的 `/gacha/draw` 也被钱包热行冲突拖入 retry）。

这是**性能问题，非正确性 bug**——原逻辑正确/原子/幂等。

## 方案（D，与 Codex 讨论后采纳）

保持"单原子事务 + 外部全成或全不成契约 + 现有幂等"不变，把 per-item 循环**集合化**：

1. **选择逻辑抽成纯函数** `planBatchSelectiveDismantle`（`_dismantlePlanner.ts`），在内存里**逐字复刻**旧 per-item 顺序语义（按已删后的状态续算，覆盖重复 item / 同 card 同 affix / 混合"指定与不指定 affix" / obtainedAt 先后 / 缺卡定义跳过）。
2. **端点改为单次批量读取快照**（1 findMany 卡定义 + 2 groupBy 留存计数 + 1 findMany 自由池）→ planner 规划 → **一次 deleteMany**（where 再套完整自由白名单兜底并发 + `deleted.count` 断言）+ **createMany 日志** + 一次 raw SQL 重算受影响卡库存 count + 一次钱包结算 + 一条 ledger。约 4000 次往返压到 **~9 次**，事务大幅变短，冲突窗口骤降。
3. 自由池查询加 `id` 次级排序，消除 `obtainedAt` 并列（如十连同刻获得）的歧义，使选择**确定性**。
4. 库存 `count` 改为按删除后真实实例数**重算**（自愈式，含归零）。

## 不变量（全部保持）

自由白名单（未交易/求购/锁定/放置/展示）、留存护栏 `minKeep=max(locked,keepAtLeast)`、count 同步、代币=被删集合的精确函数（仍由 `computeDismantleRewardByAffix` 计算）、删除与发币同一原子边界。

## 验证

- `scripts/verify-dismantle-planner.ts`：**20000** 随机用例，planner 与"逐字复刻旧循环语义"的参考实现**选中实例逐项一致**。
- `scripts/verify-dismantle-realdata.ts`：对 **8 个最重真实用户、96 用例**（含指定/不指定 sig），新查询层快照 + planner 与"逐字复刻旧端点的只读重放"完全一致；确认自由实例 `affixSignature` 无 null。
- user-backend `tsc` 0 error。两脚本不参与构建（`include: src/**` 之外），作为可复现校验工具提交。

## 风险

- 选择一致 ⇒ 奖励/日志/汇总一致（均为选择的确定性函数）。唯一与旧行为的差异是 `obtainedAt` 并列时旧代码非确定、本 PR 确定按 id 取——总量/count 不变，仅在并列边界实例 sig 不同的罕见情况下总奖励可能有微小确定性差异，仍在旧非确定性范围内。

Refs #96
