### PR TITLE
fix(forum): 跨页回复附带父帖快照+线程全局楼层 (#114)

### DIFF
--- a/bff/src/web/routes/forums.ts
+++ b/bff/src/web/routes/forums.ts
@@ -176,13 +176,26 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
             LEFT JOIN "Page" p ON p.id = t."pageId"
             WHERE t.id = $1 AND t."isDeleted" = false
           `, [threadId]),
+          // floor：线程内全局楼层号（按时间序，#1=最早），用窗口函数对【整个线程】计算后再分页，
+          // 故跨页稳定、与树形 DFS 显示顺序解耦（修 #114 楼层错位）。
+          // parentCreatedByName/parentFloor：父帖快照，自连接同一 CTE 取得，使父帖即便在别的页
+          // 也能渲染"回复 @某人 #楼层"，不再静默丢失上下文（修 #114 跨页孤儿）。
           readPool.query(`
-            SELECT id, "threadId", "parentId", title, "textHtml", "createdByName",
-                   "createdByWikidotId", "createdByType", "createdAt",
-                   "editedAt", "isDeleted"
-            FROM "ForumPost"
-            WHERE "threadId" = $1
-            ORDER BY "createdAt" ${order} NULLS LAST, id ${order}
+            WITH ordered AS (
+              SELECT id, "threadId", "parentId", title, "textHtml", "createdByName",
+                     "createdByWikidotId", "createdByType", "createdAt", "editedAt", "isDeleted",
+                     (ROW_NUMBER() OVER (ORDER BY "createdAt" ASC NULLS LAST, id ASC))::int AS floor
+              FROM "ForumPost"
+              WHERE "threadId" = $1
+            )
+            SELECT o.id, o."threadId", o."parentId", o.title, o."textHtml", o."createdByName",
+                   o."createdByWikidotId", o."createdByType", o."createdAt", o."editedAt", o."isDeleted",
+                   o.floor,
+                   par."createdByName" AS "parentCreatedByName",
+                   par.floor AS "parentFloor"
+            FROM ordered o
+            LEFT JOIN ordered par ON par.id = o."parentId"
+            ORDER BY o."createdAt" ${order} NULLS LAST, o.id ${order}
             LIMIT $2 OFFSET $3
           `, [threadId, limit, offset]),
           readPool.query(`

--- a/bff/src/web/routes/forums.ts
+++ b/bff/src/web/routes/forums.ts
@@ -180,23 +180,33 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
           // 故跨页稳定、与树形 DFS 显示顺序解耦（修 #114 楼层错位）。
           // parentCreatedByName/parentFloor：父帖快照，自连接同一 CTE 取得，使父帖即便在别的页
           // 也能渲染"回复 @某人 #楼层"，不再静默丢失上下文（修 #114 跨页孤儿）。
+          // ordered 只携带【轻字段】(排名/父帖快照所需)对整线程算全局楼层 floor，自连接取父帖
+          // 快照后分页；正文 textHtml/title 等大字段只对分页后的 50 行 JOIN 回 ForumPost，避免
+          // 热门长帖每次翻页都物化全线程正文。
           readPool.query(`
             WITH ordered AS (
-              SELECT id, "threadId", "parentId", title, "textHtml", "createdByName",
-                     "createdByWikidotId", "createdByType", "createdAt", "editedAt", "isDeleted",
+              SELECT id, "parentId", "createdByName", "createdAt",
                      (ROW_NUMBER() OVER (ORDER BY "createdAt" ASC NULLS LAST, id ASC))::int AS floor
               FROM "ForumPost"
               WHERE "threadId" = $1
+            ),
+            page AS (
+              SELECT o.id, o.floor,
+                     par."createdByName" AS "parentCreatedByName",
+                     par.floor AS "parentFloor"
+              FROM ordered o
+              LEFT JOIN ordered par ON par.id = o."parentId"
+              ORDER BY o."createdAt" ${order} NULLS LAST, o.id ${order}
+              LIMIT $2 OFFSET $3
             )
-            SELECT o.id, o."threadId", o."parentId", o.title, o."textHtml", o."createdByName",
-                   o."createdByWikidotId", o."createdByType", o."createdAt", o."editedAt", o."isDeleted",
-                   o.floor,
-                   par."createdByName" AS "parentCreatedByName",
-                   par.floor AS "parentFloor"
-            FROM ordered o
-            LEFT JOIN ordered par ON par.id = o."parentId"
-            ORDER BY o."createdAt" ${order} NULLS LAST, o.id ${order}
-            LIMIT $2 OFFSET $3
+            SELECT fp.id, fp."threadId", fp."parentId", fp.title, fp."textHtml", fp."createdByName",
+                   fp."createdByWikidotId", fp."createdByType", fp."createdAt", fp."editedAt", fp."isDeleted",
+                   pg.floor,
+                   pg."parentCreatedByName",
+                   pg."parentFloor"
+            FROM page pg
+            JOIN "ForumPost" fp ON fp.id = pg.id
+            ORDER BY fp."createdAt" ${order} NULLS LAST, fp.id ${order}
           `, [threadId, limit, offset]),
           readPool.query(`
             SELECT COUNT(*)::int AS total

--- a/frontend/composables/api/forums.ts
+++ b/frontend/composables/api/forums.ts
@@ -44,6 +44,10 @@ export function useForumsApi() {
         createdAt: string | null
         editedAt: string | null
         isDeleted: boolean
+        // 线程全局楼层号（#1=最早，跨页稳定）；父帖快照（作者名 + 楼层），用于跨页渲染"回复 @某人 #楼层"。
+        floor: number | null
+        parentCreatedByName: string | null
+        parentFloor: number | null
         sourceThreadUrl: string | null
         sourcePostUrl: string | null
       }>

--- a/frontend/pages/forums/t/[id].vue
+++ b/frontend/pages/forums/t/[id].vue
@@ -99,6 +99,10 @@ interface PostItem {
   createdAt?: string | null
   editedAt?: string | null
   isDeleted?: boolean
+  // 服务端线程全局楼层号 + 父帖快照（作者/楼层），跨页稳定（#114）。
+  floor?: number | null
+  parentCreatedByName?: string | null
+  parentFloor?: number | null
   sourceThreadUrl?: string | null
   sourcePostUrl?: string | null
   _dbIndex: number // original position in API response
@@ -170,9 +174,10 @@ const flatPosts = computed(() => {
   return result
 })
 
-// Compute floor number for a post based on its original DB position
-// 楼层号始终以正序为基准（即按时间先后顺序编号）
+// 楼层号优先用服务端线程全局 floor（#1=最早，跨页稳定、与树形 DFS 显示顺序解耦，修 #114
+// 楼层错位）；floor 缺失时兜底沿用旧的按页推算。
 function getFloorNumber(item: { post: PostItem }): number {
+  if (item.post.floor != null) return item.post.floor
   if (!data.value) return 0
   const { total, limit } = data.value
   const pageOffset = (currentPage.value - 1) * limit
@@ -180,13 +185,6 @@ function getFloorNumber(item: { post: PostItem }): number {
     return pageOffset + item.post._dbIndex + 1
   }
   return total - pageOffset - item.post._dbIndex
-}
-
-// Get parent author name for reply indicator
-function getParentAuthor(parentId: number | null | undefined): string | null {
-  if (!parentId || !data.value?.posts) return null
-  const parent = data.value.posts.find((p: any) => p.id === parentId)
-  return parent?.createdByName || null
 }
 
 // 使用 DOMPurify 过滤 HTML 并转换 Wikidot 相对链接
@@ -531,13 +529,15 @@ function copyFloorLink(floor: number) {
               </a>
             </div>
 
-            <!-- Reply indicator -->
+            <!-- Reply indicator：用服务端父帖快照（作者 + 楼层），父帖即便在别的页也能显示
+                 "回复 @某人 #楼层"，不再因跨页静默丢失上下文（修 #114）。 -->
             <div
-              v-if="item.post.parentId && getParentAuthor(item.post.parentId)"
+              v-if="item.post.parentId && item.post.parentCreatedByName"
               class="mt-1 text-[11px] text-[rgb(var(--muted)_/_0.7)] inline-flex items-center gap-1"
             >
               <LucideIcon name="CornerDownRight" class="w-3 h-3" stroke-width="2" aria-hidden="true" />
-              回复 <span class="font-medium">{{ getParentAuthor(item.post.parentId) }}</span>
+              回复 <span class="font-medium">{{ item.post.parentCreatedByName }}</span>
+              <span v-if="item.post.parentFloor" class="font-mono text-[rgb(var(--muted)_/_0.6)]">#{{ item.post.parentFloor }}</span>
             </div>
 
             <!-- Post title -->


### PR DESCRIPTION
## 问题（#114）

论坛长帖翻页后，父帖在**上一页**的回复被前端"按页拉取、按页建树"判为孤儿（`postMap.has(parentId)` 只查本页），**静默提升为顶层根节点**，丢失缩进与"回复某人"上下文。此外楼层号用本页 `_dbIndex` 推算，被树形 DFS 重排后与显示顺序错位。

## 改动

**BFF** `GET /forums/threads/:id`：
- 用窗口函数 `ROW_NUMBER() OVER (ORDER BY createdAt, id)` 对**整个线程**计算全局楼层 `floor`（#1=最早），再分页 → 楼层跨页稳定、与树形显示顺序解耦。
- 自连接同一 CTE 取**父帖快照** `parentCreatedByName` / `parentFloor` → 父帖即便在别页也带得出。

**前端** `pages/forums/t/[id].vue` + `composables/api/forums.ts`：
- 楼层号改用服务端 `floor`（缺失时兜底旧推算）。
- 回复指示器改用父帖快照，跨页也能渲染"回复 @某人 #楼层"，不再静默丢失上下文；移除只查本页的 `getParentAuthor`。

## 验证

- 真实线程 3164139：#51（page 2）回复 #49（page 1，Maxwell Heroin Roth）等多个跨页案例，自连接快照 `parentFloor`/`parentCreatedByName` 正确填充。
- BFF `tsc` 与 frontend `nuxt typecheck` 均 0 error。

## 说明

- 跨页孤儿仍渲染在根层级（无法视觉嵌套到别页父帖之下），但通过"回复 @某人 #楼层"恢复了上下文——满足 issue 的"至少线性显示 + 父楼层"要求。
- 仅改主线程视图端点；其余讨论预览端点不在本次范围。

Refs #114
