### PR TITLE
fix(platform): XSS/水合/缓存日期/投票计数 平台层批量修复 (#121 #124 #125 #126)

### DIFF
--- a/backend/src/core/store/VoteRevisionStore.ts
+++ b/backend/src/core/store/VoteRevisionStore.ts
@@ -155,6 +155,19 @@ export class VoteRevisionStore {
         for (const data of voteData) {
           try {
             if (data.userId != null) {
+              // #125：upsert 不区分插入/更新，故先按唯一约束探测是否已存在，再据此分别计数
+              // （原实现一律计入 inserted、updated 恒为 0，统计不可信）。导入为离线批处理，
+              // 多一次按唯一索引的 findUnique 开销可接受。
+              const existing = await this.prisma.vote.findUnique({
+                where: {
+                  Vote_unique_constraint: {
+                    pageVersionId: data.pageVersionId,
+                    userId: data.userId,
+                    timestamp: data.timestamp
+                  }
+                },
+                select: { id: true }
+              });
               await this.prisma.vote.upsert({
                 where: {
                   Vote_unique_constraint: {
@@ -173,8 +186,18 @@ export class VoteRevisionStore {
                   timestamp: data.timestamp
                 }
               });
-              stats.inserted++;
+              if (existing) stats.updated++; else stats.inserted++;
             } else if (data.anonKey) {
+              const existing = await this.prisma.vote.findUnique({
+                where: {
+                  Vote_anon_unique_constraint: {
+                    pageVersionId: data.pageVersionId,
+                    anonKey: data.anonKey,
+                    timestamp: data.timestamp
+                  }
+                },
+                select: { id: true }
+              });
               await this.prisma.vote.upsert({
                 where: {
                   Vote_anon_unique_constraint: {
@@ -193,7 +216,7 @@ export class VoteRevisionStore {
                   timestamp: data.timestamp
                 }
               });
-              stats.inserted++;
+              if (existing) stats.updated++; else stats.inserted++;
             } else {
               // 既无 userId 又无 anonKey：schema 没有对应唯一约束，直接 create 会在重复跑时无限膨胀，跳过
               Logger.debug(`Skipping vote with neither userId nor anonKey (pageVersionId=${pageVersionId}, timestamp=${data.timestamp.toISOString()})`);

--- a/bff/src/web/utils/cache.ts
+++ b/bff/src/web/utils/cache.ts
@@ -16,6 +16,19 @@ export type CacheHandle = {
 
 const DEFAULT_PREFIX = 'scpcn:bff:';
 
+// #124：统一缓存契约为"JSON 归一化值"。Redis 命中走 JSON.parse（Date 退化为字符串），
+// 未命中却直接返回 loader 的原始对象（Date 仍是对象），导致同一 key 命中/未命中类型不一致、
+// 消费端行为漂移。jsonClone 让未命中路径也返回归一化形态，并据此存储，使命中/未命中、
+// Redis/内存后端的返回类型一律一致（日期统一为字符串，符合代码库"字段可能是字符串需转换"约定）。
+function jsonClone<T>(value: T): T {
+  if (value === null || value === undefined || typeof value !== 'object') return value;
+  try {
+    return JSON.parse(JSON.stringify(value)) as T;
+  } catch {
+    return value;
+  }
+}
+
 // Simple in-memory cache fallback when Redis is unavailable
 const memoryCache = new Map<string, { value: unknown; expiresAt: number }>();
 const MAX_MEMORY_CACHE_SIZE = 1000;
@@ -81,8 +94,10 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
             const result = await loader();
             if (result === undefined) return result;
             if (result === null && opts?.cacheNull !== true) return result;
-            memorySet(store, maxSize, fullKey, result, ttl);
-            return result;
+            // 存储并返回归一化形态，使内存后端的命中/未命中与 Redis 后端口径一致（#124）。
+            const normalized = jsonClone(result);
+            memorySet(store, maxSize, fullKey, normalized, ttl);
+            return normalized;
           } finally {
             inflight.delete(fullKey);
           }
@@ -150,7 +165,8 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
         if (result === undefined) return result;
         if (result === null && options?.cacheNull !== true) return result;
         await setJSON(key, result, ttlSeconds);
-        return result;
+        // 未命中也返回 JSON 归一化形态，与后续命中（getJSON→JSON.parse）口径一致（#124）。
+        return jsonClone(result);
       } finally {
         inflight.delete(fullKey);
       }

--- a/bff/src/web/utils/cache.ts
+++ b/bff/src/web/utils/cache.ts
@@ -110,7 +110,8 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
       },
       async setJSON(key: string, value: unknown, ttlSeconds: number): Promise<void> {
         if (value !== undefined) {
-          memorySet(store, maxSize, `${prefix}${key}`, value, ttlSeconds);
+          // 存归一化形态，使内存后端的 getJSON 与 Redis(JSON 往返)口径一致（#124）。
+          memorySet(store, maxSize, `${prefix}${key}`, jsonClone(value), ttlSeconds);
         }
       }
     };

--- a/frontend/components/UserCard.vue
+++ b/frontend/components/UserCard.vue
@@ -186,11 +186,23 @@ import { navigateTo } from 'nuxt/app'
   })
   const avgRatingText = computed(() => Number.isFinite(avgRatingResolved.value) ? avgRatingResolved.value.toFixed(1) : '—')
   
+  // SSR 与首次客户端渲染必须一致，否则水合告警：相对时间依赖 Date.now()（当前时刻）与本地
+  // 时区，服务端/客户端必然不同。故挂载前统一渲染【时区无关的 UTC 绝对日期】（稳定、可 SSR），
+  // 挂载后再切换为相对时间（仅客户端）。
+  const lastActiveMounted = ref(false)
+  onMounted(() => { lastActiveMounted.value = true })
+  function formatUtcDate(parsed: number): string {
+    const d = new Date(parsed)
+    const y = d.getUTCFullYear(); const m = String(d.getUTCMonth() + 1).padStart(2, '0'); const da = String(d.getUTCDate()).padStart(2, '0')
+    return `${y}-${m}-${da}`
+  }
   const lastActiveText = computed(() => {
     const iso = props.lastActiveISO
     if (!iso) return ''
     const parsed = Date.parse(iso)
     if (Number.isNaN(parsed)) return ''
+    // 挂载前（SSR + 首次客户端渲染）：稳定的 UTC 绝对日期，避免水合不一致。
+    if (!lastActiveMounted.value) return formatUtcDate(parsed)
     const diff = Date.now() - parsed
     const sec = Math.floor(diff / 1000)
     if (sec < 60) return '刚刚'
@@ -200,9 +212,7 @@ import { navigateTo } from 'nuxt/app'
     if (hr < 24) return `${hr} 小时前`
     const day = Math.floor(hr / 24)
     if (day < 30) return `${day} 天前`
-    const d = new Date(parsed)
-    const y = d.getFullYear(); const m = String(d.getMonth()+1).padStart(2,'0'); const da = String(d.getDate()).padStart(2,'0')
-    return `${y}-${m}-${da}`
+    return formatUtcDate(parsed)
   })
 
   const viewerVoteBadge = computed(() => {

--- a/frontend/components/user/UserRevisions.vue
+++ b/frontend/components/user/UserRevisions.vue
@@ -63,6 +63,8 @@
 </template>
 
 <script setup lang="ts">
+import DOMPurify from 'isomorphic-dompurify'
+
 type ForumPostItem = {
   id: number
   title?: string
@@ -160,7 +162,10 @@ function formatRelativeTime(dateStr: string) {
   return `${Math.floor(diffM / 12)} 年前`
 }
 
+// 用 DOMPurify 解析器级剥离全部标签（替代脆弱正则——正则对 <img onerror=x// 等未闭合/
+// 嵌套标签会留下可执行残片，再经 v-html 直出即 XSS）。ALLOWED_TAGS:[] 输出为 DOMPurify
+// 保证安全的纯文本，可安全用于 v-html。
 function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, '').trim().slice(0, 200)
+  return DOMPurify.sanitize(html, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] }).trim().slice(0, 200)
 }
 </script>


### PR DESCRIPTION
平台层 MEDIUM/LOW 批量修复（来自 2026-06 审计），一并关闭 4 个 issue。

## #121（MEDIUM · XSS）
`UserRevisions` 用 `replace(/<[^>]*>/g, '')` 脆弱正则剥标签后经 `v-html` 直出——正则对 `<img onerror=x//`、嵌套/未闭合标签会留下可执行残片。改用 **DOMPurify（`ALLOWED_TAGS: []`）** 解析器级剥离，输出为 DOMPurify 保证安全的纯文本。

## #124（LOW · 缓存日期）
`cache.remember` 在 Redis 后端**命中**走 `JSON.parse`（日期退化为字符串），**未命中**却返回 loader 的原始对象（日期仍是 `Date`），同一 key 类型漂移。新增 `jsonClone`，未命中也返回 JSON 归一化形态并据此存储 → 命中/未命中、Redis/内存后端口径统一（日期统一为字符串，符合代码库"字段可能是字符串需转换"约定）。

## #125（LOW · 投票计数）
`VoteRevisionStore.importVotes` 每次 `upsert` 一律 `inserted++`、`updated` 恒为 0。改为 upsert 前按唯一约束 `findUnique` 探测是否已存在，据此分别计入。导入为离线批处理，多一次按唯一索引的查询可接受；不在投票写路径引入裸 SQL 风险。

## #126（LOW · 水合）
`UserCard` "最近活动"相对时间依赖 `Date.now()` + 本地时区，SSR/客户端必然不同 → 水合告警。改为挂载前渲染**时区无关的 UTC 绝对日期**（稳定可 SSR），挂载后再切相对时间。

## 验证
frontend（`nuxt typecheck`）、bff（`tsc`）、backend（`tsc`）均 0 error。

Closes #121, #124, #125, #126
