### PR TITLE
fix(forum): 列表排序唯一兜底 + 活跃用户死链守卫 (#119 #117)

### DIFF
--- a/bff/src/web/routes/forums.ts
+++ b/bff/src/web/routes/forums.ts
@@ -280,7 +280,7 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
                   AND LOWER(BTRIM(t.title)) = ANY($3::text[])
                 )
               )
-            ORDER BY t."createdAt" DESC NULLS LAST
+            ORDER BY t."createdAt" DESC NULLS LAST, t.id DESC
           `, [pageId, PAGE_DISCUSSION_CATEGORY_ID, slugCandidates])
           : readPool.query(`
             SELECT t.id, t.title, t."createdByName", t."createdByWikidotId", t."createdAt",
@@ -289,7 +289,7 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
             FROM "ForumThread" t
             LEFT JOIN "ForumCategory" c ON c.id = t."categoryId"
             WHERE t."pageId" = $1 AND t."isDeleted" = false
-            ORDER BY t."createdAt" DESC NULLS LAST
+            ORDER BY t."createdAt" DESC NULLS LAST, t.id DESC
           `, [pageId]);
 
         const { rows: threads } = await threadQuery;
@@ -324,7 +324,7 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
           FROM "ForumPost"
           WHERE "isDeleted" = false AND "createdByName" IS NOT NULL
           GROUP BY "createdByName", "createdByWikidotId"
-          ORDER BY "postCount" DESC
+          ORDER BY "postCount" DESC, "createdByWikidotId" DESC NULLS LAST, "createdByName"
           LIMIT 10
         `);
 
@@ -357,7 +357,7 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
           FROM "ForumThread" t
           LEFT JOIN "ForumCategory" c ON c.id = t."categoryId"
           WHERE t."isDeleted" = false
-          ORDER BY t."createdAt" DESC NULLS LAST
+          ORDER BY t."createdAt" DESC NULLS LAST, t.id DESC
           LIMIT $1
         `, [limit]);
 
@@ -390,7 +390,7 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
             JOIN "ForumThread" t ON t.id = p."threadId"
             LEFT JOIN "ForumCategory" c ON c.id = t."categoryId"
             WHERE p."isDeleted" = false AND t."isDeleted" = false
-            ORDER BY p."createdAt" DESC NULLS LAST
+            ORDER BY p."createdAt" DESC NULLS LAST, p.id DESC
             LIMIT $1 OFFSET $2
           `, [limit, offset]),
           readPool.query(`

--- a/bff/src/web/routes/forums.ts
+++ b/bff/src/web/routes/forums.ts
@@ -506,7 +506,7 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
             WHERE p."createdByWikidotId" = $1
               AND p."isDeleted" = false
               AND t."isDeleted" = false
-            ORDER BY p."createdAt" DESC NULLS LAST
+            ORDER BY p."createdAt" DESC NULLS LAST, p.id DESC
             LIMIT $2 OFFSET $3
           `, [wikidotId, limit, offset]),
           readPool.query(`
@@ -559,7 +559,7 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
           WHERE p."isDeleted" = false
             AND t."isDeleted" = false
             AND (p."textHtml" ILIKE $1 OR p.title ILIKE $1 OR t.title ILIKE $1)
-          ORDER BY p."createdAt" DESC NULLS LAST
+          ORDER BY p."createdAt" DESC NULLS LAST, p.id DESC
           LIMIT $2 OFFSET $3
         `, [searchPattern, limit, offset]),
         readPool.query(`

--- a/frontend/composables/api/forums.ts
+++ b/frontend/composables/api/forums.ts
@@ -79,7 +79,7 @@ export function useForumsApi() {
       threadsCount: number
       postsCount: number
       lastPostAt: string | null
-      topPosters: Array<{ name: string; wikidotId: number; postCount: number }>
+      topPosters: Array<{ name: string; wikidotId: number | null; postCount: number }>
     }>('/forums/stats')
   }
 

--- a/frontend/pages/forums/index.vue
+++ b/frontend/pages/forums/index.vue
@@ -2,6 +2,9 @@
 import { useForumsApi } from '~/composables/api/forums'
 import ForumRecentPostCard from '~/components/forums/ForumRecentPostCard.vue'
 
+// 用于活跃用户列表按是否有 wikidotId 在 NuxtLink / span 间切换（#117 死链守卫）。
+const NuxtLinkComp = resolveComponent('NuxtLink')
+
 definePageMeta({ key: route => route.fullPath })
 
 type ForumTab = 'recent' | 'categories'
@@ -95,11 +98,14 @@ const btnClass = 'px-3 py-1.5 rounded-lg text-sm border border-[rgb(var(--panel-
       <div v-if="stats.topPosters?.length" class="pt-3 border-t border-[rgb(var(--panel-border)_/_0.25)]">
         <div class="text-xs text-[rgb(var(--muted))] mb-2">活跃用户</div>
         <div class="flex flex-wrap gap-2">
-          <NuxtLink
+          <!-- 作者 wikidotId 缺失时(约 45% 论坛作者无标识)渲染为纯文本而非 /user/null 死链(#117)。 -->
+          <component
+            :is="poster.wikidotId ? NuxtLinkComp : 'span'"
             v-for="poster in stats.topPosters.slice(0, 8)"
-            :key="poster.wikidotId"
-            :to="`/user/${poster.wikidotId}`"
-            class="inline-flex items-center gap-1.5 rounded-full bg-[rgb(var(--panel)_/_0.5)] border border-[rgb(var(--panel-border)_/_0.25)] px-2 py-1 text-xs text-[rgb(var(--muted-strong))] hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)] transition"
+            :key="poster.wikidotId ?? poster.name"
+            :to="poster.wikidotId ? `/user/${poster.wikidotId}` : undefined"
+            class="inline-flex items-center gap-1.5 rounded-full bg-[rgb(var(--panel)_/_0.5)] border border-[rgb(var(--panel-border)_/_0.25)] px-2 py-1 text-xs text-[rgb(var(--muted-strong))] transition"
+            :class="poster.wikidotId ? 'hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)]' : ''"
           >
             <UserAvatar
               :wikidot-id="poster.wikidotId"
@@ -108,7 +114,7 @@ const btnClass = 'px-3 py-1.5 rounded-lg text-sm border border-[rgb(var(--panel-
             />
             {{ poster.name }}
             <span class="text-[10px] text-[rgb(var(--muted)_/_0.7)]">{{ poster.postCount }}</span>
-          </NuxtLink>
+          </component>
         </div>
       </div>
     </div>

--- a/frontend/pages/forums/index.vue
+++ b/frontend/pages/forums/index.vue
@@ -102,7 +102,7 @@ const btnClass = 'px-3 py-1.5 rounded-lg text-sm border border-[rgb(var(--panel-
           <component
             :is="poster.wikidotId ? NuxtLinkComp : 'span'"
             v-for="poster in stats.topPosters.slice(0, 8)"
-            :key="poster.wikidotId ?? poster.name"
+            :key="poster.wikidotId != null ? `wid:${poster.wikidotId}:${poster.name}` : `name:${poster.name}`"
             :to="poster.wikidotId ? `/user/${poster.wikidotId}` : undefined"
             class="inline-flex items-center gap-1.5 rounded-full bg-[rgb(var(--panel)_/_0.5)] border border-[rgb(var(--panel-border)_/_0.25)] px-2 py-1 text-xs text-[rgb(var(--muted-strong))] transition"
             :class="poster.wikidotId ? 'hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)]' : ''"


### PR DESCRIPTION
论坛域 LOW/MEDIUM 修复（延续 #112-114 论坛工作）。

## #119（LOW · 排序兜底）
`/recent-posts`（分页）、`/recent`、页面讨论线程列表、首页"活跃用户"的 `ORDER BY` 仅按 `createdAt`/`postCount`，同秒/同计数行在翻页时顺序不稳定。统一补 `id`（活跃用户用 `wikidotId`+`name`）唯一次级排序，使分页确定稳定。

## #117（MEDIUM · 死链守卫，部分）
论坛首页"活跃用户"对 `createdByWikidotId` 为 null 的作者仍渲染 `/user/null` 死链且 `:key` 碰撞。改为动态组件：有 wikidotId 才用 `NuxtLink`，否则纯文本 `span`。

**关于 #117 的完整范围**：经核查，线程/帖子作者 wikidotId 字段缺失率为 **0%**，但 **44.7% 的线程作者 wikidotId 不在本站 User 表**（链到 `/user/{wid}` 为空页）。完整修复需 BFF 为各作者加 `authorExists` 标志（LEFT JOIN User）+ 前端多处按标志条件链接，属更大改动，留作后续聚焦处理。本 PR 仅先消除明确的 `/user/null` 死链与排序不稳。

## 验证
bff `tsc`、frontend `nuxt typecheck` 均 0 error。

Closes #119
Refs #117
