### PR TITLE
revert(social): 恢复'原创'标签纳入用户标签偏好统计

### DIFF
--- a/backend/src/cli/repair-user-vote-stats.ts
+++ b/backend/src/cli/repair-user-vote-stats.ts
@@ -69,7 +69,7 @@ async function dryRunTagPreferences(prisma: PrismaClient) {
         COUNT(*) FILTER (WHERE direction < 0)::int AS downvote_count,
         COUNT(*)::int AS total_votes
       FROM user_tag_votes
-      WHERE tag NOT IN ('原创', '页面', '重定向', '管理', '_cc')
+      WHERE tag NOT IN ('页面', '重定向', '管理', '_cc')
       GROUP BY "userId", tag
       HAVING COUNT(*) >= 3
     ),

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -1276,7 +1276,7 @@ export class IncrementalAnalyzeJob {
           COUNT(*) as total_votes,
           MAX(timestamp) as last_vote_at
         FROM user_tag_votes
-        WHERE tag NOT IN ('原创', '页面', '重定向', '管理', '_cc')
+        WHERE tag NOT IN ('页面', '重定向', '管理', '_cc')
         GROUP BY "userId", tag
         HAVING COUNT(*) >= 3
       )

--- a/backend/src/jobs/UserSocialAnalysisJob.ts
+++ b/backend/src/jobs/UserSocialAnalysisJob.ts
@@ -130,7 +130,7 @@ export class UserSocialAnalysisJob {
             COUNT(*) as total_votes,
             MAX(timestamp) as last_vote_at
           FROM user_tag_votes
-          WHERE tag NOT IN ('原创', '页面', '重定向', '管理', '_cc')
+          WHERE tag NOT IN ('页面', '重定向', '管理', '_cc')
           GROUP BY "userId", tag
           HAVING COUNT(*) >= 3  -- 至少投过3次票的标签才记录
         )
@@ -231,7 +231,7 @@ export class UserSocialAnalysisJob {
             COUNT(*) as total_votes,
             MAX(timestamp) as last_vote_at
           FROM user_tag_votes
-          WHERE tag NOT IN ('原创', '页面', '重定向', '管理', '_cc')
+          WHERE tag NOT IN ('页面', '重定向', '管理', '_cc')
           GROUP BY "userId", tag
           HAVING COUNT(*) >= 3
         )

--- a/bff/src/web/routes/users.ts
+++ b/bff/src/web/routes/users.ts
@@ -1331,7 +1331,6 @@ ORDER BY period;
           FROM "UserTagPreference" utp
           JOIN "User" u ON u.id = utp."userId"
           WHERE u."wikidotId" = $1
-            AND utp."tag" <> '原创'
           ORDER BY ${orderClause}
           LIMIT $2::int OFFSET $3::int
         `;


### PR DESCRIPTION
## 背景

用户反馈：用户页"标签偏好一览/逐标签数据"里的"**原创**"标签数据消失了。

根因：#134 为避免"原创"元标签淹没标签偏好，把 `'原创'` 加入了 UTP（UserTagPreference）计算的排除列表，并在 BFF `/relations/tags` 加了展示过滤。但这使"原创"在用户标签分析中**完全不可见**，并非预期。按产品意愿恢复。

## 改动

- **backend**：4 处 UTP 排除列表撤回 `'原创'`（`UserSocialAnalysisJob`×2、`repair-user-vote-stats`、`IncrementalAnalyzeJob` 内嵌 UTP），保留 `'页面'/'重定向'/'管理'/'_cc'` 结构性元标签排除。
- **bff**：`/relations/tags` 移除 `AND utp."tag" <> '原创'` 展示过滤。
- 站点级 `popularTags`（`IncrementalAnalyzeJob:2257`，排除 `'原创'/'译文'/'指导'`）是**另一个预先存在**的热门标签部件（非 #134 改动），保持不动。

## 部署后

需重算 UTP 使"原创"重新入库：`repair-user-vote-stats --social-only`。

## 验证

backend、bff typecheck 均 0 error。

Refs #134
