### PR TITLE
perf(gacha): 改造选卡聚合化 + 分解弹窗 DOM 封顶 (#97 #98)

### DIFF
--- a/frontend/components/gacha/GachaAlbumDismantleDialog.vue
+++ b/frontend/components/gacha/GachaAlbumDismantleDialog.vue
@@ -61,6 +61,10 @@ const pageAuthors = usePageAuthors()
 
 const RENDER_LIMIT = 40
 const RENDER_BATCH = 20
+// #98：即便渐进式渲染,"显示全部"最终仍会把全部候选(可达上万)塞进 DOM,导致滚动/内存卡顿。
+// 硬上限封顶单次 DOM 规模;超出部分通过稀有度/词条筛选缩小,或直接"全选"(选择基于全部 filtered,
+// 不受渲染上限影响)分解。
+const RENDER_HARD_CAP = 1000
 const showAll = ref(false)
 const confirmPending = ref(false)
 
@@ -74,7 +78,7 @@ function startProgressiveRender() {
   cancelProgressiveRender()
   function step() {
     const target = showAll.value
-      ? filteredCandidates.value.length
+      ? Math.min(filteredCandidates.value.length, RENDER_HARD_CAP)
       : Math.min(filteredCandidates.value.length, RENDER_LIMIT)
     if (renderBudget.value < target) {
       renderBudget.value = Math.min(renderBudget.value + RENDER_BATCH, target)
@@ -221,10 +225,14 @@ const selectedCardCount = computed(() => selectedRows.value.reduce((s, r) => s +
 const selectedRewardEstimate = computed(() => selectedRows.value.reduce((s, r) => s + r.estimatedReward, 0))
 
 const visibleCandidates = computed(() => {
-  const limit = showAll.value ? renderBudget.value : Math.min(renderBudget.value, RENDER_LIMIT)
+  const limit = showAll.value
+    ? Math.min(renderBudget.value, RENDER_HARD_CAP)
+    : Math.min(renderBudget.value, RENDER_LIMIT)
   return filteredCandidates.value.slice(0, limit)
 })
 const hasMore = computed(() => !showAll.value && filteredCandidates.value.length > RENDER_LIMIT)
+// 显示全部后仍有超出硬上限未渲染的候选：提示用筛选缩小或直接全选（选择不受渲染上限影响）。
+const renderTruncated = computed(() => showAll.value && filteredCandidates.value.length > RENDER_HARD_CAP)
 
 // ─── 操作函数 ────────────────────────────────────────────
 
@@ -488,6 +496,12 @@ function handleOpenChange(nextOpen: boolean) {
               >
                 加载更多 ({{ filteredCandidates.length - RENDER_LIMIT }} 项)
               </button>
+              <p
+                v-if="renderTruncated"
+                class="mt-2 px-3 py-2 text-center text-[11px] text-neutral-500 dark:text-neutral-400"
+              >
+                已渲染前 {{ RENDER_HARD_CAP }} 项（共 {{ filteredCandidates.length }} 项）。请用上方稀有度/词条筛选缩小范围，或直接「全选」分解（选择不受渲染上限影响）。
+              </p>
             </div>
             <p v-else class="px-3 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400">
               当前过滤条件下没有可分解候选。

--- a/frontend/components/gacha/GachaAlbumDismantleDialog.vue
+++ b/frontend/components/gacha/GachaAlbumDismantleDialog.vue
@@ -500,7 +500,7 @@ function handleOpenChange(nextOpen: boolean) {
                 v-if="renderTruncated"
                 class="mt-2 px-3 py-2 text-center text-[11px] text-neutral-500 dark:text-neutral-400"
               >
-                已渲染前 {{ RENDER_HARD_CAP }} 项（共 {{ filteredCandidates.length }} 项）。请用上方稀有度/词条筛选缩小范围，或直接「全选」分解（选择不受渲染上限影响）。
+                已渲染 {{ visibleCandidates.length }} 项（共 {{ filteredCandidates.length }} 项，上限 {{ RENDER_HARD_CAP }}）。请用上方稀有度/词条筛选缩小范围，或直接「全选」分解（选择不受渲染上限影响）。
               </p>
             </div>
             <p v-else class="px-3 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400">

--- a/user-backend/src/routes/gacha/tickets.routes.ts
+++ b/user-backend/src/routes/gacha/tickets.routes.ts
@@ -164,90 +164,68 @@ export function registerTicketsRoutes(router: Router) {
         const wallet = await h.ensureWallet(tx, userId);
         await h.consumeTicketBalance(tx, wallet, userId, { drawTicket: 0, draw10Ticket: 0, affixReforgeTicket: 1 }, 'AFFIX_REFORGE');
 
-        const inventoryCandidates = payload.cardId
-          ? await tx.gachaInventory.findMany({
-            where: {
-              userId,
-              cardId: payload.cardId,
-              count: { gt: 0 }
-            },
-            include: { card: true },
-            take: 1
-          })
-          : await tx.gachaInventory.findMany({
-            where: {
-              userId,
-              count: { gt: 0 }
-            },
-            include: { card: true }
-          });
-
-        if (!inventoryCandidates.length) {
-          throw Object.assign(new Error(payload.cardId ? '未找到可改造的卡片实例' : '暂无可改造卡片'), { status: 400 });
-        }
-
-        // Batch-load free instances for candidate cards
-        const candidateCardIds = Array.from(new Set(
-          inventoryCandidates.map((item) => item.cardId).filter(Boolean)
-        ));
-        const allFreeForReforge = candidateCardIds.length > 0
-          ? await tx.gachaCardInstance.findMany({
-            where: {
-              userId,
-              cardId: { in: candidateCardIds },
-              tradeListingId: null,
-              buyRequestId: null
-            },
-            orderBy: { obtainedAt: 'asc' }
-          })
-          : [];
-        const freeByCard = new Map<string, typeof allFreeForReforge>();
-        for (const inst of allFreeForReforge) {
-          const list = freeByCard.get(inst.cardId) ?? [];
-          list.push(inst);
-          freeByCard.set(inst.cardId, list);
-        }
-
-        type CandidateForReforge = {
-          inventory: NonNullable<typeof inventoryCandidates[number]> & { card: NonNullable<typeof inventoryCandidates[number]['card']> };
-          freeInstances: typeof allFreeForReforge;
-          totalCount: number;
+        // #97：未指定卡时原实现全量载入用户库存 + 全部自由实例(重库存用户单次操作放大锁/内存),
+        // 仅为随机挑一张改造。改为:按卡【聚合】可改造(未交易/未求购[+指定 sig])实例数 → 加权随机
+        // 选卡(权重=该卡可改造数,与原分布等价) → 只取该卡最早一条可改造实例。指定卡时按卡计数即可。
+        // 不再把全部实例拉进内存与长事务。可改造口径沿用原 allFreeForReforge:仅排除交易/求购
+        // (含 locked/placed/showcased,reforge 允许)。
+        const eligibleWhere: Prisma.GachaCardInstanceWhereInput = {
+          userId,
+          tradeListingId: null,
+          buyRequestId: null,
+          ...(requestedSignature ? { affixSignature: requestedSignature } : {})
         };
-        const candidateStates: CandidateForReforge[] = [];
-        for (const item of inventoryCandidates) {
-          if (!item.card) continue;
-          const freeInstances = (freeByCard.get(item.cardId) ?? []).filter((inst) => (
-            !requestedSignature || inst.affixSignature === requestedSignature
-          ));
-          if (freeInstances.length <= 0) continue;
-          candidateStates.push({
-            inventory: item as NonNullable<typeof inventoryCandidates[number]> & { card: NonNullable<typeof inventoryCandidates[number]['card']> },
-            freeInstances,
-            totalCount: freeInstances.length
+
+        let selectedCardId: string;
+        if (payload.cardId) {
+          const ownedCount = await tx.gachaInventory.count({ where: { userId, cardId: payload.cardId, count: { gt: 0 } } });
+          if (ownedCount <= 0) {
+            throw Object.assign(new Error('未找到可改造的卡片实例'), { status: 400 });
+          }
+          const eligibleCount = await tx.gachaCardInstance.count({ where: { ...eligibleWhere, cardId: payload.cardId } });
+          if (eligibleCount <= 0) {
+            throw Object.assign(new Error(requestedSignature ? `该卡片暂无词条 ${requestedSignature} 可改造实例` : '该卡片暂无可改造变体'), { status: 400 });
+          }
+          selectedCardId = payload.cardId;
+        } else {
+          const groups = await tx.gachaCardInstance.groupBy({
+            by: ['cardId'],
+            where: eligibleWhere,
+            _count: { _all: true }
           });
-        }
-
-        if (!candidateStates.length) {
-          throw Object.assign(
-            new Error(payload.cardId
-              ? (requestedSignature ? `该卡片暂无词条 ${requestedSignature} 可改造实例` : '该卡片暂无可改造变体')
-              : (requestedSignature ? `暂无词条 ${requestedSignature} 可改造实例` : '暂无可改造卡片')),
-            { status: 400 }
-          );
-        }
-
-        let selected = candidateStates[0]!;
-        if (!payload.cardId) {
-          const totalAll = candidateStates.reduce((sum, item) => sum + item.totalCount, 0);
+          if (!groups.length) {
+            throw Object.assign(new Error(requestedSignature ? `暂无词条 ${requestedSignature} 可改造实例` : '暂无可改造卡片'), { status: 400 });
+          }
+          // 加权随机：每卡权重 = 其可改造实例数（与原实现一致的分布）。
+          const totalAll = groups.reduce((sum, g) => sum + g._count._all, 0);
           let pick = Math.floor(Math.random() * totalAll);
-          for (const item of candidateStates) {
-            if (pick < item.totalCount) {
-              selected = item;
-              break;
-            }
-            pick -= item.totalCount;
+          selectedCardId = groups[0]!.cardId;
+          for (const g of groups) {
+            if (pick < g._count._all) { selectedCardId = g.cardId; break; }
+            pick -= g._count._all;
           }
         }
+
+        // 取选中卡的库存(含卡定义)与最早一条可改造实例。
+        const selectedInventory = await tx.gachaInventory.findFirst({
+          where: { userId, cardId: selectedCardId, count: { gt: 0 } },
+          include: { card: true }
+        });
+        const firstEligible = await tx.gachaCardInstance.findFirst({
+          where: { ...eligibleWhere, cardId: selectedCardId },
+          orderBy: { obtainedAt: 'asc' }
+        });
+        if (!selectedInventory || !selectedInventory.card || !firstEligible) {
+          // 卡定义缺失/并发改动等极端情形(原实现会跳过该卡),按"暂无可改造"处理。
+          throw Object.assign(new Error(payload.cardId
+            ? (requestedSignature ? `该卡片暂无词条 ${requestedSignature} 可改造实例` : '该卡片暂无可改造变体')
+            : '暂无可改造卡片'), { status: 400 });
+        }
+
+        const selected = {
+          inventory: selectedInventory as typeof selectedInventory & { card: NonNullable<typeof selectedInventory.card> },
+          freeInstances: [firstEligible]
+        };
 
         // Pick the first free instance to reforge
         const targetInstance = selected.freeInstances[0];


### PR DESCRIPTION
Gacha 两处性能修复（延续 #95/#96）。

## #97（MEDIUM · 后端）词条改造未指定卡全量载入
`/tickets/affix-reforge/use` 未指定卡时，原实现全量载入用户库存 + **全部自由实例**（重库存用户 36k+ 实例进内存与长事务），仅为随机挑一张改造。

改为：按卡 `groupBy` 聚合可改造（未交易/未求购[+指定 sig]）实例数 → **加权随机选卡**（权重 = 该卡可改造数，与原分布等价）→ 只 `findFirst` 取该卡**最早一条**可改造实例。指定卡时按卡 `count` 即可。可改造口径、错误文案、随机分布、改造目标均与原实现一致。

实测最重用户（36,335 可改造实例）：`groupBy` **48ms**，替代"载入 36k 行 + 全部库存"。

## #98（MEDIUM · 前端）批量分解弹窗"显示全部"渲染上万候选
弹窗已有渐进式渲染（RENDER_LIMIT=40 + 每帧追加 20），但"显示全部"最终仍把全部候选（可达上万）塞进 DOM → 滚动/内存卡顿。

加 `RENDER_HARD_CAP=1000` 封顶单次渲染规模；超出时提示用稀有度/词条筛选缩小，或直接「全选」分解。**选择基于全部 filtered（`selectedKeys`），不受渲染上限影响**，故封顶不限制可分解范围。

## 验证
user-backend `tsc`、frontend `nuxt typecheck` 均 0 error；reforge groupBy 在真实最重用户上读验证。

Refs #97 #98
