### PR TITLE
fix(forum): 线程/帖子作者当前显示名 + 死链守卫 (#117 #118)

### DIFF
--- a/bff/src/web/routes/forums.ts
+++ b/bff/src/web/routes/forums.ts
@@ -170,10 +170,15 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
                    t."createdByWikidotId", t."createdAt", t."postCount",
                    t."categoryId", t."pageId",
                    p."wikidotId" AS "pageWikidotId",
-                   c.title AS "categoryTitle"
+                   c.title AS "categoryTitle",
+                   -- #118：优先展示作者当前显示名（快照随用户改名漂移）。
+                   -- #117：authorExists 标记该 wikidotId 能否关联到本站用户，前端据此决定是否出链接。
+                   COALESCE(u."displayName", t."createdByName") AS "authorDisplayName",
+                   (u.id IS NOT NULL) AS "authorExists"
             FROM "ForumThread" t
             LEFT JOIN "ForumCategory" c ON c.id = t."categoryId"
             LEFT JOIN "Page" p ON p.id = t."pageId"
+            LEFT JOIN "User" u ON u."wikidotId" = t."createdByWikidotId"
             WHERE t.id = $1 AND t."isDeleted" = false
           `, [threadId]),
           // floor：线程内全局楼层号（按时间序，#1=最早），用窗口函数对【整个线程】计算后再分页，
@@ -203,9 +208,13 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
                    fp."createdByWikidotId", fp."createdByType", fp."createdAt", fp."editedAt", fp."isDeleted",
                    pg.floor,
                    pg."parentCreatedByName",
-                   pg."parentFloor"
+                   pg."parentFloor",
+                   -- #117/#118：每帖作者的当前显示名 + 是否可关联到本站用户。
+                   COALESCE(u."displayName", fp."createdByName") AS "authorDisplayName",
+                   (u.id IS NOT NULL) AS "authorExists"
             FROM page pg
             JOIN "ForumPost" fp ON fp.id = pg.id
+            LEFT JOIN "User" u ON u."wikidotId" = fp."createdByWikidotId"
             ORDER BY fp."createdAt" ${order} NULLS LAST, fp.id ${order}
           `, [threadId, limit, offset]),
           readPool.query(`

--- a/bff/src/web/routes/forums.ts
+++ b/bff/src/web/routes/forums.ts
@@ -326,14 +326,18 @@ export function forumsRouter(pool: Pool, redis: RedisClientType | null) {
           `),
         ]);
 
-        // Top posters
+        // Top posters：LEFT JOIN User 取当前显示名 + 是否可关联到本站用户（#117 死链守卫 /
+        // #118 改名漂移）。u 由 wikidotId 唯一决定，故用 MAX 聚合不放大行数。
         const { rows: topPosters } = await readPool.query(`
-          SELECT "createdByName" AS name, "createdByWikidotId" AS "wikidotId",
-                 COUNT(*)::int AS "postCount"
-          FROM "ForumPost"
-          WHERE "isDeleted" = false AND "createdByName" IS NOT NULL
-          GROUP BY "createdByName", "createdByWikidotId"
-          ORDER BY "postCount" DESC, "createdByWikidotId" DESC NULLS LAST, "createdByName"
+          SELECT p."createdByName" AS name, p."createdByWikidotId" AS "wikidotId",
+                 COUNT(*)::int AS "postCount",
+                 (MAX(u.id) IS NOT NULL) AS "authorExists",
+                 COALESCE(MAX(u."displayName"), p."createdByName") AS "displayName"
+          FROM "ForumPost" p
+          LEFT JOIN "User" u ON u."wikidotId" = p."createdByWikidotId"
+          WHERE p."isDeleted" = false AND p."createdByName" IS NOT NULL
+          GROUP BY p."createdByName", p."createdByWikidotId"
+          ORDER BY "postCount" DESC, p."createdByWikidotId" DESC NULLS LAST, p."createdByName"
           LIMIT 10
         `);
 

--- a/frontend/composables/api/forums.ts
+++ b/frontend/composables/api/forums.ts
@@ -84,7 +84,7 @@ export function useForumsApi() {
       threadsCount: number
       postsCount: number
       lastPostAt: string | null
-      topPosters: Array<{ name: string; wikidotId: number | null; postCount: number }>
+      topPosters: Array<{ name: string; wikidotId: number | null; postCount: number; authorExists?: boolean; displayName?: string | null }>
     }>('/forums/stats')
   }
 

--- a/frontend/composables/api/forums.ts
+++ b/frontend/composables/api/forums.ts
@@ -32,6 +32,9 @@ export function useForumsApi() {
         pageWikidotId: number | null
         categoryTitle: string | null
         sourceThreadUrl: string | null
+        // 作者当前显示名（防改名漂移 #118）+ 是否可关联到本站用户（决定是否出链接 #117）。
+        authorDisplayName: string | null
+        authorExists: boolean
       }
       posts: Array<{
         id: number
@@ -48,6 +51,8 @@ export function useForumsApi() {
         floor: number | null
         parentCreatedByName: string | null
         parentFloor: number | null
+        authorDisplayName: string | null
+        authorExists: boolean
         sourceThreadUrl: string | null
         sourcePostUrl: string | null
       }>

--- a/frontend/pages/forums/index.vue
+++ b/frontend/pages/forums/index.vue
@@ -98,21 +98,22 @@ const btnClass = 'px-3 py-1.5 rounded-lg text-sm border border-[rgb(var(--panel-
       <div v-if="stats.topPosters?.length" class="pt-3 border-t border-[rgb(var(--panel-border)_/_0.25)]">
         <div class="text-xs text-[rgb(var(--muted))] mb-2">活跃用户</div>
         <div class="flex flex-wrap gap-2">
-          <!-- 作者 wikidotId 缺失时(约 45% 论坛作者无标识)渲染为纯文本而非 /user/null 死链(#117)。 -->
+          <!-- #117：仅当作者能关联到本站用户(authorExists)时才出 /user 链接,否则纯文本——
+               覆盖 wikidotId 缺失或不在 User 表(约 45%)两类死链。#118：用当前显示名。 -->
           <component
-            :is="poster.wikidotId ? NuxtLinkComp : 'span'"
+            :is="(poster.wikidotId && poster.authorExists) ? NuxtLinkComp : 'span'"
             v-for="poster in stats.topPosters.slice(0, 8)"
             :key="poster.wikidotId != null ? `wid:${poster.wikidotId}:${poster.name}` : `name:${poster.name}`"
-            :to="poster.wikidotId ? `/user/${poster.wikidotId}` : undefined"
+            :to="(poster.wikidotId && poster.authorExists) ? `/user/${poster.wikidotId}` : undefined"
             class="inline-flex items-center gap-1.5 rounded-full bg-[rgb(var(--panel)_/_0.5)] border border-[rgb(var(--panel-border)_/_0.25)] px-2 py-1 text-xs text-[rgb(var(--muted-strong))] transition"
-            :class="poster.wikidotId ? 'hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)]' : ''"
+            :class="(poster.wikidotId && poster.authorExists) ? 'hover:border-[var(--g-accent-border)] hover:text-[var(--g-accent)]' : ''"
           >
             <UserAvatar
               :wikidot-id="poster.wikidotId"
-              :name="poster.name"
+              :name="poster.displayName || poster.name"
               :size="16"
             />
-            {{ poster.name }}
+            {{ poster.displayName || poster.name }}
             <span class="text-[10px] text-[rgb(var(--muted)_/_0.7)]">{{ poster.postCount }}</span>
           </component>
         </div>

--- a/frontend/pages/forums/t/[id].vue
+++ b/frontend/pages/forums/t/[id].vue
@@ -103,6 +103,9 @@ interface PostItem {
   floor?: number | null
   parentCreatedByName?: string | null
   parentFloor?: number | null
+  // 作者当前显示名（#118）+ 是否可关联到本站用户（#117）。
+  authorDisplayName?: string | null
+  authorExists?: boolean
   sourceThreadUrl?: string | null
   sourcePostUrl?: string | null
   _dbIndex: number // original position in API response
@@ -368,21 +371,23 @@ function copyFloorLink(floor: number) {
         </h1>
 
         <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[rgb(var(--muted))]">
-          <span v-if="data.thread?.createdByName" class="inline-flex items-center gap-1.5">
+          <span v-if="data.thread?.authorDisplayName || data.thread?.createdByName" class="inline-flex items-center gap-1.5">
             <UserAvatar
               v-if="data.thread.createdByWikidotId"
               :wikidot-id="data.thread.createdByWikidotId"
-              :name="data.thread.createdByName"
+              :name="data.thread.authorDisplayName || data.thread.createdByName"
               :size="18"
             />
+            <!-- #117：仅当作者能关联到本站用户时才出链接，否则纯文本，避免 /user/ 死链。
+                 #118：用当前显示名 authorDisplayName，回退到创建时快照名。 -->
             <NuxtLink
-              v-if="data.thread.createdByWikidotId"
+              v-if="data.thread.createdByWikidotId && data.thread.authorExists"
               :to="`/user/${data.thread.createdByWikidotId}`"
               class="hover:text-[var(--g-accent)] transition-colors"
             >
-              {{ data.thread.createdByName }}
+              {{ data.thread.authorDisplayName || data.thread.createdByName }}
             </NuxtLink>
-            <span v-else>{{ data.thread.createdByName }}</span>
+            <span v-else>{{ data.thread.authorDisplayName || data.thread.createdByName }}</span>
           </span>
           <span v-if="data.thread?.createdAt" class="inline-flex items-center gap-1">
             <LucideIcon name="Calendar" class="w-3.5 h-3.5" stroke-width="2" aria-hidden="true" />
@@ -489,18 +494,19 @@ function copyFloorLink(floor: number) {
               <UserAvatar
                 v-if="item.post.createdByWikidotId"
                 :wikidot-id="item.post.createdByWikidotId"
-                :name="item.post.createdByName"
+                :name="item.post.authorDisplayName || item.post.createdByName"
                 :size="22"
               />
+              <!-- #117：仅作者可关联到本站用户时出链接（否则纯文本，避免死链）。#118：用当前显示名。 -->
               <NuxtLink
-                v-if="item.post.createdByWikidotId && item.post.createdByName"
+                v-if="item.post.createdByWikidotId && item.post.authorExists && (item.post.authorDisplayName || item.post.createdByName)"
                 :to="`/user/${item.post.createdByWikidotId}`"
                 class="font-medium text-[rgb(var(--muted-strong))] hover:text-[var(--g-accent)] transition-colors"
               >
-                {{ item.post.createdByName }}
+                {{ item.post.authorDisplayName || item.post.createdByName }}
               </NuxtLink>
-              <span v-else-if="item.post.createdByName" class="font-medium text-[rgb(var(--muted-strong))]">
-                {{ item.post.createdByName }}
+              <span v-else-if="item.post.authorDisplayName || item.post.createdByName" class="font-medium text-[rgb(var(--muted-strong))]">
+                {{ item.post.authorDisplayName || item.post.createdByName }}
               </span>
               <span v-else class="italic">匿名用户</span>
 


### PR DESCRIPTION
## #117（MEDIUM·死链）+ #118（LOW·改名漂移）
约 **44.7% 线程作者**的 wikidotId 不在本站 `User` 表，前端仍链到 `/user/{wid}` 为空页（死链）；作者名是创建时快照，用户改名后漂移。

## 改动
- BFF `threads/:id` 的 thread 与 posts 查询 `LEFT JOIN User`，返回：
  - `authorExists = (u.id IS NOT NULL)` —— 前端据此决定是否出链接（#117）。
  - `authorDisplayName = COALESCE(u.displayName, createdByName)` —— 当前显示名，回退快照（#118）。
- 前端线程详情页（`t/[id].vue`）线程作者 + 帖子作者：仅 `authorExists` 时出 `NuxtLink`，否则纯文本；显示用 `authorDisplayName`。

## 范围
聚焦**线程详情页**（作者链接最集中处）。分类/列表视图作者本就是纯文本（无死链），改名漂移属次要，留后续。

## 验证
bff `tsc`、frontend `nuxt typecheck` 均 0 error。

Refs #117 #118