### PR TITLE
fix(forum): repair-forum-post-counts 校正线程回复计数 (#116)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "repair:user-vote-stats": "node --import tsx/esm src/cli/index.ts repair-user-vote-stats",
     "repair:forum-page-links": "node --import tsx/esm src/cli/index.ts repair-forum-page-links",
     "repair:forum-stuck-threads": "node --import tsx/esm src/cli/index.ts repair-forum-stuck-threads",
+    "repair:forum-post-counts": "node --import tsx/esm src/cli/index.ts repair-forum-post-counts",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy",

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -31,6 +31,7 @@ import { runVoteTzDupCleanup } from './voteTzDupCleanup.js';
 import { runRepairUserVoteStats } from './repair-user-vote-stats.js';
 import { runRepairForumPageLinks } from './repair-forum-page-links.js';
 import { runRepairForumStuckThreads } from './repair-forum-stuck-threads.js';
+import { runRepairForumPostCounts } from './repair-forum-post-counts.js';
 
 const program = new Command();
 
@@ -270,6 +271,19 @@ program
         }
       }
       await runRepairForumStuckThreads(prisma, { apply: Boolean(options.apply), threadIds });
+    } finally {
+      await disconnectPrisma();
+    }
+  });
+
+program
+  .command('repair-forum-post-counts')
+  .description('校正线程 postCount 为真实未删帖子数(#116;仅改展示计数,不触碰水位 postCountAtSync;默认 dry-run,--apply 落库)')
+  .option('--apply', '实际落库校正(默认仅 dry-run 统计)')
+  .action(async (options) => {
+    const prisma = getPrismaClient();
+    try {
+      await runRepairForumPostCounts(prisma, { apply: Boolean(options.apply) });
     } finally {
       await disconnectPrisma();
     }

--- a/backend/src/cli/repair-forum-post-counts.ts
+++ b/backend/src/cli/repair-forum-post-counts.ts
@@ -1,0 +1,60 @@
+import type { PrismaClient } from '@prisma/client';
+
+/**
+ * 修复"线程回复计数与真实帖数不一致"(#116)：ForumThread.postCount 是远端声明值/历史水位，
+ * 部分线程与本地实际未删帖子数不符（偏高/偏低，含抓帖失败遗留）。本 CLI 把这些线程的
+ * postCount 校正为本地真实未删帖子数。
+ *
+ * 安全性：postCount 仅用于【展示】；同步的增量跳过判定用的是 postCountAtSync（水位），
+ * 见 ForumSyncProcessor 的 `localThread.postCountAtSync === remoteThread.postCount`。
+ * 故本校正【不触碰 postCountAtSync】，不影响同步行为。
+ * 默认 dry-run（只统计/列样本，不写库）；需 --apply 才落库；幂等（只改不一致的行）。
+ */
+export async function runRepairForumPostCounts(
+  prisma: PrismaClient,
+  opts: { apply?: boolean } = {}
+): Promise<void> {
+  const apply = Boolean(opts.apply);
+  console.log(apply ? '🔧 APPLY: 校正线程 postCount 为真实未删帖子数' : '🔍 DRY RUN: 仅统计不一致线程(加 --apply 落库)');
+
+  const mismatched = await prisma.$queryRaw<Array<{ id: number; declared: number; real: number }>>`
+    SELECT t.id, t."postCount" AS declared,
+           (SELECT COUNT(*)::int FROM "ForumPost" p WHERE p."threadId" = t.id AND p."isDeleted" = false) AS real
+    FROM "ForumThread" t
+    WHERE t."isDeleted" = false
+      AND t."postCount" <> (SELECT COUNT(*)::int FROM "ForumPost" p WHERE p."threadId" = t.id AND p."isDeleted" = false)
+    ORDER BY t.id
+  `;
+
+  console.log(`不一致线程数: ${mismatched.length}`);
+  if (mismatched.length === 0) {
+    console.log('无不一致，无需处理。');
+    return;
+  }
+  const higher = mismatched.filter((r) => Number(r.declared) > Number(r.real)).length;
+  const lower = mismatched.filter((r) => Number(r.declared) < Number(r.real)).length;
+  console.log(`  其中 declared>real: ${higher}，declared<real: ${lower}`);
+  console.log(
+    '样本(最多 10):',
+    mismatched.slice(0, 10).map((r) => `#${r.id}(${r.declared}→${r.real})`).join(', ')
+  );
+
+  if (!apply) {
+    console.log('DRY RUN: 未写库(加 --apply 执行校正)。');
+    return;
+  }
+
+  // 一次性按真实未删帖子数校正(只改不一致行,不触碰 postCountAtSync)。
+  const affected = await prisma.$executeRaw`
+    UPDATE "ForumThread" t
+    SET "postCount" = sub.real
+    FROM (
+      SELECT t2.id,
+             (SELECT COUNT(*)::int FROM "ForumPost" p WHERE p."threadId" = t2.id AND p."isDeleted" = false) AS real
+      FROM "ForumThread" t2
+      WHERE t2."isDeleted" = false
+    ) sub
+    WHERE t.id = sub.id AND t."postCount" <> sub.real
+  `;
+  console.log(`✓ 完成：校正 ${affected} 个线程的 postCount。`);
+}


### PR DESCRIPTION
## #116（MEDIUM）
约 151 个线程的 `postCount`（远端声明值/历史水位）与本地真实未删帖子数不符（偏高/偏低，含 #113 抓帖失败遗留）。

## 改动
新增 CLI `repair-forum-post-counts`：把不一致线程的 `postCount` 校正为本地真实未删帖子数。

**安全**：`postCount` 仅用于展示；同步的增量跳过判定用的是 `postCountAtSync`（水位，见 `ForumSyncProcessor:297` `localThread.postCountAtSync === remoteThread.postCount`）。本校正**不触碰 postCountAtSync**，不影响同步行为。默认 dry-run，`--apply` 落库，幂等。

## 部署后
`npm run repair:forum-post-counts`（dry-run 统计）→ `-- --apply`（落库）→ 关闭 #116。

Refs #116