### PR TITLE
perf(gacha): 卡片 foil will-change 收敛到 hover,消除图鉴常驻 GPU 层 (#101)

### DIFF
--- a/frontend/components/gacha/GachaCard.vue
+++ b/frontend/components/gacha/GachaCard.vue
@@ -533,7 +533,8 @@ html.dark .gacha-card__fallback-icon {
   opacity: 0;
   transition: opacity 0.4s ease;
   z-index: 1;
-  will-change: opacity;
+  /* #101：will-change 不再常驻——否则图鉴每页 80 张卡各为这层常驻一个 GPU 合成层，是图鉴
+     卡顿主因之一。foil 仅 hover 时才动画，故把 will-change 收敛到 hover(见下方 hover 规则)。 */
 }
 
 /* Foil sweep animation on hover entrance */
@@ -545,6 +546,8 @@ html.dark .gacha-card__fallback-icon {
 
 @media (hover: hover) {
   .gacha-card:hover .gacha-card__foil {
+    /* 仅 hover 时提示合成器，避免静止时 80 张卡常驻 GPU 层（#101）。 */
+    will-change: opacity;
     animation: foil-sweep-in 0.8s ease-out forwards;
   }
 }


### PR DESCRIPTION
## #101（LOW）
图鉴每页渲染 80 张重型特效卡，GPU 卡顿。`.gacha-card__foil`（全息层，`opacity:0` 仅 hover 动画）原**常驻** `will-change: opacity` → 每张卡为该层常驻一个 GPU 合成层，80 张 = 80 个常驻层，是卡顿主因之一。

## 改动
把 `will-change: opacity` 从基础规则移到 `:hover` 规则。静止时不再占用合成层；foil 仅 hover 才动画，视觉无变化。（其余 `will-change` 已是 `auto`/hover-only；3 处 backdrop-filter 在锁标/镀层 chip 等条件元素上，非全卡，保留。）

frontend typecheck 0 error。Refs #101