### PR TITLE
perf(search): 搜索结果用 content-visibility 跳过屏幕外渲染 (#111)

### DIFF
--- a/frontend/components/search/SearchResults.vue
+++ b/frontend/components/search/SearchResults.vue
@@ -42,6 +42,7 @@
             <UserCard
               v-for="u in userResults"
               :key="u.wikidotId || u.id"
+              class="[content-visibility:auto] [contain-intrinsic-size:auto_180px]"
               size="md"
               :wikidot-id="u.wikidotId"
               :display-name="u.displayName"
@@ -76,7 +77,7 @@
           </div>
           <div v-else>
             <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-              <PageCard size="md" v-for="p in pageResults" :key="p.wikidotId || p.id" :p="p" />
+              <PageCard size="md" class="[content-visibility:auto] [contain-intrinsic-size:auto_180px]" v-for="p in pageResults" :key="p.wikidotId || p.id" :p="p" />
             </div>
           </div>
           <div v-if="pageLoadingMore" class="flex items-center justify-center text-xs text-neutral-500 dark:text-neutral-400">
@@ -112,7 +113,7 @@
               v-for="post in forumResults"
               :key="post.postId || `${post.threadId}-${post.createdAt}`"
               :to="forumPostLink(post)"
-              class="block rounded-lg border border-neutral-200 bg-white p-4 shadow-sm transition hover:border-[var(--g-accent-border)] hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
+              class="[content-visibility:auto] [contain-intrinsic-size:auto_140px] block rounded-lg border border-neutral-200 bg-white p-4 shadow-sm transition hover:border-[var(--g-accent-border)] hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
             >
               <div class="flex items-start gap-3">
                 <UserAvatar


### PR DESCRIPTION
## #111（LOW）
搜索结果无限滚动累积渲染全部重型卡片（PageCard/UserCard/论坛帖卡），长结果集 DOM/内存压力大、无虚拟化。

## 改动
给三类结果卡加 `content-visibility:auto` + `contain-intrinsic-size`（Tailwind 任意属性类）。浏览器据此**自动跳过屏幕外卡片的渲染/布局**（近似虚拟化），零 JS、不改累积逻辑、不引库。`contain-intrinsic-size: auto <h>` 给屏幕外项尺寸估计避免滚动跳动（`auto` 关键字记住实际尺寸）。

frontend typecheck 0 error。Refs #111