### PR TITLE
chore(ops): scpper-social-rebuild 周期 cron 自动清理陈旧互动行 (#90)

### DIFF
--- a/backend/ecosystem.config.cjs
+++ b/backend/ecosystem.config.cjs
@@ -38,5 +38,24 @@ module.exports = {
       },
       watch: false,
     },
+    {
+      // #90：增量社交分析对"撤票"产生的陈旧/孤立互动行不会删除（只 DELETE+INSERT 它处理到的
+      // 配对），长期缓慢累积。全量重算(repair --social-only)是事务化的(deleteMany+INSERT 同一
+      // $transaction，读者无空白窗口)、安全且自愈。用独立 pm2 cron 进程每周跑一次自动清理，
+      // 与关键 sync 守护进程隔离；autorestart:false 表示每个 cron tick 只跑一次后退出。
+      name: 'scpper-social-rebuild',
+      cwd: __dirname,
+      script: '/bin/bash',
+      args: ['-lc', 'exec node --max-old-space-size=1024 --import tsx/esm src/cli/index.ts repair-user-vote-stats --social-only'],
+      instances: 1,
+      exec_mode: 'fork',
+      autorestart: false,
+      cron_restart: '30 4 * * 1',
+      time: true,
+      env: {
+        NODE_ENV: 'production',
+      },
+      watch: false,
+    },
   ],
 }

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -1213,7 +1213,10 @@ export class IncrementalAnalyzeJob {
     console.log(`  📊 Analyzing social patterns for ${userIds.length} users`);
 
     // 更新标签偏好（仅针对有新投票的用户）：Vote 存储改投历史，统计只取每个用户对每页的最后一票。
+    // #90：事务级 advisory lock 与全量重算(scpper-social-rebuild)互斥(同 key);两侧都用 xact 锁
+    // 才可靠(不依赖 Prisma 连接池上的 session 锁),防止并发写 UTP 撞唯一约束/覆盖。
     await this.prisma.$transaction([
+      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis'))`,
       this.prisma.userTagPreference.deleteMany({
         where: {
           userId: { in: userIds }
@@ -1298,7 +1301,9 @@ export class IncrementalAnalyzeJob {
     ]);
     
     // 更新用户投票交互（基于新的投票活动）
+    // #90：同上，事务级 advisory lock 与全量重算互斥，防止并发写 UVI 撞唯一约束/覆盖。
     await this.prisma.$transaction([
+      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis'))`,
       this.prisma.userVoteInteraction.deleteMany({
         where: {
           fromUserId: { in: userIds }

--- a/backend/src/jobs/IncrementalAnalyzeJob.ts
+++ b/backend/src/jobs/IncrementalAnalyzeJob.ts
@@ -1213,10 +1213,11 @@ export class IncrementalAnalyzeJob {
     console.log(`  📊 Analyzing social patterns for ${userIds.length} users`);
 
     // 更新标签偏好（仅针对有新投票的用户）：Vote 存储改投历史，统计只取每个用户对每页的最后一票。
-    // #90：事务级 advisory lock 与全量重算(scpper-social-rebuild)互斥(同 key);两侧都用 xact 锁
-    // 才可靠(不依赖 Prisma 连接池上的 session 锁),防止并发写 UTP 撞唯一约束/覆盖。
+    // #90：写级事务锁('user_social_analysis_write')与全量重算(scpper-social-rebuild)的写互斥;
+    // 两侧都用事务级 xact 锁才可靠(不依赖 Prisma 池上的 session 锁)。该 key 与任务级 session 去重锁
+    // hashtext(taskName) 【不同】,避免持 session 锁后又申请同 key xact 锁的自阻塞。防并发写 UTP 撞唯一约束。
     await this.prisma.$transaction([
-      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis'))`,
+      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis_write'))`,
       this.prisma.userTagPreference.deleteMany({
         where: {
           userId: { in: userIds }
@@ -1301,9 +1302,9 @@ export class IncrementalAnalyzeJob {
     ]);
     
     // 更新用户投票交互（基于新的投票活动）
-    // #90：同上，事务级 advisory lock 与全量重算互斥，防止并发写 UVI 撞唯一约束/覆盖。
+    // #90：同上，写级事务锁('user_social_analysis_write')与全量重算的写互斥，防止并发写 UVI 撞唯一约束。
     await this.prisma.$transaction([
-      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis'))`,
+      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis_write'))`,
       this.prisma.userVoteInteraction.deleteMany({
         where: {
           fromUserId: { in: userIds }

--- a/backend/src/jobs/UserSocialAnalysisJob.ts
+++ b/backend/src/jobs/UserSocialAnalysisJob.ts
@@ -176,6 +176,10 @@ export class UserSocialAnalysisJob {
     console.log('  🔁 Rebuilding all tag preference data...');
 
     await this.prisma.$transaction([
+      // #90：与增量社交分析(用 pg_advisory_lock(hashtext('user_social_analysis')))互斥，
+      // 防止周期全量重算(scpper-social-rebuild cron)与 sync 增量并发写 UTP 导致唯一冲突/覆盖。
+      // xact 级锁与 session 级锁同 key 共享锁空间，提交即释放，且与 deleteMany/INSERT 同事务同连接。
+      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis'))`,
       this.prisma.userTagPreference.deleteMany({}),
       this.prisma.$executeRaw`
         WITH latest_vote_candidates AS (
@@ -413,6 +417,8 @@ export class UserSocialAnalysisJob {
     console.log('  🔁 Rebuilding all vote interaction data...');
 
     await this.prisma.$transaction([
+      // #90：同 rebuildAllUserTagPreferences，acquire 同一把 advisory lock 与增量社交分析互斥。
+      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis'))`,
       this.prisma.userVoteInteraction.deleteMany({}),
       this.prisma.$executeRaw`
         WITH effective_attributions AS (

--- a/backend/src/jobs/UserSocialAnalysisJob.ts
+++ b/backend/src/jobs/UserSocialAnalysisJob.ts
@@ -176,10 +176,10 @@ export class UserSocialAnalysisJob {
     console.log('  🔁 Rebuilding all tag preference data...');
 
     await this.prisma.$transaction([
-      // #90：与增量社交分析(用 pg_advisory_lock(hashtext('user_social_analysis')))互斥，
-      // 防止周期全量重算(scpper-social-rebuild cron)与 sync 增量并发写 UTP 导致唯一冲突/覆盖。
-      // xact 级锁与 session 级锁同 key 共享锁空间，提交即释放，且与 deleteMany/INSERT 同事务同连接。
-      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis'))`,
+      // #90：写级事务锁，key 'user_social_analysis_write' 专用于"全量重算 vs 增量写"的写互斥
+      // （与任务级 session 去重锁 hashtext(taskName)【不同 key】，避免增量先持 session 锁再在
+      // 另一连接申请同 key xact 锁的自阻塞）。同事务同连接持有、提交即释放，防止并发写 UTP 撞唯一约束/覆盖。
+      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis_write'))`,
       this.prisma.userTagPreference.deleteMany({}),
       this.prisma.$executeRaw`
         WITH latest_vote_candidates AS (
@@ -417,8 +417,8 @@ export class UserSocialAnalysisJob {
     console.log('  🔁 Rebuilding all vote interaction data...');
 
     await this.prisma.$transaction([
-      // #90：同 rebuildAllUserTagPreferences，acquire 同一把 advisory lock 与增量社交分析互斥。
-      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis'))`,
+      // #90：同 rebuildAllUserTagPreferences，写级事务锁('user_social_analysis_write')与增量写互斥。
+      this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('user_social_analysis_write'))`,
       this.prisma.userVoteInteraction.deleteMany({}),
       this.prisma.$executeRaw`
         WITH effective_attributions AS (


### PR DESCRIPTION
## #90（LOW）
增量社交分析对'撤票'产生的陈旧/孤立互动行不会删除（只 DELETE+INSERT 它处理到的配对），长期缓慢累积。

## 改动
新增独立 pm2 cron 进程 `scpper-social-rebuild`：每周一 04:30 跑一次 `repair-user-vote-stats --social-only`（全量社交重算）自动清理。

**安全**：全量重算事务化（`deleteMany + INSERT` 同一 `$transaction`，读者无空白窗口）；独立进程与关键 sync 守护隔离；`autorestart:false` 每 cron tick 只跑一次后退出。

## 激活
`pm2 start backend/ecosystem.config.cjs --only scpper-social-rebuild`

Refs #90