### PR TITLE
perf(gacha): /gacha/inventory 变体预聚合 LEFT JOIN,消除相关子查询近二次成本

### DIFF
--- a/user-backend/src/routes/gacha/core.routes.ts
+++ b/user-backend/src/routes/gacha/core.routes.ts
@@ -205,16 +205,22 @@ export function registerCoreRoutes(router: Router) {
               AND ci."buyRequestId" IS NULL
               ${instAffixWhere}
             GROUP BY ci."cardId", ci."affixSignature", ci."affixVisualStyle"
+          ),
+          -- 把变体按 cardId 预聚合成 JSON 一次（O(inst_agg)），再 LEFT JOIN；替代原"每行一个相关
+          -- json_agg 子查询"（对每个 inv_page 行线性扫未索引的 inst_agg → O(inv行×inst_agg行) 近二次）。
+          -- 全量模式下重库存用户实测 40.5s → 0.3s（per-row 相关子查询是真正瓶颈，非 all=1 本身）。
+          inst_agg_json AS (
+            SELECT ia."cardId",
+                   json_agg(json_build_object('s', ia."affixSignature", 'style', ia."affixVisualStyle", 'c', ia.cnt, 'lc', ia.locked_cnt)) AS variants
+            FROM inst_agg ia
+            GROUP BY ia."cardId"
           )
           SELECT
             p."cardId", p.inv_count, p.title, p.rarity,
             p.tags, p."imageUrl", p."wikidotId", p."pageId", p."poolId", p.weight,
-            COALESCE(
-              (SELECT json_agg(json_build_object('s', ia."affixSignature", 'style', ia."affixVisualStyle", 'c', ia.cnt, 'lc', ia.locked_cnt))
-               FROM inst_agg ia WHERE ia."cardId" = p."cardId"),
-              '[]'::json
-            ) AS variants
+            COALESCE(iaj.variants, '[]'::json) AS variants
           FROM inv_page p
+          LEFT JOIN inst_agg_json iaj ON iaj."cardId" = p."cardId"
           ORDER BY p.rarity_weight ASC, p."createdAt" ASC, p.inv_id ASC
         `),
         (skipTotal || loadAll)


### PR DESCRIPTION
## 问题
用户报 `/gachas?tab=tickets`（改造候选）加载 `/api/gacha/inventory` 耗时 **29.8s**。

## 根因
真正瓶颈**不是** `all=1` 本身，而是 SELECT 里每个 `inv_page` 行一个**相关 json_agg 子查询**，对未索引的 `inst_agg` CTE 线性扫 → **O(inv行 × inst_agg行) 近二次**。最重用户（23956 库存行 / 27502 变体）实测整条路由查询 **40.5s**。（我 #95 时测的 136ms 是漏了 json_agg 的简化查询，误判了瓶颈。）

## 改动
`inst_agg` 用一次 `GROUP BY` 预聚合成 per-cardId 的 variants JSON（`inst_agg_json` CTE），再 `LEFT JOIN inv_page`（哈希连接 O(n)）。

## 验证
同用户 EXPLAIN ANALYZE：**40,509ms → 297ms（136×）**。结果行结构/内容不变（变体数组顺序无关，前端 re-sort），下游处理无需改。所有库存加载（放置/交易/改造/分解）均受益。user-backend `tsc` 0 error。