### PR TITLE
fix(bff): 搜索 relevance 排序按意图分层,修复删除页压过在档页

### DIFF
--- a/bff/src/web/routes/search.ts
+++ b/bff/src/web/routes/search.ts
@@ -933,6 +933,25 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
     const scoreExprSql = 'pgroonga_score(pv.tableoid, pv.ctid) AS score';
     const eTitleMatchSql = 'e.title &@~ pgroonga_query_escape($1)';
     const eAltMatchSql = 'e."alternateTitle" &@~ pgroonga_query_escape($1)';
+    // ── relevance 排序的匹配档位 ──────────────────────────
+    // 3 = 导航意图：slug/URL/标题/备用标题与查询精确相等（"搜什么得什么"）
+    // 2 = 标题或备用标题命中（部分匹配）
+    // 1 = 仅正文命中（探索意图）
+    // 档位之间：在档页优先于已删除页；档位 >=2 内评分优先于词频分，
+    // 避免已删除竞赛稿等高词频低质量页面压过真正的目标页面。
+    const matchTierSql = `CASE
+            WHEN lower(split_part(e.url, '/', 4)) = lower($1)
+              OR lower(e.url) = lower($1)
+              OR (e.title IS NOT NULL AND lower(e.title) = lower($1))
+              OR (e."alternateTitle" IS NOT NULL AND lower(e."alternateTitle") = lower($1))
+            THEN 3
+            WHEN (e.title IS NOT NULL AND ${eTitleMatchSql})
+              OR (e."alternateTitle" IS NOT NULL AND ${eAltMatchSql})
+            THEN 2
+            ELSE 1
+          END`;
+    // 仅在 relevance 模式参与排序；其他 orderBy 模式下这些列为 NULL（排序 no-op）
+    const relevanceGateSql = `($9::text IS NULL OR $9::text = 'relevance')`;
 
     const cteFilters = buildCteInlineFilters(false);
     const cteFiltersWithDate = buildCteInlineFilters(true);
@@ -1130,14 +1149,20 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
           CASE WHEN lower(e.url) = lower($1) THEN 1 ELSE 0 END AS exact_url,
           CASE WHEN e.title IS NOT NULL AND lower(e.title) = lower($1) THEN 1 ELSE 0 END AS exact_title,
           CASE WHEN e.title IS NOT NULL AND ${eTitleMatchSql} THEN 1 ELSE 0 END AS title_hit,
-          CASE WHEN e."alternateTitle" IS NOT NULL AND ${eAltMatchSql} THEN 1 ELSE 0 END AS alt_hit
+          CASE WHEN e."alternateTitle" IS NOT NULL AND ${eAltMatchSql} THEN 1 ELSE 0 END AS alt_hit,
+          CASE WHEN ${relevanceGateSql} THEN ${matchTierSql} END AS relevance_tier,
+          CASE WHEN ${relevanceGateSql} THEN (CASE WHEN e."isDeleted" THEN 1 ELSE 0 END) END AS relevance_deleted_rank,
+          CASE WHEN ${relevanceGateSql} AND ${matchTierSql} >= 2 THEN e.rating END AS relevance_rating_rank
         FROM enriched e
         ORDER BY
           CASE WHEN $9 IN ('rating', 'rating_asc', 'wilson95', 'wilson95_asc', 'controversy', 'controversy_asc', 'comment_count', 'comment_count_asc', 'vote_count', 'vote_count_asc') THEN NULL END,
           CASE WHEN $9 IN ('recent', 'recent_asc') THEN NULL END,
+          relevance_tier DESC NULLS LAST,
+          relevance_deleted_rank ASC NULLS LAST,
           host_match DESC NULLS LAST,
           exact_url DESC NULLS LAST,
           exact_title DESC NULLS LAST,
+          relevance_rating_rank DESC NULLS LAST,
           title_hit DESC NULLS LAST,
           alt_hit DESC NULLS LAST,
           has_url DESC NULLS LAST,
@@ -1363,6 +1388,9 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
         exact_title,
         title_hit,
         alt_hit,
+        relevance_tier,
+        relevance_deleted_rank,
+        relevance_rating_rank,
         search_preview: searchPreview,
         ...rest
       } = row;

--- a/bff/src/web/routes/search.ts
+++ b/bff/src/web/routes/search.ts
@@ -1152,13 +1152,15 @@ export function searchRouter(pool: Pool, redis: RedisClientType | null) {
           CASE WHEN e."alternateTitle" IS NOT NULL AND ${eAltMatchSql} THEN 1 ELSE 0 END AS alt_hit,
           CASE WHEN ${relevanceGateSql} THEN ${matchTierSql} END AS relevance_tier,
           CASE WHEN ${relevanceGateSql} THEN (CASE WHEN e."isDeleted" THEN 1 ELSE 0 END) END AS relevance_deleted_rank,
-          CASE WHEN ${relevanceGateSql} AND ${matchTierSql} >= 2 THEN e.rating END AS relevance_rating_rank
+          CASE WHEN ${relevanceGateSql} THEN (CASE WHEN ${matchTierSql} >= 2 THEN e.rating END) END AS relevance_rating_rank
         FROM enriched e
         ORDER BY
           CASE WHEN $9 IN ('rating', 'rating_asc', 'wilson95', 'wilson95_asc', 'controversy', 'controversy_asc', 'comment_count', 'comment_count_asc', 'vote_count', 'vote_count_asc') THEN NULL END,
           CASE WHEN $9 IN ('recent', 'recent_asc') THEN NULL END,
           relevance_tier DESC NULLS LAST,
           relevance_deleted_rank ASC NULLS LAST,
+          -- 档位内细分（有意置于 rating 之前）：tier 3 内 slug 相等 > URL 相等 > 标题相等，
+          -- 导航精度优先于评分；tier 1/2 行这三个旗标全为 0，不影响其组内次序
           host_match DESC NULLS LAST,
           exact_url DESC NULLS LAST,
           exact_title DESC NULLS LAST,


### PR DESCRIPTION
## 问题

用户反馈:搜索编号(如 `scp-cn-4000`)时,下拉预览中"神秘已删除界面"排在真正的在档页面之前。

实测旧代码(`/search/all?query=scp-cn-4000`,绕过缓存):前 6 个页面坑位中,已删除的竞赛落选稿(`镜殇` -10 分、`庄周梦蝶` -20 分)挤掉了在档的 `SCP-CN-4000𝄇-EX`(799 分)和竞赛中心页(276 分)。

## 根因

`executePageSearch` 的 relevance 排序在精确匹配旗标之后直接用 PGroonga 词频分决定次序:

- 删除稿正文短、编号反复出现 → 词频分虚高(实测删除稿 168 vs 正版 17)
- `rating` 排在词频分之后,基本不起作用;`isDeleted` 完全不参与排序

## 设计

把单一词频分拆为四个正交排序键(**仅 relevance 模式**,其他 orderBy 模式输出与旧代码逐行一致):

```
match_tier DESC      -- 3=slug/URL/标题/备用标题精确相等(导航意图)
                     -- 2=标题/备用标题命中; 1=仅正文(探索意图)
isDeleted ASC        -- 同档位:在档页优先
rating DESC          -- 档位>=2:社区评分优先(质量先验)
score DESC           -- 词频分降级为兜底
```

已删除页查找(SCPper 特色功能)完整保留:`match_tier` 在 `isDeleted` 之前,搜索只有删除版的编号时删除页仍置顶。

## 验证(本地 14396 端口,ENABLE_CACHE=false)

| 场景 | 旧代码 | 新代码 |
|---|---|---|
| `scp-cn-4000` | 正版→删×2→4000+→删除稿×2 | 正版→删×2→EX(799)→4000+(322)→中心页(276) |
| `scp-cn-4120`(仅删除版) | 词频分乱序(-13 第一) | 按删除前评分有序(4 第一) |
| `蒸汽朋克`(内容查询) | — | 标题命中按评分→正文命中按相关性 |
| `orderBy=rating` | 基线 | 与旧代码完全一致 |

新增的 `relevance_*` 排序辅助列已在结果映射处剥离,不泄漏到 API 响应。

`npm run build` / `npm run typecheck` 通过;Jest 失败为存量环境问题(`Cannot find module './helpers.js'`,不带本改动同样失败)。

待完成:Codex review + Claude Code review。