### PR TITLE
fix(tracking): 像素端点 P0 加固——防刷量/隐私止血/by-url 索引化短路

### DIFF
--- a/backend/scripts/check-tracking-health.ts
+++ b/backend/scripts/check-tracking-health.ts
@@ -404,7 +404,12 @@ function buildPairOverlaps(events: OverlapEvent[], votes: OverlapVote[]): PairOv
   return results.slice(0, MAX_PAIR_DISPLAY);
 }
 
+// IP 地理查询会把真实用户 IP 明文 HTTP 外发第三方(ip-api.com),默认关闭;
+// 仅在显式 TRACKING_HEALTH_IP_GEO=true 时启用(2026-06-10 审计 P0-7)。
+const IP_GEO_ENABLED = String(process.env.TRACKING_HEALTH_IP_GEO || '').toLowerCase() === 'true';
+
 async function fetchIpGeo(ip: string, timeoutMs = 2000): Promise<string | null> {
+  if (!IP_GEO_ENABLED) return null;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {

--- a/backend/sql/20260610_tracking_pixel_page_url_index.sql
+++ b/backend/sql/20260610_tracking_pixel_page_url_index.sql
@@ -1,0 +1,16 @@
+-- 追踪像素 by-url 页面查找索引(2026-06-10 审计 P0-5)
+--
+-- 背景: /api/tracking/pixel/by-url 按 lower("currentUrl") 精确匹配查页,此前无函数索引,
+-- 每次像素请求对 Page(~4.75 万行)整表过滤,p50 189ms,占像素端点延迟 97%。
+-- 配套代码改动: bff/src/web/routes/tracking.ts 已把 OR+EXISTS(unnest) 单查询拆成
+-- 两段短路(先 currentUrl 精确命中走本索引,miss 再退 urlHistory 慢路径)。
+--
+-- 应用方式(生产,手动): CONCURRENTLY 不能在事务内,勿走 prisma migrate deploy。
+--   psql "$DATABASE_URL" -f backend/sql/20260610_tracking_pixel_page_url_index.sql
+-- 回滚: DROP INDEX CONCURRENTLY IF EXISTS idx_page_lower_currenturl;
+--
+-- 注意(Prisma drift): 该索引在迁移体系之外,schema.prisma 不声明函数索引;
+-- 做 schema 对账/drift 修复时不要删除它(参见 db pull 后人工核对清单)。
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_page_lower_currenturl
+  ON "Page" (lower("currentUrl"));

--- a/bff/ecosystem.config.cjs
+++ b/bff/ecosystem.config.cjs
@@ -15,8 +15,10 @@ module.exports = {
         REDIS_URL: process.env.REDIS_URL,
         HTML_SNIPPET_PUBLIC_BASE: process.env.HTML_SNIPPET_PUBLIC_BASE || 'https://scpper.mer.run',
         CSS_PROXY_CACHE_CONTROL: process.env.CSS_PROXY_CACHE_CONTROL || 'public, max-age=3600, s-maxage=7200',
-        ENABLE_TRACKING_DEBUG: process.env.ENABLE_TRACKING_DEBUG || 'false',
-        TRACKING_DEBUG_SAMPLE_RATE: process.env.TRACKING_DEBUG_SAMPLE_RATE || '0'
+        // 硬编码关闭:debug 表存完整请求头+原始 IP,曾因 shell env 透传漂移以 100% 采样
+        // 常开数月(2026-06-10 审计)。需要临时开 debug 时改这里并走部署流程,不走 env。
+        ENABLE_TRACKING_DEBUG: 'false',
+        TRACKING_DEBUG_SAMPLE_RATE: '0'
       }
     }
   ]

--- a/bff/src/start.ts
+++ b/bff/src/start.ts
@@ -6,6 +6,7 @@ import pinoHttp from 'pino-http';
 import rateLimit from 'express-rate-limit';
 import { createClient } from 'redis';
 import { buildRouter } from './web/router.js';
+import { pixelRateLimiter } from './web/routes/tracking.js';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { initPools } from './web/utils/dbPool.js';
 
@@ -50,7 +51,9 @@ export async function createServer() {
   // vote-status, stats, etc.), so 120 was too tight for normal browsing
   // across 3-4 navigations per minute.
   // Skip healthz (monitoring), /internal (authenticated server-to-server),
-  // and /avatar (proxied to avatar-agent which has its own limits).
+  // /avatar (proxied to avatar-agent which has its own limits), and
+  // /tracking/pixel (dedicated limiter below — must answer 200+GIF, not 429 JSON,
+  // and must not let embedded pixels drain the shared per-IP budget).
   const globalLimiter = rateLimit({
     windowMs: 60 * 1000,
     max: 600,
@@ -59,10 +62,12 @@ export async function createServer() {
     message: { error: 'too_many_requests' },
     skip: (req) => {
       const p = req.path;
-      return p === '/healthz' || p.startsWith('/internal') || p.startsWith('/avatar');
+      return p === '/healthz' || p.startsWith('/internal') || p.startsWith('/avatar')
+        || p.startsWith('/tracking/pixel');
     }
   });
   app.use(globalLimiter);
+  app.use('/tracking/pixel', pixelRateLimiter());
 
   // Proxy avatar to avatar-agent early to avoid interference
   // Important: include '/avatar' in target so that Express mount path truncation is compensated.

--- a/bff/src/web/routes/tracking.ts
+++ b/bff/src/web/routes/tracking.ts
@@ -1,10 +1,11 @@
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import type { Pool } from 'pg';
 import type { IncomingHttpHeaders } from 'http';
 import type { Request, Response } from 'express';
 
 const PIXEL_BUFFER = Buffer.from('R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', 'base64');
-const DEDUPE_WINDOW_MS = 12 * 60 * 60 * 1000;
+const DEDUPE_WINDOW_HOURS = 12;
 const MAX_COMPONENT_LENGTH = 64;
 const MAX_SOURCE_LENGTH = 64;
 const MAX_USER_AGENT_LENGTH = 1024;
@@ -30,7 +31,17 @@ const DEBUG_HEADERS = [
   'accept'
 ];
 const DEBUG_ENABLED = String(process.env.ENABLE_TRACKING_DEBUG || '').toLowerCase() === 'true';
-const DEBUG_SAMPLE_RATE = Math.max(0, Math.min(1, Number(process.env.TRACKING_DEBUG_SAMPLE_RATE ?? '0')));
+// 生产环境采样率硬上限 5%:tracking_debug_event 存完整请求头+原始 IP,曾因 PM2 env 漂移
+// 以 100% 采样常开累积 504MB 无清理(2026-06-10 审计),clamp 兜住同类配置事故。
+const DEBUG_SAMPLE_RATE_CAP = process.env.NODE_ENV === 'production' ? 0.05 : 1;
+const DEBUG_SAMPLE_RATE = Math.max(0, Math.min(DEBUG_SAMPLE_RATE_CAP, Number(process.env.TRACKING_DEBUG_SAMPLE_RATE ?? '0')));
+// 计数白名单:referer 主机在名单内(或无 referer,如直访/strict-origin 策略)才允许给
+// PageDailyStats.views +1;名单外站点嵌像素仍记录事件行但不污染计数。
+const COUNT_REFERER_ALLOWLIST = (process.env.TRACKING_COUNT_REFERER_ALLOWLIST
+  || 'scp-wiki-cn.wikidot.com,scp-wiki-cn.wikidot.mer.run')
+  .split(',')
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
 const DEBUG_TABLE_NAME = 'tracking_debug_event' as const;
 // Safety assertion: table name must be a valid SQL identifier
 if (!/^[a-z_][a-z0-9_]*$/i.test(DEBUG_TABLE_NAME)) {
@@ -51,6 +62,30 @@ function sendPixel(res: Response, extraHeaders: PixelHeaders = {}) {
     ...extraHeaders
   });
   res.status(200).send(PIXEL_BUFFER);
+}
+
+// 像素专属限流:超限也必须回 200+GIF(而非全局限流的 429 JSON),否则会在嵌入方页面
+// 留下裂图;被限流的请求不写库。
+export function pixelRateLimiter(options: { windowMs?: number; max?: number } = {}) {
+  return rateLimit({
+    windowMs: options.windowMs ?? 60 * 1000,
+    max: options.max ?? 120,
+    standardHeaders: false,
+    legacyHeaders: false,
+    handler: (_req, res) => sendPixel(res, { 'X-Tracking-Error': 'rate_limited' })
+  });
+}
+
+function isInternalDebugRequest(req: Request): boolean {
+  const expectedKey = (process.env.BFF_INTERNAL_API_KEY || '').trim();
+  const providedKey = String(req.get('x-internal-key') || '').trim();
+  return Boolean(expectedKey && providedKey && providedKey === expectedKey);
+}
+
+function isCountableReferer(refererHost: string | null): boolean {
+  if (!refererHost) return true;
+  const host = refererHost.toLowerCase();
+  return COUNT_REFERER_ALLOWLIST.some((allowed) => host === allowed || host.endsWith(`.${allowed}`));
 }
 
 function sanitizeParam(value: unknown, maxLength: number): string | null {
@@ -142,8 +177,10 @@ function sanitizeQueryParams(rawQuery: Record<string, unknown>): Record<string, 
 
 function shouldLogDebug(req: Request): boolean {
   if (!DEBUG_ENABLED) return false;
+  // ?debug 强制开关仅对持有 x-internal-key 的内部请求生效:debug 行包含完整请求头与
+  // 原始 IP,公网可控的写放大入口必须收口。
   const flag = (req.query as Record<string, unknown>).debug;
-  if (flag !== undefined && flag !== null) {
+  if (flag !== undefined && flag !== null && isInternalDebugRequest(req)) {
     const normalized = Array.isArray(flag) ? flag.join(',') : String(flag);
     const lowered = normalized.trim().toLowerCase();
     if (lowered === '1' || lowered === 'true' || lowered === 'yes' || lowered === 'on') {
@@ -265,26 +302,27 @@ async function trackPageView(
   const clientIp = clientIpRaw && clientIpRaw.trim() ? clientIpRaw.trim() : 'unknown-ip';
   const clientFingerprint = buildClientFingerprint(clientIp, userAgent);
   const refererHost = extractRefererHost(req);
+  const countableReferer = isCountableReferer(refererHost);
 
-  const now = new Date();
-  const lookback = new Date(now.getTime() - DEDUPE_WINDOW_MS);
-
-  const dedupeRes = await pool.query(
-    `SELECT 1
-       FROM "PageViewEvent"
-      WHERE "pageId" = $1
-        AND "clientIp" = $2
-        AND "userAgent" = $3
-        AND "createdAt" >= $4
-      LIMIT 1`,
-    [pageId, clientIp, userAgent, lookback]
-  );
-  const counted = dedupeRes.rows.length === 0;
+  let counted = false;
+  if (countableReferer) {
+    const dedupeRes = await pool.query(
+      `SELECT 1
+         FROM "PageViewEvent"
+        WHERE "pageId" = $1
+          AND "clientIp" = $2
+          AND "userAgent" = $3
+          AND "createdAt" >= NOW() - INTERVAL '${DEDUPE_WINDOW_HOURS} hours'
+        LIMIT 1`,
+      [pageId, clientIp, userAgent]
+    );
+    counted = dedupeRes.rows.length === 0;
+  }
 
   await pool.query(
     `INSERT INTO "PageViewEvent"
        ("pageId", "wikidotId", "clientHash", "clientIp", "userAgent", "component", "source", "refererHost", "createdAt")
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())`,
     [
       pageId,
       wikidotId,
@@ -293,22 +331,26 @@ async function trackPageView(
       userAgent,
       component,
       source,
-      refererHost,
-      now
+      refererHost
     ]
   );
 
   if (counted) {
+    // 显式按 Asia/Shanghai 切日,与读侧 stats.ts 的 todayViews 口径逐字一致;
+    // 不再依赖 DB 会话 timezone GUC 恰好是上海这一隐性耦合。
     await pool.query(
       `INSERT INTO "PageDailyStats" ("pageId", date, views)
-       VALUES ($1, CURRENT_DATE, 1)
+       VALUES ($1, (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Shanghai')::date, 1)
        ON CONFLICT ("pageId", date)
        DO UPDATE SET views = "PageDailyStats".views + EXCLUDED.views`,
       [pageId]
     );
   }
 
-  extraHeaders['X-Tracking-Counted'] = counted ? '1' : '0';
+  // 计数结果只回显给内部请求:公开回显会成为刷量者校准去重窗口的 oracle。
+  if (isInternalDebugRequest(req)) {
+    extraHeaders['X-Tracking-Counted'] = counted ? '1' : '0';
+  }
   if (debugRequested) {
     try {
       await recordDebugEvent(pool, req, 'page', {
@@ -356,24 +398,22 @@ async function trackUserPixel(
   const clientFingerprint = buildClientFingerprint(clientIp, userAgent);
   const refererHost = extractRefererHost(req);
 
-  const now = new Date();
-  const lookback = new Date(now.getTime() - DEDUPE_WINDOW_MS);
   const dedupeRes = await pool.query(
     `SELECT 1
        FROM "UserPixelEvent"
       WHERE "userId" = $1
         AND "clientIp" = $2
         AND "userAgent" = $3
-        AND "createdAt" >= $4
+        AND "createdAt" >= NOW() - INTERVAL '${DEDUPE_WINDOW_HOURS} hours'
       LIMIT 1`,
-    [userId, clientIp, userAgent, lookback]
+    [userId, clientIp, userAgent]
   );
   const counted = dedupeRes.rows.length === 0;
 
   await pool.query(
     `INSERT INTO "UserPixelEvent"
        ("userId", "wikidotId", username, "clientHash", "clientIp", "userAgent", "component", "source", "refererHost", "createdAt")
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())`,
     [
       userId,
       Number.isFinite(wikidotId) ? wikidotId : null,
@@ -383,12 +423,13 @@ async function trackUserPixel(
       userAgent,
       component,
       source,
-      refererHost,
-      now
+      refererHost
     ]
   );
 
-  extraHeaders['X-Tracking-Counted'] = counted ? '1' : '0';
+  if (isInternalDebugRequest(req)) {
+    extraHeaders['X-Tracking-Counted'] = counted ? '1' : '0';
+  }
   if (debugRequested) {
     try {
       await recordDebugEvent(pool, req, 'user', {
@@ -436,7 +477,7 @@ export function trackingRouter(pool: Pool) {
 
       const pageRes = await pool.query('SELECT id FROM "Page" WHERE "wikidotId" = $1::int LIMIT 1', [wikidotId]);
       if (pageRes.rows.length === 0) {
-        extraHeaders['X-Tracking-Error'] = 'page_not_found';
+        extraHeaders['X-Tracking-Error'] = 'not_tracked';
         return sendPixel(res, extraHeaders);
       }
       const pageId = Number(pageRes.rows[0].id);
@@ -468,25 +509,60 @@ export function trackingRouter(pool: Pool) {
       const canonicalHttp = `${base}${normalizedPath}`;
       const canonicalHttps = canonicalHttp.replace(/^http:/i, 'https:');
       const candidateUrls = Array.from(new Set([canonicalHttp.toLowerCase(), canonicalHttps.toLowerCase()]));
-      const pageRes = await pool.query(
+      // 三段短路:原 OR + EXISTS(unnest) 单查询的子计划会让规划器放弃索引整表过滤
+      // (实测 p50 189ms,占像素延迟 97%)。绝大多数真实流量在第一段命中
+      // (在档页 + lower("currentUrl") 精确匹配,走 idx_page_lower_currenturl,
+      // 见 backend/sql/20260610_tracking_pixel_page_url_index.sql);后两段保持原查询
+      // 的优先级语义: 在档 > currentUrl 命中 > urlHistory 命中 > 已删页兜底。
+      let pageRes = await pool.query(
         `SELECT id, "wikidotId"
            FROM "Page"
-          WHERE lower("currentUrl") = ANY($1)
-             OR EXISTS (
-               SELECT 1
-               FROM unnest("urlHistory") AS hist(url)
-               WHERE lower(hist.url) = ANY($1)
-             )
-          ORDER BY "isDeleted" ASC,
-                   CASE WHEN lower("currentUrl") = ANY($1) THEN 0 ELSE 1 END ASC,
-                   "updatedAt" DESC,
+          WHERE "isDeleted" = false
+            AND lower("currentUrl") = ANY($1)
+          ORDER BY "updatedAt" DESC,
                    id DESC
           LIMIT 1`,
         [candidateUrls]
       );
+      if (pageRes.rows.length === 0) {
+        pageRes = await pool.query(
+          `SELECT id, "wikidotId"
+             FROM "Page"
+            WHERE "isDeleted" = false
+              AND EXISTS (
+                SELECT 1
+                FROM unnest("urlHistory") AS hist(url)
+                WHERE lower(hist.url) = ANY($1)
+              )
+            ORDER BY "updatedAt" DESC,
+                     id DESC
+            LIMIT 1`,
+          [candidateUrls]
+        );
+      }
+      if (pageRes.rows.length === 0) {
+        // 无在档页命中才扫已删页(罕见路径,保留原合并查询及其排序)
+        pageRes = await pool.query(
+          `SELECT id, "wikidotId"
+             FROM "Page"
+            WHERE lower("currentUrl") = ANY($1)
+               OR EXISTS (
+                 SELECT 1
+                 FROM unnest("urlHistory") AS hist(url)
+                 WHERE lower(hist.url) = ANY($1)
+               )
+            ORDER BY "isDeleted" ASC,
+                     CASE WHEN lower("currentUrl") = ANY($1) THEN 0 ELSE 1 END ASC,
+                     "updatedAt" DESC,
+                     id DESC
+            LIMIT 1`,
+          [candidateUrls]
+        );
+      }
 
       if (pageRes.rows.length === 0) {
-        extraHeaders['X-Tracking-Error'] = 'page_not_found';
+        // 统一为 not_tracked:具体的 not_found 区分会泄漏页面/用户存在性,且对嵌入方无意义。
+        extraHeaders['X-Tracking-Error'] = 'not_tracked';
         return sendPixel(res, extraHeaders);
       }
 
@@ -494,7 +570,7 @@ export function trackingRouter(pool: Pool) {
       const pageId = Number(row.id);
       const wikidotId = Number(row.wikidotId);
       if (!Number.isFinite(pageId) || !Number.isFinite(wikidotId)) {
-        extraHeaders['X-Tracking-Error'] = 'page_not_found';
+        extraHeaders['X-Tracking-Error'] = 'not_tracked';
         return sendPixel(res, extraHeaders);
       }
 
@@ -536,14 +612,14 @@ export function trackingRouter(pool: Pool) {
       );
 
       if (userRes.rows.length === 0) {
-        extraHeaders['X-Tracking-Error'] = 'user_not_found';
+        extraHeaders['X-Tracking-Error'] = 'not_tracked';
         return sendPixel(res, extraHeaders);
       }
 
       const row = userRes.rows[0];
       const userId = Number(row.id);
       if (!Number.isFinite(userId) || userId <= 0) {
-        extraHeaders['X-Tracking-Error'] = 'user_not_found';
+        extraHeaders['X-Tracking-Error'] = 'not_tracked';
         return sendPixel(res, extraHeaders);
       }
 

--- a/bff/tests/tracking-pixel.test.ts
+++ b/bff/tests/tracking-pixel.test.ts
@@ -1,8 +1,11 @@
 import request from 'supertest';
 import express from 'express';
-import { trackingRouter } from '../src/web/routes/tracking';
+import { trackingRouter, pixelRateLimiter } from '../src/web/routes/tracking';
 
 const queryMock = jest.fn();
+// X-Tracking-Counted 只对持有 x-internal-key 的内部请求回显(防刷量 oracle),
+// 测试通过设置同一 key 来观察计数语义。
+const INTERNAL_KEY = 'test-internal-key';
 
 function createTrackingTestServer() {
   const app = express();
@@ -12,6 +15,14 @@ function createTrackingTestServer() {
 }
 
 describe('Tracking pixel endpoint', () => {
+  beforeAll(() => {
+    process.env.BFF_INTERNAL_API_KEY = INTERNAL_KEY;
+  });
+
+  afterAll(() => {
+    delete process.env.BFF_INTERNAL_API_KEY;
+  });
+
   beforeEach(() => {
     queryMock.mockReset();
   });
@@ -38,6 +49,7 @@ describe('Tracking pixel endpoint', () => {
       .get('/tracking/pixel')
       .set('User-Agent', 'jest-agent')
       .set('X-Forwarded-For', '203.0.113.1')
+      .set('X-Internal-Key', INTERNAL_KEY)
       .query({ wikidotId: '123456' })
       .expect(200);
 
@@ -71,6 +83,7 @@ describe('Tracking pixel endpoint', () => {
       .get('/tracking/pixel/by-url')
       .set('User-Agent', 'jest-agent')
       .set('X-Forwarded-For', '203.0.113.3')
+      .set('X-Internal-Key', INTERNAL_KEY)
       .query({ url: target })
       .expect(200);
 
@@ -82,9 +95,9 @@ describe('Tracking pixel endpoint', () => {
     expect((arrParam || [])).toContain(`http://scp-wiki-cn.wikidot.com/${target}`);
   });
 
-  test('prefers active current-url page when url lookup has deleted duplicates', async () => {
+  test('prefers active current-url page and short-circuits before urlHistory fallback', async () => {
     queryMock.mockImplementation((sql: string) => {
-      if (sql.includes('FROM "Page"') && sql.includes('urlHistory')) {
+      if (sql.includes('FROM "Page"') && sql.includes('lower("currentUrl") = ANY') && !sql.includes('urlHistory')) {
         return Promise.resolve({ rows: [{ id: 103731, wikidotId: 1468359417 }] });
       }
       if (sql.includes('FROM "PageViewEvent"') && sql.includes('"clientIp"')) {
@@ -104,13 +117,19 @@ describe('Tracking pixel endpoint', () => {
       .get('/tracking/pixel/by-url')
       .set('User-Agent', 'jest-agent')
       .set('X-Forwarded-For', '203.0.113.42')
+      .set('X-Internal-Key', INTERNAL_KEY)
       .query({ url: 'scp-cn-4042' })
       .expect(200);
 
     expect(res.headers['x-tracking-counted']).toBe('1');
-    const lookupCall = queryMock.mock.calls.find(([sql]) => sql.includes('FROM "Page"') && sql.includes('urlHistory'));
-    expect(lookupCall?.[0]).toContain('ORDER BY "isDeleted" ASC');
-    expect(lookupCall?.[0]).toContain('CASE WHEN lower("currentUrl") = ANY($1) THEN 0 ELSE 1 END ASC');
+    const lookupCall = queryMock.mock.calls.find(
+      ([sql]) => sql.includes('FROM "Page"') && sql.includes('lower("currentUrl") = ANY')
+    );
+    // 第一段只取在档页,已删页留给后续兜底段
+    expect(lookupCall?.[0]).toContain('"isDeleted" = false');
+    // currentUrl 精确命中后不应再触发 urlHistory 慢路径
+    const historyCall = queryMock.mock.calls.find(([sql]) => sql.includes('urlHistory'));
+    expect(historyCall).toBeUndefined();
 
     const insertCall = queryMock.mock.calls.find(([sql]) => sql.includes('INSERT INTO "PageViewEvent"'));
     const insertParams = insertCall?.[1] as unknown[] | undefined;
@@ -142,6 +161,7 @@ describe('Tracking pixel endpoint', () => {
       .get('/tracking/pixel')
       .set('User-Agent', 'jest-agent')
       .set('X-Forwarded-For', '203.0.113.2')
+      .set('X-Internal-Key', INTERNAL_KEY)
       .query({ wikidotId: '654321' })
       .expect(200);
 
@@ -189,6 +209,7 @@ describe('Tracking pixel endpoint', () => {
       .get('/tracking/pixel/by-username')
       .set('User-Agent', 'jest-agent')
       .set('X-Forwarded-For', '203.0.113.5')
+      .set('X-Internal-Key', INTERNAL_KEY)
       .query({ wikidotId: '1234', component: 'top-banner' })
       .expect(200);
 
@@ -223,6 +244,7 @@ describe('Tracking pixel endpoint', () => {
       .get('/tracking/pixel/by-username')
       .set('User-Agent', 'jest-agent')
       .set('X-Forwarded-For', '203.0.113.6')
+      .set('X-Internal-Key', INTERNAL_KEY)
       .query({ wikidotId: '4321' })
       .expect(200);
 
@@ -239,7 +261,7 @@ describe('Tracking pixel endpoint', () => {
     expect(queryMock).not.toHaveBeenCalled();
   });
 
-  test('returns not found when username is unknown', async () => {
+  test('returns generic not_tracked when username is unknown', async () => {
     queryMock.mockImplementation((sql: string) => {
       if (sql.includes('FROM "User"') && sql.includes('"wikidotId"')) {
         return Promise.resolve({ rows: [] });
@@ -253,6 +275,116 @@ describe('Tracking pixel endpoint', () => {
       .query({ wikidotId: '999999' })
       .expect(200);
 
-    expect(res.headers['x-tracking-error']).toBe('user_not_found');
+    // 不区分 not_found 类型,避免无鉴权枚举页面/用户存在性
+    expect(res.headers['x-tracking-error']).toBe('not_tracked');
+  });
+
+  test('hides counted header for non-internal requests', async () => {
+    queryMock.mockImplementation((sql: string) => {
+      if (sql.includes('FROM "Page" WHERE "wikidotId"')) {
+        return Promise.resolve({ rows: [{ id: 42 }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const app = createTrackingTestServer();
+    const res = await request(app)
+      .get('/tracking/pixel')
+      .set('User-Agent', 'jest-agent')
+      .set('X-Forwarded-For', '203.0.113.10')
+      .query({ wikidotId: '123456' })
+      .expect(200);
+
+    expect(res.headers['content-type']).toBe('image/gif');
+    expect(res.headers['x-tracking-counted']).toBeUndefined();
+  });
+
+  test('offsite referer records event but does not count views', async () => {
+    let dailyInsertCount = 0;
+    let dedupeQueryCount = 0;
+    queryMock.mockImplementation((sql: string) => {
+      if (sql.includes('FROM "Page" WHERE "wikidotId"')) {
+        return Promise.resolve({ rows: [{ id: 42 }] });
+      }
+      if (sql.includes('FROM "PageViewEvent"') && sql.includes('"clientIp"')) {
+        dedupeQueryCount += 1;
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('INSERT INTO "PageDailyStats"')) {
+        dailyInsertCount += 1;
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const app = createTrackingTestServer();
+    const res = await request(app)
+      .get('/tracking/pixel')
+      .set('User-Agent', 'jest-agent')
+      .set('X-Forwarded-For', '203.0.113.11')
+      .set('Referer', 'https://evil.example.com/some-page')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .query({ wikidotId: '123456' })
+      .expect(200);
+
+    expect(res.headers['x-tracking-counted']).toBe('0');
+    expect(dedupeQueryCount).toBe(0);
+    expect(dailyInsertCount).toBe(0);
+    // 事件行仍记录,便于事后审计灌量来源
+    const eventInserts = queryMock.mock.calls.filter(([sql]: [string]) => sql.includes('INSERT INTO "PageViewEvent"'));
+    expect(eventInserts.length).toBe(1);
+  });
+
+  test('allowlisted referer still counts views', async () => {
+    let dailyInsertCount = 0;
+    queryMock.mockImplementation((sql: string) => {
+      if (sql.includes('FROM "Page" WHERE "wikidotId"')) {
+        return Promise.resolve({ rows: [{ id: 42 }] });
+      }
+      if (sql.includes('FROM "PageViewEvent"') && sql.includes('"clientIp"')) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('INSERT INTO "PageDailyStats"')) {
+        dailyInsertCount += 1;
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const app = createTrackingTestServer();
+    const res = await request(app)
+      .get('/tracking/pixel')
+      .set('User-Agent', 'jest-agent')
+      .set('X-Forwarded-For', '203.0.113.12')
+      .set('Referer', 'https://scp-wiki-cn.wikidot.com/scp-173')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .query({ wikidotId: '123456' })
+      .expect(200);
+
+    expect(res.headers['x-tracking-counted']).toBe('1');
+    expect(dailyInsertCount).toBe(1);
+  });
+
+  test('pixel rate limiter answers with GIF when over budget', async () => {
+    queryMock.mockResolvedValue({ rows: [] });
+    const app = express();
+    app.set('trust proxy', 1);
+    app.use('/tracking/pixel', pixelRateLimiter({ max: 1, windowMs: 60_000 }));
+    app.use('/tracking', trackingRouter({ query: queryMock } as any));
+
+    await request(app)
+      .get('/tracking/pixel')
+      .set('X-Forwarded-For', '203.0.113.13')
+      .query({ wikidotId: '1' })
+      .expect(200);
+
+    const res = await request(app)
+      .get('/tracking/pixel')
+      .set('X-Forwarded-For', '203.0.113.13')
+      .query({ wikidotId: '1' })
+      .expect(200);
+
+    expect(res.headers['content-type']).toBe('image/gif');
+    expect(res.headers['x-tracking-error']).toBe('rate_limited');
   });
 });


### PR DESCRIPTION
## 背景

2026-06-10 对追踪像素子系统做了专项审计（机制梳理 + 生产数据异常分析 + 对抗验证，16 条确认问题），本 PR 落地其中 P0 批次里纯代码、低风险、可独立上线的部分。

## 改动

**防刷量 / 防枚举**
- `X-Tracking-Counted` 响应头仅对持有 `x-internal-key` 的内部请求回显。此前公开回显去重结果，是刷量者校准 12h 去重窗口的 oracle（历史上已发生单页单日 views 被刷至 9276 的事件，常态 ~400）
- `page_not_found`/`user_not_found` 错误头统一泛化为 `not_tracked`，防止无鉴权枚举页面/用户存在性
- referer 计数门控：referer 主机不在白名单（env `TRACKING_COUNT_REFERER_ALLOWLIST`，默认主站+镜像）时只记录事件行、不给 `PageDailyStats.views` +1；无 referer（直访/strict-origin）仍正常计数

**性能**
- `/pixel/by-url`（100% 页面像素流量）页面查找从 `OR + EXISTS(unnest)` 单查询改为三段短路：在档+currentUrl 精确命中（走新函数索引）→ 在档+urlHistory → 已删页兜底（保留原查询及其排序，语义逐字等价）。原查询规划器无法用索引，对 Page 整表过滤，p50 189ms、占像素端点延迟 97%
- 配套索引脚本 `backend/sql/20260610_tracking_pixel_page_url_index.sql`（**生产需手动 psql 应用**，CONCURRENTLY 不能走 migrate deploy）
- 像素路径豁免全局 600/min 限流（防止站内代理路由共享预算被像素耗尽），改挂专属 120/min/IP 限流器，超限仍回 `200 + GIF`（而非 429 JSON，避免嵌入方页面裂图），且不写库

**正确性**
- `PageDailyStats` 切日从 `CURRENT_DATE` 改为显式 `(CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Shanghai')::date`，与读侧 `stats.ts` 的 todayViews 口径逐字一致；当前 DB GUC 即上海时区，**零行为变化**，但解除隐性耦合
- 事件 `createdAt` 与去重回看窗口改 SQL `NOW()`，消除应用机与 DB 的时钟漂移

**隐私止血**
- 生产环境 debug 采样率 clamp ≤5%，`?debug=1` 强制开关需内部鉴权（此前为公网可控的写放大入口）
- `ecosystem.config.cjs` 将 `ENABLE_TRACKING_DEBUG`/`TRACKING_DEBUG_SAMPLE_RATE` 硬编码关闭——此前因 PM2 env 透传漂移以 100% 采样常开，`tracking_debug_event` 已累积 504MB 含完整请求头+原始 IP 且无清理路径
- `check-tracking-health.ts` 的 ip-api.com 明文 IP 外发默认关闭，需 `TRACKING_HEALTH_IP_GEO=true` 显式启用

## 测试

- `bff/tests/tracking-pixel.test.ts` 14/14 通过（新增：referer 门控双向用例、counted 头对非内部请求隐藏、限流超限回 GIF、currentUrl 命中短路不触发 urlHistory 慢路径）
- `tsc --noEmit` 通过
- 其余 11 个测试套件失败与 main 基线完全一致（预存的 `.js` 后缀模块解析配置问题，与本改动无关）

## 部署注意

1. 合并后先手动建索引：`psql "$DATABASE_URL" -f backend/sql/20260610_tracking_pixel_page_url_index.sql`（CONCURRENTLY，不锁表）
2. BFF 重启必须用 `pm2 restart scpper-bff --update-env`（或 delete 后从 ecosystem 重启），否则 ecosystem 里硬编码的 debug 关闭不生效（当前生产 pm2 env 残留 `ENABLE_TRACKING_DEBUG=true` + `SAMPLE_RATE=1`）
3. 验证：`curl -sI 'https://scpper.mer.run/api/tracking/pixel/by-url?url=scp-173'` 应无 `X-Tracking-Counted` 头；`tracking_debug_event` 行数 24h 零增长；EXPLAIN by-url 查找走 `idx_page_lower_currenturl`
4. 后续 P1（独立 PR）：counted 列 + 摄入原子化 + 刷量数据修正（须先于 87 万行超期事件清理）+ retention 调度