### PR TITLE
feat(tracking): 像素身份信号增强 + 小号检测（重定向到 main）

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -809,6 +809,14 @@ model PageViewEvent {
   source      String?
   refererHost String?
   createdAt   DateTime @default(now())
+  // 身份信号增强（2026-06 backend/sql/20260610_tracking_identity_signals.sql，全部可空回填）
+  acceptLanguage String?
+  uaPlatform     String?
+  uaBrandMajor   String?
+  uaFamily       String?
+  softprint      String?
+  visitorToken   String?
+  tlsFingerprint String?
   page        Page     @relation(fields: [pageId], references: [id], onDelete: Cascade)
 
   @@index([pageId, createdAt])
@@ -829,11 +837,49 @@ model UserPixelEvent {
   source      String?
   refererHost String?
   createdAt   DateTime @default(now())
+  // 身份信号增强（同上迁移）
+  acceptLanguage String?
+  uaPlatform     String?
+  uaBrandMajor   String?
+  uaFamily       String?
+  softprint      String?
+  visitorToken   String?
+  tlsFingerprint String?
   user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, createdAt])
   @@index([userId, clientHash, createdAt])
   @@index([userId, clientIp, userAgent, createdAt])
+}
+
+/// 小号嫌疑账号对：analyze-alt-accounts 检测 Job 的输出，供站务复核（不自动处置）。
+model SuspectedAltPair {
+  id               Int      @id @default(autoincrement())
+  userIdA          Int
+  userIdB          Int
+  usernameA        String
+  usernameB        String
+  sharedHashes     Int      @default(0)
+  sharedSubnets    Int      @default(0)
+  sharedSoftprints Int      @default(0)
+  sharedTokens     Int      @default(0)
+  coVotes          Int      @default(0)
+  sameDir          Int      @default(0)
+  oppDir           Int      @default(0)
+  sameHour         Int      @default(0)
+  agreePct         Int?
+  shadowPct        Int?
+  selfPromoAtoB    Int      @default(0)
+  selfPromoBtoA    Int      @default(0)
+  score            Decimal  @default(0)
+  status           String   @default("candidate")
+  evidence         Json?
+  firstDetectedAt  DateTime @default(now())
+  updatedAt        DateTime @default(now())
+
+  @@unique([userIdA, userIdB])
+  @@index([score])
+  @@index([status])
 }
 
 model UserDailyStats {

--- a/backend/sql/20260610_tracking_identity_signals.sql
+++ b/backend/sql/20260610_tracking_identity_signals.sql
@@ -1,0 +1,72 @@
+-- 追踪监控增强：身份信号列 + 小号检测表（2026-06-10）
+--
+-- 全部 additive：新增可空列 / 新建表 / 新建索引。不 UPDATE 既有列、不 DROP、不破坏历史。
+-- 配套：bff/src/web/routes/tracking.ts 写侧采集；backend tracking-backfill-signals 回填；
+--       backend analyze-alt-accounts 检测 Job。
+--
+-- 应用（生产，手动；含 CONCURRENTLY 索引须逐条在事务外跑，勿走 prisma migrate deploy）：
+--   psql "$DATABASE_URL" -f backend/sql/20260610_tracking_identity_signals.sql
+-- 回滚：DROP 新列/新表/新索引即可（历史事件行不受影响）。
+--
+-- Prisma drift：本批列/表在迁移体系外，schema.prisma 已同步声明；做 db pull/对账时勿误删。
+
+-- ── 事件表新增身份信号列（image-only 可被动获取） ──
+ALTER TABLE "PageViewEvent"
+  ADD COLUMN IF NOT EXISTS "acceptLanguage" text,
+  ADD COLUMN IF NOT EXISTS "uaPlatform"     text,
+  ADD COLUMN IF NOT EXISTS "uaBrandMajor"   text,
+  ADD COLUMN IF NOT EXISTS "uaFamily"       text,
+  ADD COLUMN IF NOT EXISTS "softprint"      text,
+  ADD COLUMN IF NOT EXISTS "visitorToken"   text,
+  ADD COLUMN IF NOT EXISTS "tlsFingerprint" text;
+
+ALTER TABLE "UserPixelEvent"
+  ADD COLUMN IF NOT EXISTS "acceptLanguage" text,
+  ADD COLUMN IF NOT EXISTS "uaPlatform"     text,
+  ADD COLUMN IF NOT EXISTS "uaBrandMajor"   text,
+  ADD COLUMN IF NOT EXISTS "uaFamily"       text,
+  ADD COLUMN IF NOT EXISTS "softprint"      text,
+  ADD COLUMN IF NOT EXISTS "visitorToken"   text,
+  ADD COLUMN IF NOT EXISTS "tlsFingerprint" text;
+
+-- 检测用索引（部分索引，仅非空行；CONCURRENTLY 避免锁表）
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "PageViewEvent_softprint_idx"
+  ON "PageViewEvent" ("softprint", "createdAt") WHERE "softprint" IS NOT NULL;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "UserPixelEvent_softprint_idx"
+  ON "UserPixelEvent" ("softprint", "createdAt") WHERE "softprint" IS NOT NULL;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "UserPixelEvent_visitorToken_idx"
+  ON "UserPixelEvent" ("visitorToken") WHERE "visitorToken" IS NOT NULL;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "PageViewEvent_visitorToken_idx"
+  ON "PageViewEvent" ("visitorToken") WHERE "visitorToken" IS NOT NULL;
+
+-- ── 小号嫌疑对（检测 Job 的输出，供站务复核） ──
+CREATE TABLE IF NOT EXISTS "SuspectedAltPair" (
+  id                serial PRIMARY KEY,
+  "userIdA"         integer NOT NULL REFERENCES "User"(id) ON DELETE CASCADE,
+  "userIdB"         integer NOT NULL REFERENCES "User"(id) ON DELETE CASCADE,
+  "usernameA"       text NOT NULL,
+  "usernameB"       text NOT NULL,
+  "sharedHashes"    integer NOT NULL DEFAULT 0,   -- 共享的独立 clientHash 数
+  "sharedSubnets"   integer NOT NULL DEFAULT 0,   -- 共享的独立 /24 子网数（最强网络信号）
+  "sharedSoftprints" integer NOT NULL DEFAULT 0,
+  "sharedTokens"    integer NOT NULL DEFAULT 0,   -- 共享的 ETag visitorToken 数
+  "coVotes"         integer NOT NULL DEFAULT 0,   -- 共投页数
+  "sameDir"         integer NOT NULL DEFAULT 0,
+  "oppDir"          integer NOT NULL DEFAULT 0,
+  "sameHour"        integer NOT NULL DEFAULT 0,   -- 同向且 1 小时内
+  "agreePct"        integer,                      -- 同向占比 0-100
+  "shadowPct"       integer,                      -- 共投/小号总票数 0-100
+  "selfPromoAtoB"   integer NOT NULL DEFAULT 0,   -- A 给 B 原创页点赞数
+  "selfPromoBtoA"   integer NOT NULL DEFAULT 0,
+  score             numeric NOT NULL DEFAULT 0,   -- 综合可疑度
+  status            text NOT NULL DEFAULT 'candidate', -- candidate | confirmed | cleared
+  evidence          jsonb,
+  "firstDetectedAt" timestamptz NOT NULL DEFAULT now(),
+  "updatedAt"       timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "SuspectedAltPair_pair_uniq" UNIQUE ("userIdA", "userIdB")
+);
+
+CREATE INDEX IF NOT EXISTS "SuspectedAltPair_score_idx"
+  ON "SuspectedAltPair" (score DESC);
+CREATE INDEX IF NOT EXISTS "SuspectedAltPair_status_idx"
+  ON "SuspectedAltPair" (status);

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -10,6 +10,7 @@ import { analyzeIncremental } from '../jobs/IncrementalAnalyzeJob.js';
 import { runDailySiteOverview } from '../jobs/DailySiteOverviewJob.js';
 import { TrackingRetentionJob } from '../jobs/TrackingRetentionJob.js';
 import { AltAccountDetectionJob } from '../jobs/AltAccountDetectionJob.js';
+import { TrackingSignalBackfillJob } from '../jobs/TrackingSignalBackfillJob.js';
 import { disconnectPrisma, getPrismaClient } from '../utils/db-connection.js';
 import { validateUserStats } from '../jobs/ValidationJob.js';
 import { Logger } from '../utils/Logger.js';
@@ -340,6 +341,21 @@ program
       retentionDays: Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : undefined,
       batchSize: Number.isFinite(parsedBatch) && parsedBatch > 0 ? parsedBatch : undefined,
       dryRun: Boolean(options.dryRun)
+    });
+    await disconnectPrisma();
+  });
+
+program
+  .command('tracking-backfill-signals')
+  .description('从 debug 表回填历史事件的 Accept-Language / 平台（仅填 NULL，幂等）')
+  .option('--dry-run', '仅统计待回填行数，不写入')
+  .option('--batch <n>', '单批 id 跨度，默认 20000', '20000')
+  .action(async (options) => {
+    const job = new TrackingSignalBackfillJob();
+    const parsedBatch = Number.parseInt(String(options.batch ?? ''), 10);
+    await job.run({
+      dryRun: Boolean(options.dryRun),
+      batchSize: Number.isFinite(parsedBatch) && parsedBatch > 0 ? parsedBatch : undefined,
     });
     await disconnectPrisma();
   });

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -9,6 +9,7 @@ import { query } from './query.js';
 import { analyzeIncremental } from '../jobs/IncrementalAnalyzeJob.js';
 import { runDailySiteOverview } from '../jobs/DailySiteOverviewJob.js';
 import { TrackingRetentionJob } from '../jobs/TrackingRetentionJob.js';
+import { AltAccountDetectionJob } from '../jobs/AltAccountDetectionJob.js';
 import { disconnectPrisma, getPrismaClient } from '../utils/db-connection.js';
 import { validateUserStats } from '../jobs/ValidationJob.js';
 import { Logger } from '../utils/Logger.js';
@@ -340,6 +341,22 @@ program
       batchSize: Number.isFinite(parsedBatch) && parsedBatch > 0 ? parsedBatch : undefined,
       dryRun: Boolean(options.dryRun)
     });
+    await disconnectPrisma();
+  });
+
+program
+  .command('analyze-alt-accounts')
+  .description('小号检测：基于像素信标网络共享+投票共现+自我推广，写入 SuspectedAltPair 供站务复核')
+  .option('--dry-run', '仅打印 Top 候选，不写入 SuspectedAltPair')
+  .option('--min-score <n>', '最低可疑度阈值，默认 4', '4')
+  .action(async (options) => {
+    const job = new AltAccountDetectionJob();
+    const parsedMin = Number.parseFloat(String(options.minScore ?? ''));
+    const result = await job.run({
+      dryRun: Boolean(options.dryRun),
+      minScore: Number.isFinite(parsedMin) ? parsedMin : undefined,
+    });
+    Logger.info(`[alt-detect] 完成：候选 ${result.candidates} / 写入 ${result.written}`);
     await disconnectPrisma();
   });
 

--- a/backend/src/jobs/AltAccountDetectionJob.ts
+++ b/backend/src/jobs/AltAccountDetectionJob.ts
@@ -105,19 +105,24 @@ export class AltAccountDetectionJob {
         GROUP BY 1
       ),
       pairs AS (
+        -- 携带 a/b 两侧的 softprint/token,共享=两侧都有且相等(单侧多样性不算共享)。
+        -- 注:clientHash 为明文 ip|ua,故同 ch 的 a/b 必同 IP 同 subnet;b 侧 infra 过滤为防御性冗余。
         SELECT a."userId" ua, a.username una, b."userId" ub, b.username unb,
-               a."clientHash" ch, a.subnet24, a."softprint" sp, a."visitorToken" tok
+               a."clientHash" ch, a.subnet24,
+               a."softprint" sp_a, b."softprint" sp_b,
+               a."visitorToken" tok_a, b."visitorToken" tok_b
         FROM base a
         JOIN base b ON a."clientHash"=b."clientHash" AND a."userId" < b."userId"
         JOIN hash_small h ON h."clientHash"=a."clientHash"
-        JOIN ip_breadth ib ON ib.subnet24=a.subnet24 AND ib.ip_users <= ${INFRA_IP_USER_CAP}
+        JOIN ip_breadth iba ON iba.subnet24=a.subnet24 AND iba.ip_users <= ${INFRA_IP_USER_CAP}
+        JOIN ip_breadth ibb ON ibb.subnet24=b.subnet24 AND ibb.ip_users <= ${INFRA_IP_USER_CAP}
       ),
       pair_agg AS (
         SELECT ua, una, ub, unb,
                count(distinct ch) shared_hashes,
                count(distinct subnet24) shared_subnets,
-               count(distinct sp) FILTER (WHERE sp IS NOT NULL) shared_softprints,
-               count(distinct tok) FILTER (WHERE tok IS NOT NULL) shared_tokens
+               count(distinct sp_a) FILTER (WHERE sp_a IS NOT NULL AND sp_a = sp_b) shared_softprints,
+               count(distinct tok_a) FILTER (WHERE tok_a IS NOT NULL AND tok_a = tok_b) shared_tokens
         FROM pairs GROUP BY ua, una, ub, unb
         HAVING count(distinct ch) >= 1
       ),

--- a/backend/src/jobs/AltAccountDetectionJob.ts
+++ b/backend/src/jobs/AltAccountDetectionJob.ts
@@ -128,12 +128,13 @@ export class AltAccountDetectionJob {
       ),
       ru AS ( SELECT ua uid FROM pair_agg UNION SELECT ub FROM pair_agg ),
       lv AS (
+        -- 先按 (voter,page) 取最新一票, 再过滤方向: 撤票/改票后旧票不得被当作当前票。
         SELECT "userId", "pageId", direction, ts FROM (
           SELECT v."userId", pv."pageId", v.direction, v.timestamp ts,
                  row_number() OVER (PARTITION BY v."userId", pv."pageId" ORDER BY v.timestamp DESC, v.id DESC) rn
           FROM "Vote" v JOIN "PageVersion" pv ON pv.id=v."pageVersionId"
-          WHERE v."userId" IN (SELECT uid FROM ru) AND v.direction <> 0
-        ) z WHERE rn=1
+          WHERE v."userId" IN (SELECT uid FROM ru)
+        ) z WHERE rn=1 AND direction <> 0
       ),
       tot AS ( SELECT "userId", count(*) n FROM lv GROUP BY "userId" ),
       co AS (
@@ -179,13 +180,13 @@ export class AltAccountDetectionJob {
     const promo = await this.prisma.$queryRawUnsafe<any[]>(`
       WITH ids(uid) AS (SELECT unnest($1::int[])),
       lv AS (
+        -- 同 lv 口径: 先取最新票再过滤, 只保留当前仍为 upvote 的页。
         SELECT "userId", "pageId" FROM (
-          SELECT v."userId", pv."pageId",
-                 row_number() OVER (PARTITION BY v."userId", pv."pageId" ORDER BY v.timestamp DESC, v.id DESC) rn,
-                 v.direction
+          SELECT v."userId", pv."pageId", v.direction,
+                 row_number() OVER (PARTITION BY v."userId", pv."pageId" ORDER BY v.timestamp DESC, v.id DESC) rn
           FROM "Vote" v JOIN "PageVersion" pv ON pv.id=v."pageVersionId"
-          WHERE v."userId" IN (SELECT uid FROM ids) AND v.direction = 1
-        ) z WHERE rn=1
+          WHERE v."userId" IN (SELECT uid FROM ids)
+        ) z WHERE rn=1 AND direction = 1
       ),
       authored AS (
         SELECT DISTINCT a."userId", pv."pageId"

--- a/backend/src/jobs/AltAccountDetectionJob.ts
+++ b/backend/src/jobs/AltAccountDetectionJob.ts
@@ -1,0 +1,254 @@
+// src/jobs/AltAccountDetectionJob.ts
+import { PrismaClient } from '@prisma/client';
+import { getPrismaClient } from '../utils/db-connection.js';
+import { Logger } from '../utils/Logger.js';
+
+/**
+ * 小号（同人多号）检测 Job。
+ *
+ * 把 2026-06-10 手工分析固化为可重复运行：基于 UserPixelEvent 的"账号 = clientHash/
+ * softprint/visitorToken 信标"假设，找出在多个相互独立网络反复成对的账号，并用投票共现
+ * （同向占比/影子比例/时间协同）与互投原创作品（自我推广）交叉验证，写入 SuspectedAltPair
+ * 供站务复核。**只产出候选，不自动处置。**
+ *
+ * 口径要点：
+ * - 仅 image-only 被动信号 + 公开投票数据，只读分析。
+ * - 排除共享出口（同 IP 被 >8 个注册账号当信标 = VPN/NAT），避免把无关用户判成小号。
+ * - clientHash 口径覆盖全部历史；softprint/visitorToken 为增强信号（go-forward 渐充）。
+ * - 人工已置 confirmed/cleared 的对，只更新指标不覆盖 status。
+ */
+
+const INFRA_IP_USER_CAP = 8; // 同 IP 注册账号数上限，超过视为共享出口
+const HASH_USER_MIN = 2;
+const HASH_USER_MAX = 8;
+const CANDIDATE_LIMIT = 500;
+
+export type AltAccountDetectionOptions = {
+  dryRun?: boolean;
+  minScore?: number;
+};
+
+type PairMetric = {
+  uaId: number; ubId: number; una: string; unb: string;
+  sharedHashes: number; sharedSubnets: number; sharedSoftprints: number; sharedTokens: number;
+  votesA: number; votesB: number;
+  coVotes: number; sameDir: number; oppDir: number; sameHour: number;
+  selfPromoAtoB: number; selfPromoBtoA: number;
+};
+
+function n(v: unknown): number {
+  if (typeof v === 'number') return Number.isFinite(v) ? v : 0;
+  if (typeof v === 'bigint') return Number(v);
+  if (typeof v === 'string') { const x = Number(v); return Number.isFinite(x) ? x : 0; }
+  return 0;
+}
+
+export class AltAccountDetectionJob {
+  private prisma: PrismaClient;
+  constructor(prisma?: PrismaClient) {
+    this.prisma = prisma ?? getPrismaClient();
+  }
+
+  async run(options: AltAccountDetectionOptions = {}): Promise<{ candidates: number; written: number }> {
+    const dryRun = Boolean(options.dryRun);
+    const minScore = options.minScore ?? 4;
+    Logger.info(`[alt-detect] start${dryRun ? ' [dry-run]' : ''} minScore=${minScore}`);
+
+    const metrics = await this.computeNetworkAndVoteMetrics();
+    Logger.info(`[alt-detect] 网络+投票候选对 ${metrics.length}`);
+    const withPromo = await this.attachSelfPromotion(metrics);
+
+    const scored = withPromo
+      .map((m) => ({ m, score: this.score(m) }))
+      .filter((x) => x.score >= minScore)
+      .sort((a, b) => b.score - a.score);
+    Logger.info(`[alt-detect] 达阈值候选 ${scored.length}（minScore=${minScore}）`);
+
+    if (dryRun) {
+      for (const { m, score } of scored.slice(0, 30)) {
+        Logger.info(
+          `[alt-detect] ${m.una} ↔ ${m.unb} score=${score.toFixed(1)} ` +
+          `nets=${m.sharedSubnets} hashes=${m.sharedHashes} sp=${m.sharedSoftprints} tok=${m.sharedTokens} ` +
+          `co=${m.coVotes} same=${m.sameDir} opp=${m.oppDir} hr=${m.sameHour} promo=${m.selfPromoAtoB}/${m.selfPromoBtoA}`
+        );
+      }
+      return { candidates: scored.length, written: 0 };
+    }
+
+    let written = 0;
+    for (const { m, score } of scored) {
+      await this.upsertPair(m, score);
+      written++;
+    }
+    Logger.info(`[alt-detect] 写入 SuspectedAltPair ${written} 行`);
+    return { candidates: scored.length, written };
+  }
+
+  /** 网络共享（clientHash/subnet/softprint/token）+ 投票共现，一次性算出候选对。 */
+  private async computeNetworkAndVoteMetrics(): Promise<PairMetric[]> {
+    const rows = await this.prisma.$queryRawUnsafe<any[]>(`
+      WITH base AS (
+        SELECT DISTINCT "clientHash",
+               split_part("clientIp",'.',1)||'.'||split_part("clientIp",'.',2)||'.'||split_part("clientIp",'.',3) AS subnet24,
+               "softprint", "visitorToken", "userId", username
+        FROM "UserPixelEvent"
+        WHERE "userId" IS NOT NULL AND username IS NOT NULL AND trim(username) <> ''
+      ),
+      hash_small AS (
+        SELECT "clientHash" FROM base
+        GROUP BY "clientHash" HAVING count(distinct "userId") BETWEEN ${HASH_USER_MIN} AND ${HASH_USER_MAX}
+      ),
+      ip_breadth AS (
+        SELECT split_part("clientIp",'.',1)||'.'||split_part("clientIp",'.',2)||'.'||split_part("clientIp",'.',3) AS subnet24,
+               count(distinct "userId") ip_users
+        FROM "UserPixelEvent" WHERE "userId" IS NOT NULL
+        GROUP BY 1
+      ),
+      pairs AS (
+        SELECT a."userId" ua, a.username una, b."userId" ub, b.username unb,
+               a."clientHash" ch, a.subnet24, a."softprint" sp, a."visitorToken" tok
+        FROM base a
+        JOIN base b ON a."clientHash"=b."clientHash" AND a."userId" < b."userId"
+        JOIN hash_small h ON h."clientHash"=a."clientHash"
+        JOIN ip_breadth ib ON ib.subnet24=a.subnet24 AND ib.ip_users <= ${INFRA_IP_USER_CAP}
+      ),
+      pair_agg AS (
+        SELECT ua, una, ub, unb,
+               count(distinct ch) shared_hashes,
+               count(distinct subnet24) shared_subnets,
+               count(distinct sp) FILTER (WHERE sp IS NOT NULL) shared_softprints,
+               count(distinct tok) FILTER (WHERE tok IS NOT NULL) shared_tokens
+        FROM pairs GROUP BY ua, una, ub, unb
+        HAVING count(distinct ch) >= 1
+      ),
+      ru AS ( SELECT ua uid FROM pair_agg UNION SELECT ub FROM pair_agg ),
+      lv AS (
+        SELECT "userId", "pageId", direction, ts FROM (
+          SELECT v."userId", pv."pageId", v.direction, v.timestamp ts,
+                 row_number() OVER (PARTITION BY v."userId", pv."pageId" ORDER BY v.timestamp DESC, v.id DESC) rn
+          FROM "Vote" v JOIN "PageVersion" pv ON pv.id=v."pageVersionId"
+          WHERE v."userId" IN (SELECT uid FROM ru) AND v.direction <> 0
+        ) z WHERE rn=1
+      ),
+      tot AS ( SELECT "userId", count(*) n FROM lv GROUP BY "userId" ),
+      co AS (
+        SELECT p.ua, p.ub,
+               count(*) co_pages,
+               count(*) FILTER (WHERE la.direction=lb.direction) same_dir,
+               count(*) FILTER (WHERE la.direction<>lb.direction) opp_dir,
+               count(*) FILTER (WHERE la.direction=lb.direction AND abs(extract(epoch FROM la.ts-lb.ts))<3600) same_hr
+        FROM pair_agg p
+        JOIN lv la ON la."userId"=p.ua
+        JOIN lv lb ON lb."userId"=p.ub AND lb."pageId"=la."pageId"
+        GROUP BY p.ua, p.ub
+      )
+      SELECT p.ua, p.una, p.ub, p.unb,
+             p.shared_hashes, p.shared_subnets, p.shared_softprints, p.shared_tokens,
+             COALESCE(ta.n,0) votes_a, COALESCE(tb.n,0) votes_b,
+             COALESCE(c.co_pages,0) co_pages, COALESCE(c.same_dir,0) same_dir,
+             COALESCE(c.opp_dir,0) opp_dir, COALESCE(c.same_hr,0) same_hr
+      FROM pair_agg p
+      LEFT JOIN tot ta ON ta."userId"=p.ua
+      LEFT JOIN tot tb ON tb."userId"=p.ub
+      LEFT JOIN co c ON c.ua=p.ua AND c.ub=p.ub
+      WHERE p.shared_hashes >= 2 OR COALESCE(c.same_dir,0) >= 15
+      ORDER BY p.shared_subnets DESC, COALESCE(c.same_dir,0) DESC
+      LIMIT ${CANDIDATE_LIMIT}
+    `);
+
+    return rows.map((r) => ({
+      uaId: n(r.ua), ubId: n(r.ub), una: r.una, unb: r.unb,
+      sharedHashes: n(r.shared_hashes), sharedSubnets: n(r.shared_subnets),
+      sharedSoftprints: n(r.shared_softprints), sharedTokens: n(r.shared_tokens),
+      votesA: n(r.votes_a), votesB: n(r.votes_b),
+      coVotes: n(r.co_pages), sameDir: n(r.same_dir), oppDir: n(r.opp_dir), sameHour: n(r.same_hr),
+      selfPromoAtoB: 0, selfPromoBtoA: 0,
+    }));
+  }
+
+  /** 互投原创作品（自我推广）：B 给 A 原创页 up 票数 / A 给 B 原创页 up 票数。 */
+  private async attachSelfPromotion(metrics: PairMetric[]): Promise<PairMetric[]> {
+    if (metrics.length === 0) return metrics;
+    const ids = Array.from(new Set(metrics.flatMap((m) => [m.uaId, m.ubId])));
+    // 相关用户的当前 up 票 + 原创页
+    const promo = await this.prisma.$queryRawUnsafe<any[]>(`
+      WITH ids(uid) AS (SELECT unnest($1::int[])),
+      lv AS (
+        SELECT "userId", "pageId" FROM (
+          SELECT v."userId", pv."pageId",
+                 row_number() OVER (PARTITION BY v."userId", pv."pageId" ORDER BY v.timestamp DESC, v.id DESC) rn,
+                 v.direction
+          FROM "Vote" v JOIN "PageVersion" pv ON pv.id=v."pageVersionId"
+          WHERE v."userId" IN (SELECT uid FROM ids) AND v.direction = 1
+        ) z WHERE rn=1
+      ),
+      authored AS (
+        SELECT DISTINCT a."userId", pv."pageId"
+        FROM "Attribution" a JOIN "PageVersion" pv ON pv.id=a."pageVerId" AND pv."validTo" IS NULL
+        WHERE a."userId" IN (SELECT uid FROM ids) AND a.type IN ('AUTHOR','SUBMITTER')
+      )
+      SELECT v."userId" voter, au."userId" author, count(*) cnt
+      FROM lv v JOIN authored au ON au."pageId"=v."pageId" AND au."userId" <> v."userId"
+      GROUP BY 1,2
+    `, ids);
+
+    const key = (voter: number, author: number) => `${voter}|${author}`;
+    const map = new Map<string, number>();
+    for (const r of promo) map.set(key(n(r.voter), n(r.author)), n(r.cnt));
+    for (const m of metrics) {
+      m.selfPromoAtoB = map.get(key(m.uaId, m.ubId)) ?? 0; // A 投 B 原创
+      m.selfPromoBtoA = map.get(key(m.ubId, m.uaId)) ?? 0; // B 投 A 原创
+    }
+    return metrics;
+  }
+
+  private score(m: PairMetric): number {
+    const agree = m.sameDir + m.oppDir > 0 ? m.sameDir / (m.sameDir + m.oppDir) : 0;
+    let s = 0;
+    s += 3.0 * m.sharedSubnets;                 // 独立网络数（最强）
+    s += 1.0 * Math.min(m.sharedHashes, 10);
+    s += 1.0 * m.sharedSoftprints;
+    s += 2.5 * m.sharedTokens;                  // 同 ETag token = 同浏览器
+    s += 0.12 * m.sameDir;
+    s += 0.10 * m.sameHour;
+    s += (agree >= 0.9 && m.coVotes >= 10) ? 2.5 : 0;
+    s += 0.3 * (m.selfPromoAtoB + m.selfPromoBtoA); // 自我推广
+    s -= 0.5 * m.oppDir;                        // 投票分歧降可疑度
+    return Math.max(0, s);
+  }
+
+  private agreePct(m: PairMetric): number | null {
+    const d = m.sameDir + m.oppDir;
+    return d > 0 ? Math.round((100 * m.sameDir) / d) : null;
+  }
+  private shadowPct(m: PairMetric): number | null {
+    const min = Math.min(m.votesA, m.votesB);
+    return min > 0 ? Math.round((100 * m.coVotes) / min) : null;
+  }
+
+  private async upsertPair(m: PairMetric, score: number): Promise<void> {
+    const evidence = JSON.stringify({
+      votesA: m.votesA, votesB: m.votesB, sharedTokens: m.sharedTokens, sharedSoftprints: m.sharedSoftprints,
+    });
+    // 人工已置 status 不覆盖；只刷新指标与 score、updatedAt。
+    await this.prisma.$executeRawUnsafe(`
+      INSERT INTO "SuspectedAltPair"
+        ("userIdA","userIdB","usernameA","usernameB","sharedHashes","sharedSubnets","sharedSoftprints",
+         "sharedTokens","coVotes","sameDir","oppDir","sameHour","agreePct","shadowPct","selfPromoAtoB","selfPromoBtoA",
+         score, status, evidence, "firstDetectedAt", "updatedAt")
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,'candidate',$18::jsonb, now(), now())
+      ON CONFLICT ("userIdA","userIdB") DO UPDATE SET
+        "usernameA"=EXCLUDED."usernameA", "usernameB"=EXCLUDED."usernameB",
+        "sharedHashes"=EXCLUDED."sharedHashes", "sharedSubnets"=EXCLUDED."sharedSubnets",
+        "sharedSoftprints"=EXCLUDED."sharedSoftprints", "sharedTokens"=EXCLUDED."sharedTokens",
+        "coVotes"=EXCLUDED."coVotes", "sameDir"=EXCLUDED."sameDir", "oppDir"=EXCLUDED."oppDir",
+        "sameHour"=EXCLUDED."sameHour", "agreePct"=EXCLUDED."agreePct", "shadowPct"=EXCLUDED."shadowPct",
+        "selfPromoAtoB"=EXCLUDED."selfPromoAtoB", "selfPromoBtoA"=EXCLUDED."selfPromoBtoA",
+        score=EXCLUDED.score, evidence=EXCLUDED.evidence, "updatedAt"=now()
+    `,
+      m.uaId, m.ubId, m.una, m.unb, m.sharedHashes, m.sharedSubnets, m.sharedSoftprints,
+      m.sharedTokens, m.coVotes, m.sameDir, m.oppDir, m.sameHour, this.agreePct(m), this.shadowPct(m),
+      m.selfPromoAtoB, m.selfPromoBtoA, score, evidence
+    );
+  }
+}

--- a/backend/src/jobs/TrackingSignalBackfillJob.ts
+++ b/backend/src/jobs/TrackingSignalBackfillJob.ts
@@ -81,25 +81,32 @@ export class TrackingSignalBackfillJob {
     let updated = 0;
     while (lo <= hi) {
       const upperExclusive = lo + batch;
+      // LATERAL 不能引用 UPDATE 目标表别名,故先在子查询里以普通 FROM 项 e 做 JOIN LATERAL 匹配,
+      // 再按 id 回写 UPDATE 目标 ev。
       const res = await this.prisma.$executeRawUnsafe(
         `UPDATE "${t.table}" ev SET
-            "acceptLanguage" = d.al,
-            "uaPlatform" = COALESCE(ev."uaPlatform", d.platform)
-         FROM LATERAL (
-           SELECT btrim(de.headers->>'accept-language') al,
-                  btrim(btrim(de.headers->>'sec-ch-ua-platform'), '"') platform
-             FROM "${DEBUG_TABLE}" de
-            WHERE de.kind = $3
-              AND de.client_hash = ev."clientHash"
-              AND de.${t.idCol} = ev."${t.evIdCol}"
-              AND de.created_at BETWEEN ev."createdAt" - INTERVAL '1 hour' AND ev."createdAt" + INTERVAL '1 hour'
-              AND de.headers ? 'accept-language'
-            ORDER BY abs(extract(epoch FROM de.created_at - ev."createdAt")) ASC
-            LIMIT 1
-         ) d
-         WHERE ev.id >= $1 AND ev.id < $2
-           AND ev."acceptLanguage" IS NULL
-           AND d.al IS NOT NULL AND d.al <> ''`,
+            "acceptLanguage" = m.al,
+            "uaPlatform" = COALESCE(ev."uaPlatform", m.platform)
+         FROM (
+           SELECT e.id, d.al, d.platform
+             FROM "${t.table}" e
+             JOIN LATERAL (
+               SELECT btrim(de.headers->>'accept-language') al,
+                      btrim(btrim(de.headers->>'sec-ch-ua-platform'), '"') platform
+                 FROM "${DEBUG_TABLE}" de
+                WHERE de.kind = $3
+                  AND de.client_hash = e."clientHash"
+                  AND de.${t.idCol} = e."${t.evIdCol}"
+                  AND de.created_at BETWEEN e."createdAt" - INTERVAL '1 hour' AND e."createdAt" + INTERVAL '1 hour'
+                  AND de.headers ? 'accept-language'
+                ORDER BY abs(extract(epoch FROM de.created_at - e."createdAt")) ASC
+                LIMIT 1
+             ) d ON true
+            WHERE e.id >= $1 AND e.id < $2
+              AND e."acceptLanguage" IS NULL
+              AND d.al IS NOT NULL AND d.al <> ''
+         ) m
+         WHERE ev.id = m.id`,
         lo, upperExclusive, t.kind
       );
       const n = num(res);

--- a/backend/src/jobs/TrackingSignalBackfillJob.ts
+++ b/backend/src/jobs/TrackingSignalBackfillJob.ts
@@ -1,0 +1,112 @@
+// src/jobs/TrackingSignalBackfillJob.ts
+import { PrismaClient } from '@prisma/client';
+import { getPrismaClient } from '../utils/db-connection.js';
+import { Logger } from '../utils/Logger.js';
+
+/**
+ * 历史事件信号回填：从 tracking_debug_event 把 Accept-Language / sec-ch-ua-platform
+ * 回填到 PageViewEvent / UserPixelEvent 的新列（仅填 NULL，幂等）。
+ *
+ * 这两个字段只有 debug 表采集过、无法从事件已存列(clientIp/userAgent)再生，故必须从 debug 表拷贝。
+ * uaBrandMajor / uaFamily / softprint 含解析/派生逻辑，留 go-forward 由写侧填充，避免 SQL 侧逻辑漂移。
+ *
+ * 匹配：debug 与其对应事件在同一请求写入，共享 (clientHash, kind→表, page_id/user_id) 且时间相近。
+ * debug 表仅 2026-04-07 起，故只回填该时间窗内事件。全程只读 debug + 只填 NULL，可逆（置回 NULL）。
+ */
+
+const DEBUG_TABLE = 'tracking_debug_event';
+const DEBUG_START = '2026-04-07';
+const DEFAULT_BATCH = 20000;
+
+export type TrackingSignalBackfillOptions = {
+  dryRun?: boolean;
+  batchSize?: number;
+};
+
+type Target = {
+  table: 'PageViewEvent' | 'UserPixelEvent';
+  kind: 'page' | 'user';
+  idCol: 'page_id' | 'user_id';
+  evIdCol: 'pageId' | 'userId';
+};
+
+const TARGETS: Target[] = [
+  { table: 'PageViewEvent', kind: 'page', idCol: 'page_id', evIdCol: 'pageId' },
+  { table: 'UserPixelEvent', kind: 'user', idCol: 'user_id', evIdCol: 'userId' },
+];
+
+function num(v: unknown): number {
+  if (typeof v === 'bigint') return Number(v);
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string') { const x = Number(v); return Number.isFinite(x) ? x : 0; }
+  return 0;
+}
+
+export class TrackingSignalBackfillJob {
+  private prisma: PrismaClient;
+  constructor(prisma?: PrismaClient) {
+    this.prisma = prisma ?? getPrismaClient();
+  }
+
+  async run(options: TrackingSignalBackfillOptions = {}): Promise<void> {
+    const dryRun = Boolean(options.dryRun);
+    const batch = options.batchSize ?? DEFAULT_BATCH;
+    Logger.info(`[signal-backfill] start${dryRun ? ' [dry-run]' : ''} batch=${batch} from=${DEBUG_START}`);
+
+    for (const t of TARGETS) {
+      await this.backfillTable(t, batch, dryRun);
+    }
+  }
+
+  private async backfillTable(t: Target, batch: number, dryRun: boolean): Promise<void> {
+    const pending = await this.prisma.$queryRawUnsafe<Array<{ c: bigint }>>(
+      `SELECT count(*)::bigint c FROM "${t.table}"
+        WHERE "acceptLanguage" IS NULL AND "createdAt" >= $1::date`,
+      DEBUG_START
+    );
+    const total = num(pending[0]?.c);
+    Logger.info(`[signal-backfill] ${t.table}: ${total.toLocaleString()} 行待回填（acceptLanguage IS NULL，${DEBUG_START} 起）`);
+    if (total === 0 || dryRun) return;
+
+    // 按 id 分批 UPDATE，匹配最近的 debug 行（同 clientHash + 同 page/user + 时间窗 1 小时内）。
+    const bounds = await this.prisma.$queryRawUnsafe<Array<{ mn: number | null; mx: number | null }>>(
+      `SELECT min(id) mn, max(id) mx FROM "${t.table}"
+        WHERE "acceptLanguage" IS NULL AND "createdAt" >= $1::date`,
+      DEBUG_START
+    );
+    let lo = num(bounds[0]?.mn);
+    const hi = num(bounds[0]?.mx);
+    if (!lo || !hi) return;
+
+    let updated = 0;
+    while (lo <= hi) {
+      const upperExclusive = lo + batch;
+      const res = await this.prisma.$executeRawUnsafe(
+        `UPDATE "${t.table}" ev SET
+            "acceptLanguage" = d.al,
+            "uaPlatform" = COALESCE(ev."uaPlatform", d.platform)
+         FROM LATERAL (
+           SELECT btrim(de.headers->>'accept-language') al,
+                  btrim(btrim(de.headers->>'sec-ch-ua-platform'), '"') platform
+             FROM "${DEBUG_TABLE}" de
+            WHERE de.kind = $3
+              AND de.client_hash = ev."clientHash"
+              AND de.${t.idCol} = ev."${t.evIdCol}"
+              AND de.created_at BETWEEN ev."createdAt" - INTERVAL '1 hour' AND ev."createdAt" + INTERVAL '1 hour'
+              AND de.headers ? 'accept-language'
+            ORDER BY abs(extract(epoch FROM de.created_at - ev."createdAt")) ASC
+            LIMIT 1
+         ) d
+         WHERE ev.id >= $1 AND ev.id < $2
+           AND ev."acceptLanguage" IS NULL
+           AND d.al IS NOT NULL AND d.al <> ''`,
+        lo, upperExclusive, t.kind
+      );
+      const n = num(res);
+      updated += n;
+      if (n > 0) Logger.info(`[signal-backfill] ${t.table}: id[${lo},${upperExclusive}) +${n}（累计 ${updated.toLocaleString()}）`);
+      lo = upperExclusive;
+    }
+    Logger.info(`[signal-backfill] ${t.table}: 回填完成，共 ${updated.toLocaleString()} 行`);
+  }
+}

--- a/bff/src/web/routes/tracking.ts
+++ b/bff/src/web/routes/tracking.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import rateLimit from 'express-rate-limit';
+import { createHash, randomBytes } from 'crypto';
 import type { Pool } from 'pg';
 import type { IncomingHttpHeaders } from 'http';
 import type { Request, Response } from 'express';
@@ -10,6 +11,14 @@ const MAX_COMPONENT_LENGTH = 64;
 const MAX_SOURCE_LENGTH = 64;
 const MAX_USER_AGENT_LENGTH = 1024;
 const MAX_REFERER_LENGTH = 255;
+const MAX_SIGNAL_LENGTH = 256;
+// 软指纹盐:防外部用已知字段反推聚类。未设置时仍可聚类(仅降隐私),设置后更稳。
+const SOFTPRINT_SALT = process.env.TRACKING_SOFTPRINT_SALT || '';
+// ETag 缓存型持久访客标识(image-only 无 cookie 持久 ID)。默认关,部署评审后开。
+const VISITOR_TOKEN_ENABLED = String(process.env.TRACKING_VISITOR_TOKEN || '').toLowerCase() === 'true';
+const VISITOR_TOKEN_RE = /^[0-9a-f]{32}$/;
+// openresty/nginx 在 TLS 终止层注入的 JA3/JA4 指纹头名(连接层,抗改 UA)。默认读 x-tls-fingerprint。
+const TLS_FP_HEADER = (process.env.TRACKING_TLS_FP_HEADER || 'x-tls-fingerprint').toLowerCase();
 const MAX_DEBUG_HEADER_VALUE = 2048;
 const DEBUG_HEADERS = [
   'user-agent',
@@ -52,16 +61,103 @@ const WIKIDOT_HTTP_BASE = 'http://scp-wiki-cn.wikidot.com';
 
 type PixelHeaders = Record<string, string>;
 
-function sendPixel(res: Response, extraHeaders: PixelHeaders = {}) {
-  res.set({
+function sendPixel(res: Response, extraHeaders: PixelHeaders = {}, visitorToken?: string | null) {
+  const base: PixelHeaders = {
     'Content-Type': 'image/gif',
     'Content-Length': String(PIXEL_BUFFER.length),
     'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
     Pragma: 'no-cache',
-    Expires: '0',
-    ...extraHeaders
-  });
+    Expires: '0'
+  };
+  if (visitorToken) {
+    // ETag 持久标识:用 no-cache(私有)让浏览器缓存响应但每次使用前必发条件请求,
+    // 我们每次都收到 If-None-Match 回送 token、仍每次命中服务器(不丢计数),并稳定回显同一 ETag。
+    base['Cache-Control'] = 'private, no-cache, max-age=0';
+    base.Pragma = 'no-cache';
+    base.ETag = `"${visitorToken}"`;
+  }
+  res.set({ ...base, ...extraHeaders });
   res.status(200).send(PIXEL_BUFFER);
+}
+
+// ── 身份信号采集(image-only:仅来自被动请求头/IP/TLS,无 JS/cookie) ──
+
+function deriveUaFamily(ua: string): string | null {
+  if (!ua || ua === 'unknown-ua') return null;
+  const os =
+    /Android/i.test(ua) ? 'Android' :
+    /iPhone|iPad|iOS/i.test(ua) ? 'iOS' :
+    /Windows/i.test(ua) ? 'Windows' :
+    /Mac OS X|Macintosh/i.test(ua) ? 'macOS' :
+    /Linux/i.test(ua) ? 'Linux' : 'Other';
+  const browser =
+    /Edg[A-Z]?\//i.test(ua) ? 'Edge' :
+    /OPR\/|Opera/i.test(ua) ? 'Opera' :
+    /HuaweiBrowser/i.test(ua) ? 'Huawei' :
+    /QuarkPC|Quark/i.test(ua) ? 'Quark' :
+    /Firefox\//i.test(ua) ? 'Firefox' :
+    /Chrome\//i.test(ua) ? 'Chrome' :
+    /Version\/.*Safari/i.test(ua) ? 'Safari' :
+    /Safari/i.test(ua) ? 'Safari' : 'Other';
+  return `${browser}/${os}`;
+}
+
+// 从 sec-ch-ua 取"有意义品牌+大版本",剔除 GREASE 占位(Not.A/Brand)。
+function parseSecChUaBrandMajor(value: string | null): string | null {
+  if (!value) return null;
+  const entries: Array<{ brand: string; v: string }> = [];
+  const re = /"([^"]+)";v="([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(value)) !== null) entries.push({ brand: m[1], v: m[2] });
+  if (entries.length === 0) return null;
+  const real = entries.filter((e) => !/not.?a.?brand/i.test(e.brand));
+  const prefer = real.find((e) => !/^chromium$/i.test(e.brand)) || real[0] || entries[0];
+  return `${prefer.brand} ${prefer.v}`.slice(0, MAX_SIGNAL_LENGTH);
+}
+
+function unquoteHint(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const t = value.trim().replace(/^"+|"+$/g, '').trim();
+  return t ? t.slice(0, MAX_SIGNAL_LENGTH) : null;
+}
+
+function ipSubnet24(ip: string): string {
+  const parts = ip.split('.');
+  if (parts.length === 4) return `${parts[0]}.${parts[1]}.${parts[2]}.0/24`;
+  return ip; // IPv6/异常:整段参与
+}
+
+type IdentitySignals = {
+  acceptLanguage: string | null;
+  uaPlatform: string | null;
+  uaBrandMajor: string | null;
+  uaFamily: string | null;
+  softprint: string | null;
+  tlsFingerprint: string | null;
+};
+
+function collectIdentitySignals(req: Request, clientIp: string, userAgent: string): IdentitySignals {
+  const acceptLanguage = truncateValue(req.get('accept-language'), MAX_SIGNAL_LENGTH);
+  const uaPlatform = unquoteHint(req.get('sec-ch-ua-platform'));
+  const uaBrandMajor = parseSecChUaBrandMajor(req.get('sec-ch-ua') || null);
+  const uaFamily = deriveUaFamily(userAgent);
+  const tlsFingerprint = truncateValue(req.headers[TLS_FP_HEADER] as string | undefined, MAX_SIGNAL_LENGTH);
+  // 软指纹:/24 子网 + 语言 + 品牌大版本 + 平台 + UA 族,salted 不可逆。
+  // 比 ip|ua 更稳(抗版本漂移/移动末位变动)且能拆开 VPN 碰撞(语言不同=不同人)。
+  const material = [ipSubnet24(clientIp), acceptLanguage || '', uaBrandMajor || '', uaPlatform || '', uaFamily || ''].join('|');
+  const softprint = createHash('sha256').update(`${SOFTPRINT_SALT}|${material}`).digest('hex').slice(0, 24);
+  return { acceptLanguage, uaPlatform, uaBrandMajor, uaFamily, softprint, tlsFingerprint };
+}
+
+// ETag 持久访客 token:复用 If-None-Match 回送的合法 token,否则签发新随机 token。
+function resolveVisitorToken(req: Request): string | null {
+  if (!VISITOR_TOKEN_ENABLED) return null;
+  const inm = req.get('if-none-match');
+  if (inm) {
+    const candidate = inm.trim().replace(/^W\//, '').replace(/^"+|"+$/g, '').trim().toLowerCase();
+    if (VISITOR_TOKEN_RE.test(candidate)) return candidate;
+  }
+  return randomBytes(16).toString('hex');
 }
 
 // 像素专属限流:超限也必须回 200+GIF(而非全局限流的 429 JSON),否则会在嵌入方页面
@@ -303,6 +399,8 @@ async function trackPageView(
   const clientFingerprint = buildClientFingerprint(clientIp, userAgent);
   const refererHost = extractRefererHost(req);
   const countableReferer = isCountableReferer(refererHost);
+  const sig = collectIdentitySignals(req, clientIp, userAgent);
+  const visitorToken = resolveVisitorToken(req);
 
   let counted = false;
   if (countableReferer) {
@@ -321,8 +419,9 @@ async function trackPageView(
 
   await pool.query(
     `INSERT INTO "PageViewEvent"
-       ("pageId", "wikidotId", "clientHash", "clientIp", "userAgent", "component", "source", "refererHost", "createdAt")
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())`,
+       ("pageId", "wikidotId", "clientHash", "clientIp", "userAgent", "component", "source", "refererHost",
+        "acceptLanguage", "uaPlatform", "uaBrandMajor", "uaFamily", "softprint", "visitorToken", "tlsFingerprint", "createdAt")
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, NOW())`,
     [
       pageId,
       wikidotId,
@@ -331,7 +430,14 @@ async function trackPageView(
       userAgent,
       component,
       source,
-      refererHost
+      refererHost,
+      sig.acceptLanguage,
+      sig.uaPlatform,
+      sig.uaBrandMajor,
+      sig.uaFamily,
+      sig.softprint,
+      visitorToken,
+      sig.tlsFingerprint
     ]
   );
 
@@ -373,7 +479,7 @@ async function trackPageView(
       console.error('tracking_debug_log_failed', err);
     }
   }
-  sendPixel(res, extraHeaders);
+  sendPixel(res, extraHeaders, visitorToken);
 }
 
 async function trackUserPixel(
@@ -397,6 +503,8 @@ async function trackUserPixel(
   const clientIp = clientIpRaw && clientIpRaw.trim() ? clientIpRaw.trim() : 'unknown-ip';
   const clientFingerprint = buildClientFingerprint(clientIp, userAgent);
   const refererHost = extractRefererHost(req);
+  const sig = collectIdentitySignals(req, clientIp, userAgent);
+  const visitorToken = resolveVisitorToken(req);
 
   const dedupeRes = await pool.query(
     `SELECT 1
@@ -412,8 +520,9 @@ async function trackUserPixel(
 
   await pool.query(
     `INSERT INTO "UserPixelEvent"
-       ("userId", "wikidotId", username, "clientHash", "clientIp", "userAgent", "component", "source", "refererHost", "createdAt")
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())`,
+       ("userId", "wikidotId", username, "clientHash", "clientIp", "userAgent", "component", "source", "refererHost",
+        "acceptLanguage", "uaPlatform", "uaBrandMajor", "uaFamily", "softprint", "visitorToken", "tlsFingerprint", "createdAt")
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NOW())`,
     [
       userId,
       Number.isFinite(wikidotId) ? wikidotId : null,
@@ -423,7 +532,14 @@ async function trackUserPixel(
       userAgent,
       component,
       source,
-      refererHost
+      refererHost,
+      sig.acceptLanguage,
+      sig.uaPlatform,
+      sig.uaBrandMajor,
+      sig.uaFamily,
+      sig.softprint,
+      visitorToken,
+      sig.tlsFingerprint
     ]
   );
 
@@ -453,7 +569,7 @@ async function trackUserPixel(
       console.error('tracking_debug_log_failed', err);
     }
   }
-  sendPixel(res, extraHeaders);
+  sendPixel(res, extraHeaders, visitorToken);
 }
 
 export function trackingRouter(pool: Pool) {

--- a/bff/tests/tracking-pixel.test.ts
+++ b/bff/tests/tracking-pixel.test.ts
@@ -387,4 +387,139 @@ describe('Tracking pixel endpoint', () => {
     expect(res.headers['content-type']).toBe('image/gif');
     expect(res.headers['x-tracking-error']).toBe('rate_limited');
   });
+
+  // ── 身份信号采集（image-only，被动请求头） ──
+
+  function pageInsertParams(): unknown[] | undefined {
+    const call = queryMock.mock.calls.find(([sql]: [string]) => sql.includes('INSERT INTO "PageViewEvent"'));
+    return call?.[1] as unknown[] | undefined;
+  }
+
+  function mockPageHappyPath() {
+    queryMock.mockImplementation((sql: string) => {
+      if (sql.includes('FROM "Page" WHERE "wikidotId"')) return Promise.resolve({ rows: [{ id: 42 }] });
+      if (sql.includes('FROM "PageViewEvent"') && sql.includes('"clientIp"')) return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [] });
+    });
+  }
+
+  test('captures Accept-Language / sec-ch-ua / softprint / uaFamily into the event row', async () => {
+    mockPageHappyPath();
+    const app = createTrackingTestServer();
+    await request(app)
+      .get('/tracking/pixel')
+      .set('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0')
+      .set('Accept-Language', 'zh-CN,zh;q=0.9,en-US;q=0.8')
+      .set('Sec-CH-UA', '"Chromium";v="136", "Microsoft Edge";v="136", "Not/A)Brand";v="99"')
+      .set('Sec-CH-UA-Platform', '"Windows"')
+      .set('X-Forwarded-For', '203.0.113.20')
+      .query({ wikidotId: '123456' })
+      .expect(200);
+
+    const p = pageInsertParams();
+    // 顺序: ...refererHost(idx7), acceptLanguage(8), uaPlatform(9), uaBrandMajor(10), uaFamily(11), softprint(12), visitorToken(13), tlsFingerprint(14)
+    expect(p?.[8]).toBe('zh-CN,zh;q=0.9,en-US;q=0.8');
+    expect(p?.[9]).toBe('Windows');
+    expect(p?.[10]).toBe('Microsoft Edge 136'); // GREASE 占位被剔除, 取真实品牌
+    expect(p?.[11]).toBe('Edge/Windows');
+    expect(typeof p?.[12]).toBe('string');
+    expect((p?.[12] as string).length).toBe(24); // softprint 24 hex
+    expect(p?.[13]).toBeNull(); // visitorToken 默认关
+  });
+
+  test('softprint discriminates same IP+UA but different Accept-Language (kills VPN collision)', async () => {
+    const softprints: string[] = [];
+    const run = async (lang: string) => {
+      queryMock.mockReset();
+      mockPageHappyPath();
+      const app = createTrackingTestServer();
+      await request(app)
+        .get('/tracking/pixel')
+        .set('User-Agent', 'Mozilla/5.0 (Windows NT 10.0) Chrome/136.0.0.0')
+        .set('Accept-Language', lang)
+        .set('X-Forwarded-For', '198.51.100.7')
+        .query({ wikidotId: '1' })
+        .expect(200);
+      softprints.push(pageInsertParams()?.[12] as string);
+    };
+    await run('zh-CN,zh;q=0.9');
+    await run('en-US,en;q=0.9');
+    await run('zh-CN,zh;q=0.9'); // 与第一次相同输入 → 软指纹应一致
+    expect(softprints[0]).not.toBe(softprints[1]); // 同 IP+UA 不同语言 = 不同人
+    expect(softprints[0]).toBe(softprints[2]);      // 相同输入 = 确定性一致
+  });
+});
+
+describe('Tracking pixel with ETag visitor token enabled', () => {
+  const INTERNAL_KEY = 'test-internal-key';
+  let etagRouter: any;
+  const tokenQueryMock = jest.fn();
+
+  beforeAll(() => {
+    process.env.BFF_INTERNAL_API_KEY = INTERNAL_KEY;
+    process.env.TRACKING_VISITOR_TOKEN = 'true';
+    jest.isolateModules(() => {
+      // 在 env 设好后重新加载模块, 使 VISITOR_TOKEN_ENABLED 读到 true
+      etagRouter = require('../src/web/routes/tracking').trackingRouter;
+    });
+  });
+  afterAll(() => {
+    delete process.env.BFF_INTERNAL_API_KEY;
+    delete process.env.TRACKING_VISITOR_TOKEN;
+  });
+  beforeEach(() => tokenQueryMock.mockReset());
+
+  function server() {
+    const app = express();
+    app.set('trust proxy', 1);
+    app.use('/tracking', etagRouter({ query: tokenQueryMock } as any));
+    return app;
+  }
+  function mockHappy() {
+    tokenQueryMock.mockImplementation((sql: string) => {
+      if (sql.includes('FROM "Page" WHERE "wikidotId"')) return Promise.resolve({ rows: [{ id: 42 }] });
+      return Promise.resolve({ rows: [] });
+    });
+  }
+  const pveInsert = () => tokenQueryMock.mock.calls.find(([sql]: [string]) => sql.includes('INSERT INTO "PageViewEvent"'));
+
+  test('issues an ETag token and recovers it from If-None-Match', async () => {
+    mockHappy();
+    const app = server();
+    const first = await request(app)
+      .get('/tracking/pixel')
+      .set('X-Forwarded-For', '203.0.113.30')
+      .query({ wikidotId: '1' })
+      .expect(200);
+    const etag = first.headers['etag'];
+    expect(etag).toMatch(/^"[0-9a-f]{32}"$/);
+    expect(first.headers['cache-control']).toContain('no-cache');
+    const token = etag.replace(/"/g, '');
+    expect((pveInsert()?.[1] as unknown[])?.[13]).toBe(token); // 新 token 写入事件行
+
+    tokenQueryMock.mockReset();
+    mockHappy();
+    // 命中 If-None-Match → Express 自动回 304(省带宽), 但我们的 INSERT/计数在 send 前已执行
+    const second = await request(app)
+      .get('/tracking/pixel')
+      .set('X-Forwarded-For', '203.0.113.30')
+      .set('If-None-Match', `"${token}"`)
+      .query({ wikidotId: '1' })
+      .expect(304);
+    expect(second.headers['etag']).toBe(`"${token}"`);          // 恢复同一 token
+    expect((pveInsert()?.[1] as unknown[])?.[13]).toBe(token);  // 仍计入事件(不丢计数)
+  });
+
+  test('rejects forged non-hex If-None-Match and mints a fresh token', async () => {
+    mockHappy();
+    const app = server();
+    const res = await request(app)
+      .get('/tracking/pixel')
+      .set('X-Forwarded-For', '203.0.113.31')
+      .set('If-None-Match', '"not-a-valid-token"')
+      .query({ wikidotId: '1' })
+      .expect(200);
+    expect(res.headers['etag']).toMatch(/^"[0-9a-f]{32}"$/);
+    expect(res.headers['etag']).not.toBe('"not-a-valid-token"');
+  });
 });


### PR DESCRIPTION
原 #164 因 retarget 未在合并前生效,误并入 fix/tracking-p0-hardening 分支。本 PR 把同一批增强 commit(b05d4d1..6f8ab75,含 Codex/Claude review 两轮修复)正确落到 main。内容与 #164 一致,详见 #164 描述。两轮 review 已完成。