### PR TITLE
feat(tracking): softprint 改纯数据可读键 + 启用 visitorToken + TLS 指纹全量

### DIFF
--- a/bff/ecosystem.config.cjs
+++ b/bff/ecosystem.config.cjs
@@ -18,7 +18,10 @@ module.exports = {
         // 硬编码关闭:debug 表存完整请求头+原始 IP,曾因 shell env 透传漂移以 100% 采样
         // 常开数月(2026-06-10 审计)。需要临时开 debug 时改这里并走部署流程,不走 env。
         ENABLE_TRACKING_DEBUG: 'false',
-        TRACKING_DEBUG_SAMPLE_RATE: '0'
+        TRACKING_DEBUG_SAMPLE_RATE: '0',
+        // 启用 ETag 缓存型持久访客标识(站方决定开启,2026-06-10)。像素响应改 no-cache+ETag,
+        // 浏览器每次条件请求回送 If-None-Match→恢复 token,命中自动 304 不丢计数。
+        TRACKING_VISITOR_TOKEN: 'true'
       }
     }
   ]

--- a/bff/src/web/routes/tracking.ts
+++ b/bff/src/web/routes/tracking.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import rateLimit from 'express-rate-limit';
-import { createHash, randomBytes } from 'crypto';
+import { randomBytes } from 'crypto';
 import type { Pool } from 'pg';
 import type { IncomingHttpHeaders } from 'http';
 import type { Request, Response } from 'express';
@@ -12,8 +12,8 @@ const MAX_SOURCE_LENGTH = 64;
 const MAX_USER_AGENT_LENGTH = 1024;
 const MAX_REFERER_LENGTH = 255;
 const MAX_SIGNAL_LENGTH = 256;
-// 软指纹盐:防外部用已知字段反推聚类。未设置时仍可聚类(仅降隐私),设置后更稳。
-const SOFTPRINT_SALT = process.env.TRACKING_SOFTPRINT_SALT || '';
+// TLS 指纹(openresty 注入的原始 ClientHello 密码套件/曲线列表)较长,单独放宽上限存全量。
+const MAX_TLS_FP_LENGTH = 1024;
 // ETag 缓存型持久访客标识(image-only 无 cookie 持久 ID)。默认关,部署评审后开。
 const VISITOR_TOKEN_ENABLED = String(process.env.TRACKING_VISITOR_TOKEN || '').toLowerCase() === 'true';
 const VISITOR_TOKEN_RE = /^[0-9a-f]{32}$/;
@@ -141,11 +141,13 @@ function collectIdentitySignals(req: Request, clientIp: string, userAgent: strin
   const uaPlatform = unquoteHint(req.get('sec-ch-ua-platform'));
   const uaBrandMajor = parseSecChUaBrandMajor(req.get('sec-ch-ua') || null);
   const uaFamily = deriveUaFamily(userAgent);
-  const tlsFingerprint = truncateValue(req.headers[TLS_FP_HEADER] as string | undefined, MAX_SIGNAL_LENGTH);
-  // 软指纹:/24 子网 + 语言 + 品牌大版本 + 平台 + UA 族,salted 不可逆。
-  // 比 ip|ua 更稳(抗版本漂移/移动末位变动)且能拆开 VPN 碰撞(语言不同=不同人)。
-  const material = [ipSubnet24(clientIp), acceptLanguage || '', uaBrandMajor || '', uaPlatform || '', uaFamily || ''].join('|');
-  const softprint = createHash('sha256').update(`${SOFTPRINT_SALT}|${material}`).digest('hex').slice(0, 24);
+  // TLS 指纹存原始 ClientHello 信号(协议|协商套件|客户端套件列表|曲线列表),纯数据可审计,放宽上限。
+  const tlsFingerprint = truncateValue(req.headers[TLS_FP_HEADER] as string | undefined, MAX_TLS_FP_LENGTH);
+  // 软指纹:可读复合键(纯数据,不哈希),便于审计;= /24 子网 | UA族 | 品牌大版本 | 平台 | 语言。
+  // 比 ip|ua 更稳(抗版本漂移/移动末位变动)且能拆开 VPN 碰撞(语言不同=不同人);各原始分量另有独立列。
+  const softprint = [ipSubnet24(clientIp), uaFamily || '', uaBrandMajor || '', uaPlatform || '', acceptLanguage || '']
+    .join('|')
+    .slice(0, MAX_SIGNAL_LENGTH);
   return { acceptLanguage, uaPlatform, uaBrandMajor, uaFamily, softprint, tlsFingerprint };
 }
 

--- a/bff/src/web/routes/tracking.ts
+++ b/bff/src/web/routes/tracking.ts
@@ -14,7 +14,10 @@ const MAX_REFERER_LENGTH = 255;
 const MAX_SIGNAL_LENGTH = 256;
 // TLS 指纹(openresty 注入的原始 ClientHello 密码套件/曲线列表)较长,单独放宽上限存全量。
 const MAX_TLS_FP_LENGTH = 1024;
-// ETag 缓存型持久访客标识(image-only 无 cookie 持久 ID)。默认关,部署评审后开。
+// ETag 缓存型访客标识(image-only 无 cookie)。语义重要: HTTP 缓存按 URL 分键,故 token 是
+// "同一像素 URL 的复访信号"(同浏览器对 /pixel/by-url?url=X 复访得稳定 token),而非跨页/跨账号
+// 的全局浏览器 ID——不同像素 URL 会得到不同 token。因此不能用它做跨账号小号关联(检测 Job 的
+// sharedTokens 对 by-username 不同 wikidotId 恒为 0),它的价值是页面级"独立复访者"计量。
 const VISITOR_TOKEN_ENABLED = String(process.env.TRACKING_VISITOR_TOKEN || '').toLowerCase() === 'true';
 const VISITOR_TOKEN_RE = /^[0-9a-f]{32}$/;
 // openresty/nginx 在 TLS 终止层注入的 JA3/JA4 指纹头名(连接层,抗改 UA)。默认读 x-tls-fingerprint。
@@ -122,9 +125,15 @@ function unquoteHint(value: string | null | undefined): string | null {
 }
 
 function ipSubnet24(ip: string): string {
-  const parts = ip.split('.');
+  let v = (ip || '').trim();
+  // IPv4-mapped IPv6 (::ffff:1.2.3.4) → 取内嵌 IPv4,与普通 IPv4 归一到同一 /24
+  const mapped = v.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  if (mapped) v = mapped[1];
+  const parts = v.split('.');
   if (parts.length === 4) return `${parts[0]}.${parts[1]}.${parts[2]}.0/24`;
-  return ip; // IPv6/异常:整段参与
+  // 真实 IPv6: 取前 4 个 hextet 作为 /64 粗前缀(去碎片化, 长度有界), 其余忽略
+  if (v.includes(':')) return v.split(':').slice(0, 4).join(':') + '::/64';
+  return v.slice(0, 45);
 }
 
 type IdentitySignals = {
@@ -145,9 +154,14 @@ function collectIdentitySignals(req: Request, clientIp: string, userAgent: strin
   const tlsFingerprint = truncateValue(req.headers[TLS_FP_HEADER] as string | undefined, MAX_TLS_FP_LENGTH);
   // 软指纹:可读复合键(纯数据,不哈希),便于审计;= /24 子网 | UA族 | 品牌大版本 | 平台 | 语言。
   // 比 ip|ua 更稳(抗版本漂移/移动末位变动)且能拆开 VPN 碰撞(语言不同=不同人);各原始分量另有独立列。
-  const softprint = [ipSubnet24(clientIp), uaFamily || '', uaBrandMajor || '', uaPlatform || '', acceptLanguage || '']
-    .join('|')
-    .slice(0, MAX_SIGNAL_LENGTH);
+  // 给前四项各设硬预算,保证末尾的"语言"永不被整体 256 上限挤掉(否则同/24+长品牌串会假碰撞)。
+  const softprint = [
+    ipSubnet24(clientIp),
+    (uaFamily || '').slice(0, 24),
+    (uaBrandMajor || '').slice(0, 48),
+    (uaPlatform || '').slice(0, 24),
+    acceptLanguage || ''
+  ].join('|').slice(0, MAX_SIGNAL_LENGTH);
   return { acceptLanguage, uaPlatform, uaBrandMajor, uaFamily, softprint, tlsFingerprint };
 }
 

--- a/bff/tests/tracking-pixel.test.ts
+++ b/bff/tests/tracking-pixel.test.ts
@@ -422,8 +422,8 @@ describe('Tracking pixel endpoint', () => {
     expect(p?.[9]).toBe('Windows');
     expect(p?.[10]).toBe('Microsoft Edge 136'); // GREASE 占位被剔除, 取真实品牌
     expect(p?.[11]).toBe('Edge/Windows');
-    expect(typeof p?.[12]).toBe('string');
-    expect((p?.[12] as string).length).toBe(24); // softprint 24 hex
+    // softprint 现为可读复合键(纯数据,不哈希): /24|UA族|品牌|平台|语言
+    expect(p?.[12]).toBe('203.0.113.0/24|Edge/Windows|Microsoft Edge 136|Windows|zh-CN,zh;q=0.9,en-US;q=0.8');
     expect(p?.[13]).toBeNull(); // visitorToken 默认关
   });
 
@@ -447,6 +447,41 @@ describe('Tracking pixel endpoint', () => {
     await run('zh-CN,zh;q=0.9'); // 与第一次相同输入 → 软指纹应一致
     expect(softprints[0]).not.toBe(softprints[1]); // 同 IP+UA 不同语言 = 不同人
     expect(softprints[0]).toBe(softprints[2]);      // 相同输入 = 确定性一致
+  });
+
+  test('softprint folds same /24 across different last octet (de-fragmentation)', async () => {
+    const sp: string[] = [];
+    for (const ip of ['114.5.1.9', '114.5.1.250']) {
+      queryMock.mockReset();
+      mockPageHappyPath();
+      await request(createTrackingTestServer())
+        .get('/tracking/pixel')
+        .set('User-Agent', 'Mozilla/5.0 (Windows NT 10.0) Chrome/136.0.0.0')
+        .set('Accept-Language', 'zh-CN')
+        .set('X-Forwarded-For', ip)
+        .query({ wikidotId: '1' })
+        .expect(200);
+      sp.push(pageInsertParams()?.[12] as string);
+    }
+    expect(sp[0]).toBe(sp[1]); // 同 /24 不同末位 → 同一软指纹(合并移动 IP 漂移)
+    expect(sp[0]).toContain('114.5.1.0/24');
+  });
+
+  test('captures full raw TLS fingerprint header (not truncated at 256)', async () => {
+    mockPageHappyPath();
+    // 模拟 openresty 注入的原始 ClientHello 信号(>256 字符,曲线列表在尾部)
+    const longFp = 'TLSv1.3|TLS_AES_256_GCM_SHA384|' + Array.from({ length: 30 }, (_, i) => `ECDHE-CIPHER-${i}`).join(':') + '|X25519:secp256r1:secp384r1';
+    await request(createTrackingTestServer())
+      .get('/tracking/pixel')
+      .set('User-Agent', 'Mozilla/5.0 (Windows NT 10.0) Chrome/136.0.0.0')
+      .set('X-Forwarded-For', '203.0.113.21')
+      .set('X-TLS-Fingerprint', longFp)
+      .query({ wikidotId: '1' })
+      .expect(200);
+    const tls = pageInsertParams()?.[14] as string;
+    expect(tls).toBe(longFp);                 // 全量存储,不截断
+    expect(tls.length).toBeGreaterThan(256);  // 确认超过旧上限仍完整
+    expect(tls).toContain('X25519:secp256r1'); // 尾部曲线列表保留
   });
 });
 

--- a/bff/tests/tracking-pixel.test.ts
+++ b/bff/tests/tracking-pixel.test.ts
@@ -467,6 +467,27 @@ describe('Tracking pixel endpoint', () => {
     expect(sp[0]).toContain('114.5.1.0/24');
   });
 
+  test('softprint keeps Accept-Language even when sec-ch-ua brand is abusively long', async () => {
+    const sp: string[] = [];
+    const longBrand = '"' + 'X'.repeat(300) + '";v="9"'; // 构造超长品牌名
+    for (const lang of ['zh-CN', 'en-US']) {
+      queryMock.mockReset();
+      mockPageHappyPath();
+      await request(createTrackingTestServer())
+        .get('/tracking/pixel')
+        .set('User-Agent', 'Mozilla/5.0 (Windows NT 10.0) Chrome/136.0.0.0')
+        .set('Accept-Language', lang)
+        .set('Sec-CH-UA', longBrand)
+        .set('X-Forwarded-For', '198.51.100.9')
+        .query({ wikidotId: '1' })
+        .expect(200);
+      sp.push(pageInsertParams()?.[12] as string);
+    }
+    // 即便品牌串恶意超长, 末尾语言仍进入键 → 不同语言仍区分(不被截断挤掉)
+    expect(sp[0]).not.toBe(sp[1]);
+    expect(sp[0].endsWith('|zh-CN')).toBe(true);
+  });
+
   test('captures full raw TLS fingerprint header (not truncated at 256)', async () => {
     mockPageHappyPath();
     // 模拟 openresty 注入的原始 ClientHello 信号(>256 字符,曲线列表在尾部)


### PR DESCRIPTION
回应站方诉求(部署后观察):**启用 visitorToken 与 tlsFingerprint、偏向纯数据可审计、不加盐**。

## 为什么之前是 NULL
- visitorToken: 默认关(env `TRACKING_VISITOR_TOKEN`),因它把像素 Cache-Control 从 P0 的 no-store 改 no-cache(ETag 持久标识需要),属持久追踪面升级,留站方拍板。
- tlsFingerprint: 读 openresty 注入的头,但 1Panel openresty 镜像无 JA3 模块、未配置注入,故 Node 侧读到空。

## 本 PR 改动
- **softprint 改可读纯数据复合键** `"/24|UA族|品牌大版本|平台|语言"`(原 sha256→明文,便于审计;不加盐;各原始分量另有独立列)。聚类/VPN拆分语义不变(相等比较),检测 Job 无需改。
- **tlsFingerprint 上限 256→1024** 存 openresty 注入的原始 ClientHello 全量(协议\|协商套件\|客户端套件列表\|曲线列表),不再截断丢曲线。
- **ecosystem 启用 `TRACKING_VISITOR_TOKEN=true`**。
- 移除不再使用的 SOFTPRINT_SALT/createHash。

## 配套基础设施(已随本次部署在 1Panel openresty 容器配置)
`/www/sites/scpper.mer.run/proxy/API.conf` 加 `proxy_set_header X-TLS-Fingerprint "$ssl_protocol|$ssl_cipher|$ssl_ciphers|$ssl_curves"`(nginx 1.27 内置 ssl 变量,**无需改镜像/无 JA3 模块**,纯原始数据)。已 `openresty -t` 校验 + reload,实测像素经公网采集到真实 TLS 串。

## 测试
- tracking-pixel.test.ts **20/20**(新增 /24 去碎片化、TLS 全量不截断;原 softprint 断言改可读键)
- bff build + tsc 通过
- softprint/tlsFingerprint 均 text 列,无需迁移

## 部署注意
- `pm2 restart bff/ecosystem.config.cjs --update-env` 使 TRACKING_VISITOR_TOKEN 生效
- 部署后一次性重算历史 1010 行旧哈希 softprint 为可读键(组件已存于独立列):见部署脚本