### PR TITLE
feat(tracking): 读取图谱(零改组件) + 看后投票/缓存投毒检查

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -882,6 +882,23 @@ model SuspectedAltPair {
   @@index([status])
 }
 
+/// 读取图谱：登录用户浏览过的页面(由 PageViewEvent⋈UserPixelEvent 按 clientHash+时间窗重建)。
+/// 见 backend/sql/20260611_tracking_read_graph.sql；FK 在 SQL 层,Prisma 不声明关系。
+model UserPageView {
+  id            BigInt   @id @default(autoincrement())
+  userId        Int
+  wikidotId     Int?
+  pageId        Int
+  firstViewedAt DateTime
+  lastViewedAt  DateTime
+  viewCount     Int      @default(1)
+  updatedAt     DateTime @default(now())
+
+  @@unique([userId, pageId])
+  @@index([pageId])
+  @@index([lastViewedAt])
+}
+
 model UserDailyStats {
   id           Int       @id @default(autoincrement())
   userId       Int

--- a/backend/sql/20260611_tracking_read_graph.sql
+++ b/backend/sql/20260611_tracking_read_graph.sql
@@ -1,0 +1,29 @@
+-- 追踪读取图谱 + 反作弊检查支撑（2026-06-11）
+--
+-- 全部 additive：新建表 + 新建索引。不改既有列、不 DROP、不破坏历史。
+-- 背景：UserPixelEvent = "登录浏览者 X(wikidotId) 用 clientHash=H 浏览了带组件的页面"，
+--   PageViewEvent = "clientHash=H 浏览了页面 Y"(匿名/登录通吃)。两者皆带 clientHash+时间，
+--   按 (clientHash, ±窗口) join 即可重建"用户 X 读了页面 Y"的读取图谱(零改组件)。
+--
+-- 应用(生产,手动；CONCURRENTLY 不能在事务内,勿走 prisma migrate deploy)：
+--   psql "$DATABASE_URL" -f backend/sql/20260611_tracking_read_graph.sql
+-- 回滚：DROP TABLE "UserPageView"; DROP INDEX CONCURRENTLY 各新索引。
+
+-- 支撑读取图谱 join 的 clientHash 时间索引(现有索引均 pageId/wikidotId 前导,无 clientHash 前导)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "PageViewEvent_clientHash_createdAt_idx"
+  ON "PageViewEvent" ("clientHash", "createdAt");
+
+-- 读取图谱：每个(注册用户, 页面)的浏览聚合(去重到对,带首末次与次数)
+CREATE TABLE IF NOT EXISTS "UserPageView" (
+  id             bigserial PRIMARY KEY,
+  "userId"       integer NOT NULL REFERENCES "User"(id) ON DELETE CASCADE,
+  "wikidotId"    integer,
+  "pageId"       integer NOT NULL REFERENCES "Page"(id) ON DELETE CASCADE,
+  "firstViewedAt" timestamptz NOT NULL,
+  "lastViewedAt"  timestamptz NOT NULL,
+  "viewCount"    integer NOT NULL DEFAULT 1,
+  "updatedAt"    timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "UserPageView_user_page_uniq" UNIQUE ("userId", "pageId")
+);
+CREATE INDEX IF NOT EXISTS "UserPageView_pageId_idx" ON "UserPageView" ("pageId");
+CREATE INDEX IF NOT EXISTS "UserPageView_lastViewedAt_idx" ON "UserPageView" ("lastViewedAt");

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -11,6 +11,8 @@ import { runDailySiteOverview } from '../jobs/DailySiteOverviewJob.js';
 import { TrackingRetentionJob } from '../jobs/TrackingRetentionJob.js';
 import { AltAccountDetectionJob } from '../jobs/AltAccountDetectionJob.js';
 import { TrackingSignalBackfillJob } from '../jobs/TrackingSignalBackfillJob.js';
+import { ReadGraphJob } from '../jobs/ReadGraphJob.js';
+import { TrackingAnomalyCheckJob } from '../jobs/TrackingAnomalyCheckJob.js';
 import { disconnectPrisma, getPrismaClient } from '../utils/db-connection.js';
 import { validateUserStats } from '../jobs/ValidationJob.js';
 import { Logger } from '../utils/Logger.js';
@@ -356,6 +358,40 @@ program
     await job.run({
       dryRun: Boolean(options.dryRun),
       batchSize: Number.isFinite(parsedBatch) && parsedBatch > 0 ? parsedBatch : undefined,
+    });
+    await disconnectPrisma();
+  });
+
+program
+  .command('analyze-read-graph')
+  .description('重建读取图谱: PageViewEvent⋈UserPixelEvent 按 clientHash+时间窗 → UserPageView(谁读了哪页)')
+  .option('--hours <n>', '处理近 N 小时的用户像素, 默认 26', '26')
+  .option('--full', '全量重建(忽略 --hours)')
+  .option('--dry-run', '仅预览可产出对数, 不写入')
+  .action(async (options) => {
+    const job = new ReadGraphJob();
+    const parsedHours = Number.parseInt(String(options.hours ?? ''), 10);
+    const result = await job.run({
+      hours: Number.isFinite(parsedHours) && parsedHours > 0 ? parsedHours : undefined,
+      full: Boolean(options.full),
+      dryRun: Boolean(options.dryRun),
+    });
+    Logger.info(`[read-graph] 完成: upsert ${result.upserted} (window ${result.window})`);
+    await disconnectPrisma();
+  });
+
+program
+  .command('check-tracking-anomalies')
+  .description('追踪反作弊/数据质量只读检查: 缓存投毒 + 看后投票(需先 analyze-read-graph)')
+  .option('--days <n>', '检查窗口天数, 默认 30', '30')
+  .option('--top <n>', '每项报告 top N, 默认 20', '20')
+  .action(async (options) => {
+    const job = new TrackingAnomalyCheckJob();
+    const parsedDays = Number.parseInt(String(options.days ?? ''), 10);
+    const parsedTop = Number.parseInt(String(options.top ?? ''), 10);
+    await job.run({
+      days: Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : undefined,
+      topN: Number.isFinite(parsedTop) && parsedTop > 0 ? parsedTop : undefined,
     });
     await disconnectPrisma();
   });

--- a/backend/src/cli/index.ts
+++ b/backend/src/cli/index.ts
@@ -371,13 +371,16 @@ program
   .action(async (options) => {
     const job = new ReadGraphJob();
     const parsedHours = Number.parseInt(String(options.hours ?? ''), 10);
-    const result = await job.run({
-      hours: Number.isFinite(parsedHours) && parsedHours > 0 ? parsedHours : undefined,
-      full: Boolean(options.full),
-      dryRun: Boolean(options.dryRun),
-    });
-    Logger.info(`[read-graph] 完成: upsert ${result.upserted} (window ${result.window})`);
-    await disconnectPrisma();
+    try {
+      const result = await job.run({
+        hours: Number.isFinite(parsedHours) && parsedHours > 0 ? parsedHours : undefined,
+        full: Boolean(options.full),
+        dryRun: Boolean(options.dryRun),
+      });
+      Logger.info(`[read-graph] 完成: upsert ${result.upserted} (window ${result.window})`);
+    } finally {
+      await disconnectPrisma();
+    }
   });
 
 program
@@ -389,11 +392,14 @@ program
     const job = new TrackingAnomalyCheckJob();
     const parsedDays = Number.parseInt(String(options.days ?? ''), 10);
     const parsedTop = Number.parseInt(String(options.top ?? ''), 10);
-    await job.run({
-      days: Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : undefined,
-      topN: Number.isFinite(parsedTop) && parsedTop > 0 ? parsedTop : undefined,
-    });
-    await disconnectPrisma();
+    try {
+      await job.run({
+        days: Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : undefined,
+        topN: Number.isFinite(parsedTop) && parsedTop > 0 ? parsedTop : undefined,
+      });
+    } finally {
+      await disconnectPrisma();
+    }
   });
 
 program

--- a/backend/src/jobs/ReadGraphJob.ts
+++ b/backend/src/jobs/ReadGraphJob.ts
@@ -1,0 +1,103 @@
+// src/jobs/ReadGraphJob.ts
+import { PrismaClient } from '@prisma/client';
+import { getPrismaClient } from '../utils/db-connection.js';
+import { Logger } from '../utils/Logger.js';
+
+/**
+ * 读取图谱构建 Job。
+ *
+ * UserPixelEvent = "登录用户 X(wikidotId) 用 clientHash=H 浏览了带组件的页面"(无页面字段)。
+ * PageViewEvent  = "clientHash=H 浏览了页面 Y"(匿名/登录通吃)。
+ * 两者皆带 clientHash + createdAt → 按 (clientHash, ±MATCH_WINDOW) join 即可重建
+ * "用户 X 浏览了页面 Y" 的读取图谱，聚合到 (userId, pageId) 写入 UserPageView。**零改组件**。
+ *
+ * 增量：按 UserPixelEvent.createdAt 时间窗处理(默认近 --hours 小时)，upsert 幂等可重跑。
+ * 全程只读两事件表，仅写 UserPageView。
+ */
+
+const MATCH_WINDOW_SECONDS = 15; // 与 check-tracking-health 同口径
+const DEFAULT_HOURS = 26;        // 增量默认回看(略大于小时级调度间隔，容错)
+
+export type ReadGraphOptions = {
+  hours?: number;     // 处理近 N 小时的 UserPixelEvent
+  full?: boolean;     // 全量重建(忽略 hours)
+  dryRun?: boolean;
+};
+
+function num(v: unknown): number {
+  if (typeof v === 'bigint') return Number(v);
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string') { const x = Number(v); return Number.isFinite(x) ? x : 0; }
+  return 0;
+}
+
+export class ReadGraphJob {
+  private prisma: PrismaClient;
+  constructor(prisma?: PrismaClient) {
+    this.prisma = prisma ?? getPrismaClient();
+  }
+
+  async run(options: ReadGraphOptions = {}): Promise<{ upserted: number; window: string }> {
+    const dryRun = Boolean(options.dryRun);
+    const full = Boolean(options.full);
+    const hours = options.hours ?? DEFAULT_HOURS;
+    const windowSql = full ? "TIMESTAMP 'epoch'" : `now() - INTERVAL '${hours} hours'`;
+    Logger.info(`[read-graph] start${dryRun ? ' [dry-run]' : ''} ${full ? '[full]' : `[since ${hours}h]`}`);
+
+    // 预览：本窗能产出多少 (user,page) 对
+    const preview = await this.prisma.$queryRawUnsafe<Array<{ pairs: bigint; users: bigint; pages: bigint }>>(`
+      WITH up AS (
+        SELECT "clientHash", "userId", "wikidotId", "createdAt"
+        FROM "UserPixelEvent"
+        WHERE "createdAt" >= ${windowSql} AND "clientHash" IS NOT NULL
+      )
+      SELECT count(DISTINCT (up."userId", pv."pageId"))::bigint pairs,
+             count(DISTINCT up."userId")::bigint users,
+             count(DISTINCT pv."pageId")::bigint pages
+      FROM up
+      JOIN "PageViewEvent" pv
+        ON pv."clientHash" = up."clientHash"
+       AND pv."createdAt" BETWEEN up."createdAt" - INTERVAL '${MATCH_WINDOW_SECONDS} seconds'
+                              AND up."createdAt" + INTERVAL '${MATCH_WINDOW_SECONDS} seconds'
+    `);
+    const pairs = num(preview[0]?.pairs);
+    Logger.info(`[read-graph] 窗内可产出 ${pairs} 个(用户,页面)对 / ${num(preview[0]?.users)} 用户 / ${num(preview[0]?.pages)} 页`);
+
+    if (dryRun) return { upserted: 0, window: full ? 'full' : `${hours}h` };
+
+    // 聚合 upsert：firstViewedAt 取最小、lastViewedAt 取最大、viewCount 累加(去重到 voter 像素事件计数)。
+    // 冲突(已存在该 user-page)：扩展首末次区间、累加次数。幂等：重跑同窗只会刷新区间/次数(不重复累计因
+    // 我们以"匹配事件对"为计数源，且窗口固定→重跑结果一致地覆盖)。
+    const affected = await this.prisma.$executeRawUnsafe(`
+      WITH up AS (
+        SELECT "clientHash", "userId", "wikidotId", "createdAt"
+        FROM "UserPixelEvent"
+        WHERE "createdAt" >= ${windowSql} AND "clientHash" IS NOT NULL
+      ),
+      matched AS (
+        SELECT up."userId", up."wikidotId", pv."pageId", up."createdAt" AS viewed_at
+        FROM up
+        JOIN "PageViewEvent" pv
+          ON pv."clientHash" = up."clientHash"
+         AND pv."createdAt" BETWEEN up."createdAt" - INTERVAL '${MATCH_WINDOW_SECONDS} seconds'
+                                AND up."createdAt" + INTERVAL '${MATCH_WINDOW_SECONDS} seconds'
+      ),
+      agg AS (
+        SELECT "userId", min("wikidotId") AS wikidot_id, "pageId",
+               min(viewed_at) AS first_v, max(viewed_at) AS last_v, count(*) AS cnt
+        FROM matched GROUP BY "userId", "pageId"
+      )
+      INSERT INTO "UserPageView" ("userId","wikidotId","pageId","firstViewedAt","lastViewedAt","viewCount","updatedAt")
+      SELECT "userId", wikidot_id, "pageId", first_v, last_v, cnt, now() FROM agg
+      ON CONFLICT ("userId","pageId") DO UPDATE SET
+        "firstViewedAt" = LEAST("UserPageView"."firstViewedAt", EXCLUDED."firstViewedAt"),
+        "lastViewedAt"  = GREATEST("UserPageView"."lastViewedAt", EXCLUDED."lastViewedAt"),
+        "viewCount"     = GREATEST("UserPageView"."viewCount", EXCLUDED."viewCount"),
+        "wikidotId"     = COALESCE("UserPageView"."wikidotId", EXCLUDED."wikidotId"),
+        "updatedAt"     = now()
+    `);
+    const n = num(affected);
+    Logger.info(`[read-graph] upsert 完成，影响 ${n} 行`);
+    return { upserted: n, window: full ? 'full' : `${hours}h` };
+  }
+}

--- a/backend/src/jobs/ReadGraphJob.ts
+++ b/backend/src/jobs/ReadGraphJob.ts
@@ -65,9 +65,11 @@ export class ReadGraphJob {
 
     if (dryRun) return { upserted: 0, window: full ? 'full' : `${hours}h` };
 
-    // 聚合 upsert：firstViewedAt 取最小、lastViewedAt 取最大、viewCount 累加(去重到 voter 像素事件计数)。
-    // 冲突(已存在该 user-page)：扩展首末次区间、累加次数。幂等：重跑同窗只会刷新区间/次数(不重复累计因
-    // 我们以"匹配事件对"为计数源，且窗口固定→重跑结果一致地覆盖)。
+    // 聚合 upsert：firstViewedAt 取 min、lastViewedAt 取 max、viewCount 取 GREATEST。
+    // viewCount 语义=该窗内匹配事件对数；**--full 模式给生命周期准确总数(全量 agg 即总计,
+    // GREATEST 与已存量取大即等于总计)；增量模式仅作单调下界/近期刷新(不跨窗累加,不会减小)**。
+    // 全量 join 仅 ~7.5 万对(秒级)，需准确 viewCount 时跑 --full。幂等：同窗重跑结果一致。
+    // first/last 区间在增量下也始终正确扩展(LEAST/GREATEST 时间戳)。
     const affected = await this.prisma.$executeRawUnsafe(`
       WITH up AS (
         SELECT "clientHash", "userId", "wikidotId", "createdAt"

--- a/backend/src/jobs/TrackingAnomalyCheckJob.ts
+++ b/backend/src/jobs/TrackingAnomalyCheckJob.ts
@@ -1,0 +1,117 @@
+// src/jobs/TrackingAnomalyCheckJob.ts
+import { PrismaClient } from '@prisma/client';
+import { getPrismaClient } from '../utils/db-connection.js';
+import { Logger } from '../utils/Logger.js';
+
+/**
+ * 追踪反作弊 / 数据质量检查（纯只读报告，不写库）。
+ *
+ * 1) 缓存投毒监控：若 Wikidot 把某登录浏览者的 %%number%% 烤进整页缓存再发给他人，会表现为
+ *    "单 wikidotId 短时间跨大量 /24 子网且每子网≈1 次"。正常移动轮换是少量子网×多次。
+ * 2) 看后投票校验：对带组件的页面(有 PageViewEvent 数据),已知 clientHash 的用户(发过用户像素)
+ *    若投了票却无任何浏览记录(读取图谱 UserPageView 无该对) → 疑似脚本/API 刷票或换票。
+ *    依赖 analyze-read-graph 已构建 UserPageView。
+ */
+
+export type TrackingAnomalyOptions = {
+  days?: number;
+  topN?: number;
+};
+
+const DEFAULT_DAYS = 30;
+const DEFAULT_TOPN = 20;
+// 缓存投毒阈值：子网数≥此值 且 每子网事件<1.5 视为可疑
+const POISON_MIN_SUBNETS = 15;
+const POISON_MAX_EV_PER_SUBNET = 1.5;
+// 看后投票：只对"投票数≥此值且其中带组件页≥此值"的用户评估，避免小样本噪声
+const VWV_MIN_COMPONENT_VOTES = 10;
+
+function num(v: unknown): number {
+  if (typeof v === 'bigint') return Number(v);
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string') { const x = Number(v); return Number.isFinite(x) ? x : 0; }
+  return 0;
+}
+
+export class TrackingAnomalyCheckJob {
+  private prisma: PrismaClient;
+  constructor(prisma?: PrismaClient) {
+    this.prisma = prisma ?? getPrismaClient();
+  }
+
+  async run(options: TrackingAnomalyOptions = {}): Promise<void> {
+    const days = options.days ?? DEFAULT_DAYS;
+    const topN = options.topN ?? DEFAULT_TOPN;
+    Logger.info(`[tracking-anomaly] 检查窗口 ${days} 天, top ${topN}`);
+    await this.checkCachePoisoning(days, topN);
+    await this.checkVoteWithoutView(days, topN);
+  }
+
+  /** 缓存投毒：单 wikidotId 跨异常多 /24 且每子网≈1 次。 */
+  private async checkCachePoisoning(days: number, topN: number): Promise<void> {
+    const rows = await this.prisma.$queryRawUnsafe<any[]>(`
+      SELECT username, "wikidotId", count(*) ev,
+             count(DISTINCT split_part("clientIp",'.',1)||'.'||split_part("clientIp",'.',2)||'.'||split_part("clientIp",'.',3)) subnets,
+             round(count(*)::numeric / NULLIF(count(DISTINCT split_part("clientIp",'.',1)||'.'||split_part("clientIp",'.',2)||'.'||split_part("clientIp",'.',3)),0), 2) ev_per_subnet
+      FROM "UserPixelEvent"
+      WHERE "createdAt" > now() - INTERVAL '${days} days' AND "clientIp" IS NOT NULL
+      GROUP BY username, "wikidotId"
+      HAVING count(DISTINCT split_part("clientIp",'.',1)||'.'||split_part("clientIp",'.',2)||'.'||split_part("clientIp",'.',3)) >= ${POISON_MIN_SUBNETS}
+         AND count(*)::numeric / NULLIF(count(DISTINCT split_part("clientIp",'.',1)||'.'||split_part("clientIp",'.',2)||'.'||split_part("clientIp",'.',3)),0) < ${POISON_MAX_EV_PER_SUBNET}
+      ORDER BY subnets DESC LIMIT ${topN}
+    `);
+    if (rows.length === 0) {
+      Logger.info('[tracking-anomaly] 缓存投毒: 无可疑(身份数据健康)');
+      return;
+    }
+    Logger.warn(`[tracking-anomaly] 缓存投毒嫌疑 ${rows.length} 个 wikidotId(可能被烤进整页缓存发给他人):`);
+    for (const r of rows) {
+      Logger.warn(`  - ${r.username}(${r.wikidotId}) 子网=${num(r.subnets)} 事件=${num(r.ev)} 每子网=${r.ev_per_subnet}`);
+    }
+  }
+
+  /** 看后投票：带组件页 + 已知用户 + 有投票但读取图谱无浏览记录。 */
+  private async checkVoteWithoutView(days: number, topN: number): Promise<void> {
+    const rows = await this.prisma.$queryRawUnsafe<any[]>(`
+      WITH known_users AS (        -- 发过用户像素 = 我们掌握其 clientHash 的登录用户
+        SELECT DISTINCT "userId" FROM "UserPixelEvent" WHERE "userId" IS NOT NULL
+      ),
+      component_pages AS (         -- 有 PageViewEvent 数据 = 该页带组件(像素触发过)
+        SELECT DISTINCT "pageId" FROM "PageViewEvent"
+      ),
+      latest_votes AS (            -- 用户在带组件页的当前有效 upvote/downvote(按 voter,page 取最新)
+        SELECT "userId", "pageId" FROM (
+          SELECT v."userId", pv."pageId", v.direction,
+                 row_number() OVER (PARTITION BY v."userId", pv."pageId" ORDER BY v.timestamp DESC, v.id DESC) rn
+          FROM "Vote" v JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
+          WHERE v."userId" IN (SELECT "userId" FROM known_users)
+            AND pv."pageId" IN (SELECT "pageId" FROM component_pages)
+            AND v.timestamp > now() - INTERVAL '${days} days'
+        ) z WHERE rn = 1 AND direction <> 0
+      ),
+      per_user AS (
+        SELECT lv."userId",
+               count(*) component_votes,
+               count(*) FILTER (WHERE upv."userId" IS NULL) votes_without_view
+        FROM latest_votes lv
+        LEFT JOIN "UserPageView" upv ON upv."userId" = lv."userId" AND upv."pageId" = lv."pageId"
+        GROUP BY lv."userId"
+      )
+      SELECT u.username, u."wikidotId", pu.component_votes, pu.votes_without_view,
+             round(100.0 * pu.votes_without_view / NULLIF(pu.component_votes,0)) pct_no_view
+      FROM per_user pu JOIN "User" u ON u.id = pu."userId"
+      WHERE pu.component_votes >= ${VWV_MIN_COMPONENT_VOTES}
+      ORDER BY pct_no_view DESC, pu.votes_without_view DESC
+      LIMIT ${topN}
+    `);
+    if (rows.length === 0) {
+      Logger.info('[tracking-anomaly] 看后投票: 无足量样本或无可疑');
+      return;
+    }
+    Logger.info(`[tracking-anomaly] 看后投票 top ${rows.length}(带组件页投票但读取图谱无浏览记录占比高=脚本/换票嫌疑):`);
+    for (const r of rows) {
+      Logger.info(`  - ${r.username}(${r.wikidotId}) 带组件页投票=${num(r.component_votes)} 无浏览=${num(r.votes_without_view)} (${num(r.pct_no_view)}%)`);
+    }
+    Logger.info('[tracking-anomaly] 注意: 组件覆盖不全, 高占比仅为线索需人工复核(用户可能关像素/用其他设备)');
+  }
+}

--- a/backend/src/jobs/TrackingAnomalyCheckJob.ts
+++ b/backend/src/jobs/TrackingAnomalyCheckJob.ts
@@ -49,15 +49,23 @@ export class TrackingAnomalyCheckJob {
 
   /** 缓存投毒：单 wikidotId 跨异常多 /24 且每子网≈1 次。 */
   private async checkCachePoisoning(days: number, topN: number): Promise<void> {
+    // 仅 IPv4(实测流量 100% IPv4)。IPv6 用 split_part /24 会把隐私地址轮换误判成投毒,故排除;
+    // 子网在 CTE 算一次(避免 SELECT/HAVING/ORDER 三处重复求值)。
     const rows = await this.prisma.$queryRawUnsafe<any[]>(`
-      SELECT username, "wikidotId", count(*) ev,
-             count(DISTINCT split_part("clientIp",'.',1)||'.'||split_part("clientIp",'.',2)||'.'||split_part("clientIp",'.',3)) subnets,
-             round(count(*)::numeric / NULLIF(count(DISTINCT split_part("clientIp",'.',1)||'.'||split_part("clientIp",'.',2)||'.'||split_part("clientIp",'.',3)),0), 2) ev_per_subnet
-      FROM "UserPixelEvent"
-      WHERE "createdAt" > now() - INTERVAL '${days} days' AND "clientIp" IS NOT NULL
+      WITH base AS (
+        SELECT username, "wikidotId",
+               split_part("clientIp",'.',1)||'.'||split_part("clientIp",'.',2)||'.'||split_part("clientIp",'.',3) AS subnet
+        FROM "UserPixelEvent"
+        WHERE "createdAt" > now() - INTERVAL '${days} days'
+          AND "clientIp" ~ '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$'
+      )
+      SELECT username, "wikidotId", count(*)::int ev,
+             count(DISTINCT subnet)::int subnets,
+             round(count(*)::numeric / NULLIF(count(DISTINCT subnet),0), 2)::float8 ev_per_subnet
+      FROM base
       GROUP BY username, "wikidotId"
-      HAVING count(DISTINCT split_part("clientIp",'.',1)||'.'||split_part("clientIp",'.',2)||'.'||split_part("clientIp",'.',3)) >= ${POISON_MIN_SUBNETS}
-         AND count(*)::numeric / NULLIF(count(DISTINCT split_part("clientIp",'.',1)||'.'||split_part("clientIp",'.',2)||'.'||split_part("clientIp",'.',3)),0) < ${POISON_MAX_EV_PER_SUBNET}
+      HAVING count(DISTINCT subnet) >= ${POISON_MIN_SUBNETS}
+         AND count(*)::numeric / NULLIF(count(DISTINCT subnet),0) < ${POISON_MAX_EV_PER_SUBNET}
       ORDER BY subnets DESC LIMIT ${topN}
     `);
     if (rows.length === 0) {
@@ -79,15 +87,14 @@ export class TrackingAnomalyCheckJob {
       component_pages AS (         -- 有 PageViewEvent 数据 = 该页带组件(像素触发过)
         SELECT DISTINCT "pageId" FROM "PageViewEvent"
       ),
-      latest_votes AS (            -- 用户在带组件页的当前有效 upvote/downvote(按 voter,page 取最新)
-        SELECT "userId", "pageId" FROM (
-          SELECT v."userId", pv."pageId", v.direction,
+      latest_votes AS (            -- 当前有效票: 先按(voter,page)取最新再过滤方向+时间(时间过滤必须在
+        SELECT "userId", "pageId" FROM (   -- 去重之后,否则会把非最新票当当前票;窗口内是因读取图谱依赖
+          SELECT v."userId", pv."pageId", v.direction, v.timestamp ts,  -- UserPixelEvent(~75天保留)
                  row_number() OVER (PARTITION BY v."userId", pv."pageId" ORDER BY v.timestamp DESC, v.id DESC) rn
           FROM "Vote" v JOIN "PageVersion" pv ON pv.id = v."pageVersionId"
           WHERE v."userId" IN (SELECT "userId" FROM known_users)
             AND pv."pageId" IN (SELECT "pageId" FROM component_pages)
-            AND v.timestamp > now() - INTERVAL '${days} days'
-        ) z WHERE rn = 1 AND direction <> 0
+        ) z WHERE rn = 1 AND direction <> 0 AND ts > now() - INTERVAL '${days} days'
       ),
       per_user AS (
         SELECT lv."userId",
@@ -97,8 +104,8 @@ export class TrackingAnomalyCheckJob {
         LEFT JOIN "UserPageView" upv ON upv."userId" = lv."userId" AND upv."pageId" = lv."pageId"
         GROUP BY lv."userId"
       )
-      SELECT u.username, u."wikidotId", pu.component_votes, pu.votes_without_view,
-             round(100.0 * pu.votes_without_view / NULLIF(pu.component_votes,0)) pct_no_view
+      SELECT u.username, u."wikidotId", pu.component_votes::int component_votes, pu.votes_without_view::int votes_without_view,
+             round(100.0 * pu.votes_without_view / NULLIF(pu.component_votes,0))::int pct_no_view
       FROM per_user pu JOIN "User" u ON u.id = pu."userId"
       WHERE pu.component_votes >= ${VWV_MIN_COMPONENT_VOTES}
       ORDER BY pct_no_view DESC, pu.votes_without_view DESC


### PR DESCRIPTION
承接 Wikidot 机理研究的结论,落地三个**纯后端、零改组件、可逆**的能力。

## 背景认知
- `UserPixelEvent` = 登录浏览者身份信标(`users="."` 是当前浏览者本人, 已研究+数据证实), 带 clientHash+时间, **无页面字段**。
- `PageViewEvent` = clientHash 浏览页面 Y(匿名/登录通吃)。
- 两者按 `(clientHash, ±15s)` join → 重建"用户 X 读了页面 Y"读取图谱。Wikidot 模块嵌套不共享 `%%` 作用域、无法在组件层合并, 故走服务端 join。

## 改动(全 additive)
- `UserPageView` 表 + `PageViewEvent(clientHash,createdAt)` 索引(现有索引均非 clientHash 前导, join 需要)
- `analyze-read-graph` CLI(ReadGraphJob): 增量/全量构建 UserPageView, 幂等
- `check-tracking-anomalies` CLI(只读报告): 缓存投毒监控 + 看后投票校验

## 验证(临时表端到端 + 生产只读)
- 读取图谱全量 **74609 对 / 9739 用户 / 326 页**(规模可控)
- 缓存投毒 **0 命中**(身份数据健康; 20 子网用户因 4.5 次/子网=移动轮换, 正确不误报)
- 看后投票产出排名, `depressed-39` 10/10=100% 无浏览被捞出为线索
- backend typecheck 通过

## 部署
- 手动应用迁移: `psql "$DATABASE_URL" -f backend/sql/20260611_tracking_read_graph.sql`(含 CONCURRENTLY 索引)
- 无服务重启(均为手动 CLI; 常驻 sync 不使用)
- 运行: `analyze-read-graph --full` 首建 → `check-tracking-anomalies`
- 后续可挂周期 cron(仿 scpper-social-rebuild)