### PR TITLE
fix(search): 加载更多页面创建日期全变成同一天

### DIFF
--- a/frontend/pages/search.vue
+++ b/frontend/pages/search.vue
@@ -1224,7 +1224,10 @@ async function fetchPages(params: Record<string, any> | null = null, options: { 
         offset,
         includeTotal,
         includeSnippet: true,
-        includeDate: includeTotal
+        // 每一页结果都需要展示创建日期（firstRevisionAt）。此前误写成 includeTotal，
+        // 导致 offset>0 的"加载更多"请求 includeDate=false，BFF 会剥离 firstRevisionAt，
+        // 前端回退到 validFrom（当前版本生效时间，常为批量同步日期）→ 新加载页面创建日期全变成同一天。
+        includeDate: true
       }
     })
     const rowsRaw = Array.isArray(resp?.results) ? resp.results : (Array.isArray(resp) ? resp : [])


### PR DESCRIPTION
## 问题

搜索页面按"创建日期 新→旧"排序时,点一次"加载更多"后,**新加载出来的页面创建日期全部变成同一天**。

## 根因

`frontend/pages/search.vue` 的 `fetchPages` 把"是否返回创建日期"的开关 `includeDate` 错误地绑定到了"是否查询总数"的开关 `includeTotal`(= `offset === 0`):

- 首屏 `offset=0` → `includeTotal=true` → `includeDate=true`(正常)
- 加载更多 `offset>0` → `includeTotal=false` → `includeDate=false`(出错)

BFF(`bff/src/web/routes/search.ts:707/920/1405`)在 `wantDate=false` 时会从每行结果中**剥离 `firstRevisionAt`**(即 `firstPublishedAt`,真正的首发/创建日期)。前端 `normalizePage`(`search.vue:819`)随即回退:

```js
createdDate: toISODate(p.firstRevisionAt || p.createdAt || p.validFrom)
```

`firstRevisionAt` 缺失、响应里也没有 `createdAt`,只能落到 `validFrom`——当前版本的生效时间。对大量从未编辑过的页面,该值即某次批量同步/迁移的时间戳,于是创建日期全部显示为同一天。

**为什么"顺序对、只有日期错"**:`wantDate` 只作用于 JSON 投影,完全不影响 SQL 的 `ORDER BY`/`WHERE`。SQL 仍按 `firstRevisionAt` 排序,所以行顺序(新→旧)正确,只是那一列的值没回传。

## 修复

`fetchPages` 始终发送 `includeDate: true`。`firstRevisionAt` 本就一直被 SQL `SELECT`,返回它零额外成本(无新增 JOIN/查询)。

## 影响范围

- 全仓 `includeDate` 仅两处:出错的 `fetchPages`,与 CSV 导出(本就为 `includeDate: true`)。
- `/search/forums`、`/search/users` 不传该参数,走服务端默认 `'true'`,**不受影响**。

## 验证

- 三视角对抗式代码审查(因果链 / 修复安全性 / 同类站点)均高置信度确认。
- `cd frontend && npm run build` 通过(exit 0)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
