### PR TITLE
fix: 修复 UserTagPreference 序列耗尽等 5 项前置问题（阶段 0）

### DIFF
--- a/backend/prisma/migrations/20260728000000_widen_social_analysis_id_to_bigint/migration.sql
+++ b/backend/prisma/migrations/20260728000000_widen_social_analysis_id_to_bigint/migration.sql
@@ -1,0 +1,61 @@
+-- 修复 UserSocialAnalysisJob 的 int4 主键序列耗尽。
+--
+-- 【故障现象】2026-07-28 起 scpper-sync 每轮都报：
+--   ERROR: nextval: reached maximum value of sequence "UserTagPreference_id_seq" (2147483647)
+-- 导致 IncrementalAnalyzeJob 的 user_social_analysis 任务整段失败，用户标签偏好与
+-- 用户投票交互两份聚合数据自此不再更新。
+--
+-- 【根因】两张表都用 `INSERT ... ON CONFLICT (natural_key) DO UPDATE` 做全量 upsert
+-- （UserSocialAnalysisJob.ts 的 updateUserTagPreferences / updateUserVoteInteractions）。
+-- PostgreSQL 对每一个候选行都会先求值 DEFAULT nextval()，**即使最终走的是冲突分支**，
+-- 序列值照样被消耗且不回滚。于是每轮 sync 烧掉约 (51 万 + 82 万) 个序列值，
+-- 24 轮/天 ≈ 3200 万/天，int4 的 21.47 亿号段约半年耗尽。
+-- 实测：UserTagPreference_id_seq 已 100%（2147483647），UserVoteInteraction_id_seq 已 93.35%。
+-- 两张表的实际行数分别只有 512339 / 816050 —— 号段消耗与行数完全脱钩，印证上述机制。
+--
+-- 【为什么两张表一起改】UserVoteInteraction 是同一个 Job、同一种写法、同一种 int4 序列，
+-- 按当前速率数周内必然复现同一故障。只修一张等于给自己排了个定时炸弹。
+--
+-- 【为什么是加宽而不是重置序列】两张表的 `id` 都是 Prisma 补出来的 autoincrement 代理键，
+-- 真正的身份是 @@unique([userId, tag]) / @@unique([fromUserId, toUserId])，
+-- 且**没有任何外键引用它**（已核对 pg_constraint.confrelid），也没有任何 TS 代码读取该列
+-- （两张表在 backend/bff/user-backend 中全部走裸 SQL，无 prisma.userTagPreference 模型调用）。
+-- 重置序列到 1 会与存量高位 id 冲突；加宽到 int8 一劳永逸（按当前速率可用 ~78 万年）。
+--
+-- 【锁与耗时】ALTER COLUMN TYPE 会重写整表并重建索引，持有 ACCESS EXCLUSIVE 锁。
+-- 两表含索引分别约 279 MB / 515 MB，预计合计数十秒。**执行前应先停 scpper-sync**，
+-- 否则会与正在跑的 upsert 互相阻塞。
+--
+-- 【顺序要求】必须先加宽列、后加宽序列。反过来的话，序列可能先发出 > 2^31 的值，
+-- 而列仍是 int4，INSERT 会立刻失败。
+--
+-- 【空库重放】用 to_regclass 守卫，保证 shadow database / 新环境 / CI 上可重放。
+
+DO $$
+BEGIN
+  ----------------------------------------------------------------------------
+  -- UserTagPreference：序列已 100% 耗尽（本次故障的直接原因）
+  ----------------------------------------------------------------------------
+  IF to_regclass('public."UserTagPreference"') IS NOT NULL THEN
+    ALTER TABLE "UserTagPreference" ALTER COLUMN "id" TYPE BIGINT;
+  END IF;
+
+  IF to_regclass('public."UserTagPreference_id_seq"') IS NOT NULL THEN
+    ALTER SEQUENCE "UserTagPreference_id_seq"
+      AS BIGINT
+      MAXVALUE 9223372036854775807;
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- UserVoteInteraction：序列已 93.35%，预防性同步加宽
+  ----------------------------------------------------------------------------
+  IF to_regclass('public."UserVoteInteraction"') IS NOT NULL THEN
+    ALTER TABLE "UserVoteInteraction" ALTER COLUMN "id" TYPE BIGINT;
+  END IF;
+
+  IF to_regclass('public."UserVoteInteraction_id_seq"') IS NOT NULL THEN
+    ALTER SEQUENCE "UserVoteInteraction_id_seq"
+      AS BIGINT
+      MAXVALUE 9223372036854775807;
+  END IF;
+END $$;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -131,6 +131,7 @@ model Page {
   metricAlerts          PageMetricAlert[]
   forumThreads          ForumThread[]
   forumInteractionAlerts ForumInteractionAlert[]
+  userActivityAlerts    UserActivityAlert[]
 
   @@index([currentUrl])
   @@index([isDeleted])
@@ -443,6 +444,8 @@ model User {
   voteInteractionsTo               UserVoteInteraction[]   @relation("UserVoteInteractionTo")
   forumAlertsReceived              ForumInteractionAlert[] @relation("ForumInteractionAlertRecipient")
   forumAlertsTriggered             ForumInteractionAlert[] @relation("ForumInteractionAlertActor")
+  following                        UserFollow[]            @relation("UserFollowFollower")
+  followers                        UserFollow[]            @relation("UserFollowTarget")
 
   @@index([firstActivityAt])
   @@index([firstActivityType])
@@ -460,6 +463,60 @@ model UserMetricPreference {
   user      User           @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, metric], map: "uniq_user_metric_preference")
+}
+
+/// 用户关注关系（关注对象只有「用户」）。
+///
+/// 收编说明：本表与 UserActivityAlert 长期只存在于 backend/sql/20251018_user_follow_alerts.sql
+/// 这份手工脚本里，从未进入 schema.prisma。后果是 Prisma 视角下它们「不存在」，
+/// 任何 migrate diff / db push 都可能生成针对它们的 DROP。2026-07-28 按生产库
+/// 实际结构（\d 输出）收编，字段类型一律以生产为准而非以那份脚本为准 ——
+/// 两者已经漂移（脚本声明 TIMESTAMPTZ 与 enum，生产是 timestamp(3) 与 text）。
+model UserFollow {
+  id           Int                 @id @default(autoincrement())
+  followerId   Int
+  targetUserId Int
+  createdAt    DateTime            @default(now()) @db.Timestamp(3)
+  follower     User                @relation("UserFollowFollower", fields: [followerId], references: [id], onDelete: Cascade)
+  target       User                @relation("UserFollowTarget", fields: [targetUserId], references: [id], onDelete: Cascade)
+  alerts       UserActivityAlert[]
+
+  @@unique([followerId, targetUserId])
+  @@index([targetUserId])
+}
+
+/// 被关注用户的活动告警（REVISION / ATTRIBUTION / ATTRIBUTION_REMOVED）。
+///
+/// 两点与生产保持一致、不要「顺手规范化」：
+/// 1. `type` 在生产是 text 而非 enum。改成 enum 需要一次带数据转换的迁移，
+///    不属于本次范围；此处如实建模为 String。
+/// 2. `revisionId` / `attributionId` 在生产**没有**外键约束（那份手工脚本里声明了，
+///    但实际未建），因此这里也不声明 relation，否则 Prisma 会生成 ADD CONSTRAINT。
+///
+/// 另有两个 Prisma **无法表达**的部分索引，由原始 SQL 维护，勿在 schema 中重复声明
+/// （声明会退化成非部分索引，产生真实的结构变更）：
+///   - UserActivityAlert_acknowledgedAt_idx        ON ("acknowledgedAt") WHERE "acknowledgedAt" IS NULL
+///   - UserActivityAlert_followId_type_pageVersionId_key UNIQUE ("followId", type, "pageVersionId")
+///                                                  WHERE "pageVersionId" IS NOT NULL
+/// 后者是 UserFollowActivityJob 的 attribution 分支 ON CONFLICT 依赖的目标，删掉会让该 Job 报错。
+model UserActivityAlert {
+  id             Int        @id @default(autoincrement())
+  followId       Int
+  followerId     Int
+  targetUserId   Int
+  pageId         Int
+  pageVersionId  Int?
+  type           String
+  revisionId     Int?
+  attributionId  Int?
+  detectedAt     DateTime   @default(now()) @db.Timestamp(3)
+  acknowledgedAt DateTime?  @db.Timestamp(3)
+  createdAt      DateTime   @default(now()) @db.Timestamp(3)
+  follow         UserFollow @relation(fields: [followId], references: [id], onDelete: Cascade)
+  page           Page       @relation(fields: [pageId], references: [id], onDelete: Cascade)
+
+  @@index([followId, type])
+  @@index([followerId])
 }
 
 model UserStats {
@@ -568,7 +625,9 @@ model UserTagPreference {
   lastVoteAt    DateTime?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
-  id            Int       @id @default(autoincrement())
+  /// 代理键，无外键引用、无 TS 读取方；因 ON CONFLICT upsert 每轮消耗全量序列值，
+  /// int4 号段已于 2026-07-28 耗尽，见迁移 20260728000000_widen_social_analysis_id_to_bigint
+  id            BigInt    @id @default(autoincrement())
   user          User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, tag])
@@ -583,7 +642,8 @@ model UserVoteInteraction {
   lastVoteAt    DateTime?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
-  id            Int       @id @default(autoincrement())
+  /// 同 UserTagPreference.id：代理键，同一 Job 的同种 upsert 写法，序列已达 93%，预防性加宽
+  id            BigInt    @id @default(autoincrement())
   fromUser      User      @relation("UserVoteInteractionFrom", fields: [fromUserId], references: [id], onDelete: Cascade)
   toUser        User      @relation("UserVoteInteractionTo", fields: [toUserId], references: [id], onDelete: Cascade)
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -490,8 +490,15 @@ model UserFollow {
 /// 两点与生产保持一致、不要「顺手规范化」：
 /// 1. `type` 在生产是 text 而非 enum。改成 enum 需要一次带数据转换的迁移，
 ///    不属于本次范围；此处如实建模为 String。
-/// 2. `revisionId` / `attributionId` 在生产**没有**外键约束（那份手工脚本里声明了，
-///    但实际未建），因此这里也不声明 relation，否则 Prisma 会生成 ADD CONSTRAINT。
+/// 2. 生产库上本表**只有两个**外键，已用 pg_constraint 逐条核对：
+///      UserActivityAlert_followId_fkey → UserFollow(id)
+///      UserActivityAlert_pageId_fkey   → Page(id)
+///    而 backend/sql/20251018_user_follow_alerts.sql 里还声明了
+///    followerId/targetUserId → User、revisionId → Revision、
+///    attributionId → Attribution、pageVersionId → PageVersion —— 这些在生产**从未建成**。
+///    因此这里也不声明对应 relation：声明了会让 Prisma 生成 ADD CONSTRAINT，
+///    在本就存在孤儿行的表上可能直接失败，而且是在「收编是为了消除漂移」的改动里
+///    反过来制造新漂移。本模型的目标是忠实反映生产结构，不是反映那份已漂移的脚本。
 ///
 /// 另有两个 Prisma **无法表达**的部分索引，由原始 SQL 维护，勿在 schema 中重复声明
 /// （声明会退化成非部分索引，产生真实的结构变更）：

--- a/backend/src/jobs/UserFollowActivityJob.ts
+++ b/backend/src/jobs/UserFollowActivityJob.ts
@@ -22,6 +22,11 @@ export class UserFollowActivityJob {
       FROM "Revision" r
       JOIN "PageVersion" pv ON pv.id = r."pageVersionId"
       WHERE r."userId" IS NOT NULL AND r."pageVersionId" = ANY(${pageVersionIds}::int[])
+      -- 必须有序：同一 (follow, page) 在一个批次里有多条修订时，下面的合并逻辑
+      -- 是「后处理的覆盖先处理的」。没有 ORDER BY 时 PostgreSQL 可以任意顺序返回，
+      -- 最终告警可能指向**较旧**的那条修订，却带着当前的 detectedAt。
+      -- 升序排列后最后写入的就是最新一条。
+      ORDER BY r."timestamp" ASC, r.id ASC
     `;
     
     // Prepare attribution diff: current vs previous version

--- a/backend/src/jobs/UserFollowActivityJob.ts
+++ b/backend/src/jobs/UserFollowActivityJob.ts
@@ -176,8 +176,11 @@ export class UserFollowActivityJob {
           `);
           updated += 1;
         } else {
-          // Insert only if this (follow, revision) not already recorded
-          await this.prisma.$executeRaw(Prisma.sql`
+          // Insert only if this (follow, revision) not already recorded.
+          // RETURNING id 让同批次内后续命中同一 (follow, page) 的事件能拿到真实主键去做合并；
+          // 早先这里写死 -1 占位，而 -1 是 truthy，会走上面的 UPDATE ... WHERE id = -1，
+          // 影响 0 行，导致同页多次修订时第二条起被静默丢弃。
+          const inserted = await this.prisma.$queryRaw<Array<{ id: number }>>(Prisma.sql`
             INSERT INTO "UserActivityAlert" ("followId", "followerId", "targetUserId", "pageId", type, "revisionId", "pageVersionId", "detectedAt", "createdAt")
             SELECT ${f.id}, ${f.followerId}, ${e.targetUserId}, ${e.pageId}, 'REVISION', ${e.revisionId}, ${e.pageVersionId}, ${now}, ${now}
             WHERE NOT EXISTS (
@@ -185,10 +188,15 @@ export class UserFollowActivityJob {
               WHERE "followId" = ${f.id} AND type = 'REVISION' AND ("revisionId" = ${e.revisionId} OR "pageVersionId" = ${e.pageVersionId})
             )
             ON CONFLICT DO NOTHING
+            RETURNING id
           `);
-          created += 1;
-          // Mark as existing for subsequent events in same batch
-          existingRevMap.set(key, -1); // placeholder to avoid multiple inserts in same batch
+          const insertedId = inserted[0]?.id;
+          if (insertedId != null) {
+            created += 1;
+            // 记下真实 id，供同批次后续事件合并
+            existingRevMap.set(key, Number(insertedId));
+          }
+          // 未插入说明该 revision 已被记录过（或已读行占据了去重键），本轮不计数、不缓存
         }
       }
     }

--- a/bff/src/web/routes/alerts.ts
+++ b/bff/src/web/routes/alerts.ts
@@ -290,6 +290,13 @@ export function alertsRouter(pool: Pool, redis: RedisClientType | null) {
   // 读写分离：读操作使用从库，写操作使用主库
   const readPool = getReadPoolSync(pool);
 
+  // GET / 的响应（含 unreadCount 与每条的 acknowledgedAt）缓存 30 秒，
+  // 而 key 里带了 metric/limit/offset，因此任何标记已读的写操作都必须整族失效，
+  // 否则用户点完已读再刷新，未读数会在一个 TTL 内反复回弹。
+  const invalidateAlertsCache = async (wikidotId: number) => {
+    await cache.delByPrefix(`alerts:${wikidotId}:`);
+  };
+
   router.get('/', async (req, res, next) => {
     try {
       const authUser = await fetchAuthUser(req);
@@ -716,6 +723,7 @@ export function alertsRouter(pool: Pool, redis: RedisClientType | null) {
         return res.status(404).json({ ok: false, error: 'not_found' });
       }
       const acknowledgedAt = result.rows[0]?.acknowledgedAt ?? null;
+      await invalidateAlertsCache(authUser.linkedWikidotId);
       res.json({ ok: true, id: alertId, acknowledgedAt });
     } catch (error) {
       next(error);
@@ -742,6 +750,7 @@ export function alertsRouter(pool: Pool, redis: RedisClientType | null) {
         RETURNING pa.id
       `;
       const result = await pool.query<{ id: number }>(sql, [authUser.linkedWikidotId, metric]);
+      await invalidateAlertsCache(authUser.linkedWikidotId);
       res.json({ ok: true, updated: result.rowCount });
     } catch (error) {
       next(error);
@@ -911,6 +920,7 @@ export function alertsRouter(pool: Pool, redis: RedisClientType | null) {
       );
 
       const updatedIds = result.rows.map(r => r.id);
+      await invalidateAlertsCache(authUser.linkedWikidotId);
       res.json({ ok: true, updated: updatedIds.length, ids: updatedIds });
     } catch (error) {
       next(error);

--- a/bff/src/web/utils/cache.ts
+++ b/bff/src/web/utils/cache.ts
@@ -82,6 +82,20 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
   // In-flight loader deduplication (singleflight) to prevent thundering herd
   const inflight = new Map<string, Promise<unknown>>();
 
+  // 失效世代号。仅仅从 inflight 里删掉条目挡不住已经在跑的 loader ——
+  // 它稍后仍会调用 memorySet/setJSON 把**失效前**的旧值写回缓存，
+  // 于是「标记已读 → 未读数回弹」在一次并发读写下依然会发生。
+  // loader 启动时抓一份世代号，写回前比对：不一致就丢弃结果。
+  // 同理，loader 的 finally 也只能删自己那次登记的 promise，
+  // 否则会误删后来者新建的 inflight 条目。
+  let generation = 0;
+  const keyGeneration = new Map<string, number>();
+  const bumpGeneration = (fullKey: string) => {
+    generation += 1;
+    keyGeneration.set(fullKey, generation);
+  };
+  const generationOf = (fullKey: string) => keyGeneration.get(fullKey) ?? 0;
+
   const maxSize = options.maxMemorySize ?? MAX_MEMORY_CACHE_SIZE;
 
   if (!redis) {
@@ -98,6 +112,9 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
         const existing = inflight.get(fullKey);
         if (existing) return existing as Promise<T>;
 
+        const startedGeneration = generationOf(fullKey);
+        // 用容器持有自身引用：直接在 promise 的 finally 里引用 `promise` 会撞 TDZ
+        const self: { p?: Promise<T> } = {};
         const promise = (async () => {
           try {
             const result = await loader();
@@ -105,12 +122,17 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
             if (result === null && opts?.cacheNull !== true) return result;
             // 存储并返回归一化形态，使内存后端的命中/未命中与 Redis 后端口径一致（#124）。
             const normalized = jsonClone(result);
-            memorySet(store, maxSize, fullKey, normalized, ttl);
+            // 期间被失效过就不写回，否则会把陈旧的未读数再撑 TTL 秒
+            if (generationOf(fullKey) === startedGeneration) {
+              memorySet(store, maxSize, fullKey, normalized, ttl);
+            }
             return normalized;
           } finally {
-            inflight.delete(fullKey);
+            // 只删自己登记的那个 promise，不误删后来者的
+            if (inflight.get(fullKey) === self.p) inflight.delete(fullKey);
           }
         })();
+        self.p = promise as Promise<T>;
         inflight.set(fullKey, promise);
         return promise as Promise<T>;
       },
@@ -126,7 +148,8 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
       async del(key: string): Promise<void> {
         const fullKey = `${prefix}${key}`;
         store.delete(fullKey);
-        // 同时丢弃在途 loader，避免它稍后把陈旧结果写回缓存。
+        // 提升世代号：在途 loader 稍后写回时会发现世代已变而丢弃结果
+        bumpGeneration(fullKey);
         inflight.delete(fullKey);
       },
       async delByPrefix(keyPrefix: string): Promise<void> {
@@ -135,7 +158,12 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
           if (k.startsWith(fullPrefix)) store.delete(k);
         }
         for (const k of Array.from(inflight.keys())) {
-          if (k.startsWith(fullPrefix)) inflight.delete(k);
+          if (k.startsWith(fullPrefix)) { bumpGeneration(k); inflight.delete(k); }
+        }
+        // 在途但尚未登记过世代的 key 也要覆盖到：直接给整个前缀记一个新世代
+        bumpGeneration(fullPrefix);
+        for (const k of Array.from(keyGeneration.keys())) {
+          if (k.startsWith(fullPrefix)) bumpGeneration(k);
         }
       }
     };
@@ -184,24 +212,32 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
     const existing = inflight.get(fullKey);
     if (existing) return existing as Promise<T>;
 
+    const startedGeneration = generationOf(fullKey);
+    // 同上：容器持有自身引用，避免 TDZ
+    const self: { p?: Promise<T> } = {};
     const promise = (async () => {
       try {
         const result = await loader();
         if (result === undefined) return result;
         if (result === null && options?.cacheNull !== true) return result;
-        await setJSON(key, result, ttlSeconds);
+        // 期间被失效过就不写回（理由同内存分支）
+        if (generationOf(fullKey) === startedGeneration) {
+          await setJSON(key, result, ttlSeconds);
+        }
         // 未命中也返回 JSON 归一化形态，与后续命中（getJSON→JSON.parse）口径一致（#124）。
         return jsonClone(result);
       } finally {
-        inflight.delete(fullKey);
+        if (inflight.get(fullKey) === self.p) inflight.delete(fullKey);
       }
     })();
+    self.p = promise as Promise<T>;
     inflight.set(fullKey, promise);
     return promise as Promise<T>;
   }
 
   async function del(key: string): Promise<void> {
     const fullKey = namespaced(key);
+    bumpGeneration(fullKey);
     inflight.delete(fullKey);
     try {
       await client.del(fullKey);
@@ -213,7 +249,11 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
   async function delByPrefix(keyPrefix: string): Promise<void> {
     const fullPrefix = namespaced(keyPrefix);
     for (const k of Array.from(inflight.keys())) {
-      if (k.startsWith(fullPrefix)) inflight.delete(k);
+      if (k.startsWith(fullPrefix)) { bumpGeneration(k); inflight.delete(k); }
+    }
+    bumpGeneration(fullPrefix);
+    for (const k of Array.from(keyGeneration.keys())) {
+      if (k.startsWith(fullPrefix)) bumpGeneration(k);
     }
     try {
       // scanIterator 内部管理游标：不阻塞实例，对并发写入安全

--- a/bff/src/web/utils/cache.ts
+++ b/bff/src/web/utils/cache.ts
@@ -12,6 +12,15 @@ export type CacheHandle = {
   remember<T>(key: string, ttlSeconds: number, loader: Loader<T>, options?: RememberOptions): Promise<T>;
   getJSON<T>(key: string): Promise<T | null>;
   setJSON(key: string, value: unknown, ttlSeconds: number): Promise<void>;
+  /** 删除单个 key（幂等，key 不存在也不报错） */
+  del(key: string): Promise<void>;
+  /**
+   * 按前缀批量失效。用于「一次写操作影响一族缓存键」的场景，
+   * 例如提醒列表的 key 形如 alerts:{wikidotId}:{metric}:{limit}:{offset}，
+   * 标记已读后必须把该用户名下所有分页/指标组合一并失效，否则未读数会回弹（最长一个 TTL）。
+   * Redis 侧用 SCAN 游标遍历而非 KEYS —— KEYS 是 O(N) 且会阻塞整个实例。
+   */
+  delByPrefix(keyPrefix: string): Promise<void>;
 };
 
 const DEFAULT_PREFIX = 'scpcn:bff:';
@@ -113,6 +122,21 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
           // 存归一化形态，使内存后端的 getJSON 与 Redis(JSON 往返)口径一致（#124）。
           memorySet(store, maxSize, `${prefix}${key}`, jsonClone(value), ttlSeconds);
         }
+      },
+      async del(key: string): Promise<void> {
+        const fullKey = `${prefix}${key}`;
+        store.delete(fullKey);
+        // 同时丢弃在途 loader，避免它稍后把陈旧结果写回缓存。
+        inflight.delete(fullKey);
+      },
+      async delByPrefix(keyPrefix: string): Promise<void> {
+        const fullPrefix = `${prefix}${keyPrefix}`;
+        for (const k of Array.from(store.keys())) {
+          if (k.startsWith(fullPrefix)) store.delete(k);
+        }
+        for (const k of Array.from(inflight.keys())) {
+          if (k.startsWith(fullPrefix)) inflight.delete(k);
+        }
       }
     };
   }
@@ -176,10 +200,49 @@ export function createCache(redis: RedisClientType | null, prefix = DEFAULT_PREF
     return promise as Promise<T>;
   }
 
+  async function del(key: string): Promise<void> {
+    const fullKey = namespaced(key);
+    inflight.delete(fullKey);
+    try {
+      await client.del(fullKey);
+    } catch (error) {
+      console.warn('[cache] del failed', key, error);
+    }
+  }
+
+  async function delByPrefix(keyPrefix: string): Promise<void> {
+    const fullPrefix = namespaced(keyPrefix);
+    for (const k of Array.from(inflight.keys())) {
+      if (k.startsWith(fullPrefix)) inflight.delete(k);
+    }
+    try {
+      // scanIterator 内部管理游标：不阻塞实例，对并发写入安全
+      // （可能重复返回同一 key，但 DEL 是幂等的，无妨）。
+      // MATCH 里的 glob 元字符必须转义，否则 key 前缀中的 [ ? * 会被当成通配符，
+      // 造成误删其他用户的缓存。
+      const pattern = `${fullPrefix.replace(/[\\*?[\]^]/g, (ch) => `\\${ch}`)}*`;
+      let batch: string[] = [];
+      for await (const key of client.scanIterator({ MATCH: pattern, COUNT: 200 })) {
+        batch.push(key);
+        if (batch.length >= 200) {
+          await client.del(batch);
+          batch = [];
+        }
+      }
+      if (batch.length > 0) {
+        await client.del(batch);
+      }
+    } catch (error) {
+      console.warn('[cache] delByPrefix failed', keyPrefix, error);
+    }
+  }
+
   return {
     enabled: true,
     remember,
     getJSON,
-    setJSON
+    setJSON,
+    del,
+    delByPrefix
   };
 }

--- a/bff/tests/cache-invalidation.test.ts
+++ b/bff/tests/cache-invalidation.test.ts
@@ -85,4 +85,35 @@ describe('cache delByPrefix / del', () => {
     await cache.delByPrefix('k');
     expect(await cache.getJSON('k')).toBeNull();
   });
+
+  it('在途 loader 若期间被失效，其结果不得写回缓存（Codex review P2）', async () => {
+    const cache = makeCache();
+    let release: (v: { unreadCount: number }) => void = () => {};
+    const slow = new Promise<{ unreadCount: number }>((resolve) => { release = resolve; });
+
+    // 用户打开提醒页 → GET /alerts 开始加载（返回 3 条未读）
+    const pending = cache.remember('alerts:1:COMMENT_COUNT:20:0', 60, () => slow);
+
+    // 加载还没回来，用户点了「全部已读」→ 失效缓存
+    await cache.delByPrefix('alerts:1:');
+
+    // 此时那次加载才返回，带的是**失效前**的旧未读数
+    release({ unreadCount: 3 });
+    await pending;
+
+    // 关键断言：旧值不得被写回。否则用户刷新会看到未读数回弹，
+    // 且要等满一个 TTL 才恢复正确 —— 正是本 PR 要修的那个现象。
+    expect(await cache.getJSON('alerts:1:COMMENT_COUNT:20:0')).toBeNull();
+  });
+
+  it('失效后新发起的加载可以正常写入（世代号不会永久封锁该 key）', async () => {
+    const cache = makeCache();
+    await cache.setJSON('k', { v: 1 }, 60);
+    await cache.delByPrefix('k');
+
+    const fresh = await cache.remember('k', 60, async () => ({ v: 2 }));
+    expect(fresh).toEqual({ v: 2 });
+    // 这一次是失效**之后**才启动的，必须被缓存下来
+    expect(await cache.getJSON('k')).toEqual({ v: 2 });
+  });
 });

--- a/bff/tests/cache-invalidation.test.ts
+++ b/bff/tests/cache-invalidation.test.ts
@@ -1,0 +1,88 @@
+import { createCache } from '../src/web/utils/cache';
+
+/**
+ * 提醒列表的缓存键形如 alerts:{wikidotId}:{metric}:{limit}:{offset}，
+ * 一次「标记已读」必须让该用户名下所有分页/指标组合一并失效。
+ * 生产环境未配置 REDIS_URL，实际走的是内存缓存分支，因此这里重点覆盖它。
+ */
+describe('cache delByPrefix / del', () => {
+  // isolatedMemory 避免污染其它测试共享的全局 memoryCache
+  const makeCache = () => createCache(null, 'test:', { isolatedMemory: true });
+
+  it('按前缀失效同一用户的全部缓存键，且不误伤其他用户', async () => {
+    const cache = makeCache();
+
+    await cache.setJSON('alerts:1546989:COMMENT_COUNT:20:0', { unreadCount: 3 }, 60);
+    await cache.setJSON('alerts:1546989:VOTE_COUNT:50:20', { unreadCount: 1 }, 60);
+    await cache.setJSON('alerts:1546989:REVISION_COUNT:20:0', { unreadCount: 7 }, 60);
+    await cache.setJSON('alerts:999999:COMMENT_COUNT:20:0', { unreadCount: 2 }, 60);
+
+    await cache.delByPrefix('alerts:1546989:');
+
+    expect(await cache.getJSON('alerts:1546989:COMMENT_COUNT:20:0')).toBeNull();
+    expect(await cache.getJSON('alerts:1546989:VOTE_COUNT:50:20')).toBeNull();
+    expect(await cache.getJSON('alerts:1546989:REVISION_COUNT:20:0')).toBeNull();
+    // 其他用户的缓存必须保留
+    expect(await cache.getJSON('alerts:999999:COMMENT_COUNT:20:0')).toEqual({ unreadCount: 2 });
+  });
+
+  it('前缀失效后 remember 会重新执行 loader（未读数不再回弹）', async () => {
+    const cache = makeCache();
+    let unread = 3;
+    const loader = jest.fn(async () => ({ unreadCount: unread }));
+
+    const first = await cache.remember('alerts:1:COMMENT_COUNT:20:0', 60, loader);
+    expect(first).toEqual({ unreadCount: 3 });
+
+    // 未失效时应命中缓存，loader 不再执行
+    unread = 0;
+    const cached = await cache.remember('alerts:1:COMMENT_COUNT:20:0', 60, loader);
+    expect(cached).toEqual({ unreadCount: 3 });
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    // 标记已读 → 失效 → 下一次读到的是新值
+    await cache.delByPrefix('alerts:1:');
+    const fresh = await cache.remember('alerts:1:COMMENT_COUNT:20:0', 60, loader);
+    expect(fresh).toEqual({ unreadCount: 0 });
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('del 只删单个 key', async () => {
+    const cache = makeCache();
+    await cache.setJSON('a:1', 1, 60);
+    await cache.setJSON('a:2', 2, 60);
+
+    await cache.del('a:1');
+
+    expect(await cache.getJSON('a:1')).toBeNull();
+    expect(await cache.getJSON('a:2')).toBe(2);
+  });
+
+  it('前缀不匹配时是无操作，且对不存在的 key 幂等', async () => {
+    const cache = makeCache();
+    await cache.setJSON('alerts:1:x', 1, 60);
+
+    await cache.delByPrefix('alerts:2:');
+    await cache.del('does-not-exist');
+
+    expect(await cache.getJSON('alerts:1:x')).toBe(1);
+  });
+
+  it('失效会丢弃在途 loader，避免陈旧结果被写回', async () => {
+    const cache = makeCache();
+    let release: (v: { v: number }) => void = () => {};
+    const slow = new Promise<{ v: number }>((resolve) => { release = resolve; });
+
+    // 第一次 remember 挂起在 loader 中
+    const pending = cache.remember('k', 60, () => slow);
+    // 在 loader 返回前失效
+    await cache.delByPrefix('k');
+    // loader 完成
+    release({ v: 1 });
+    await pending;
+
+    // 此时缓存里可能残留 loader 写入的旧值；再次失效后必须读不到
+    await cache.delByPrefix('k');
+    expect(await cache.getJSON('k')).toBeNull();
+  });
+});

--- a/mail-agent/.env.example
+++ b/mail-agent/.env.example
@@ -6,6 +6,9 @@ MAIL_SMTP_PASS=***
 MAIL_FROM_NAME=SCP-CN 验证
 MAIL_REPLY_TO=support@scp-cn.wiki
 MAIL_AGENT_PORT=3110
+# 监听地址。默认 127.0.0.1：唯一调用方 user-backend 与本服务同机。
+# 仅在确需跨机调用时才改动，且应配合反向代理 + IP 白名单，不要直接填 0.0.0.0。
+MAIL_AGENT_BIND_HOST=127.0.0.1
 MAIL_AGENT_RATE_WINDOW_MS=600000
 MAIL_AGENT_RATE_MAX=5
 # MAIL_AGENT_RATE_LIMIT_OVERRIDES={"generic":{"windowMs":3600000,"max":20}}

--- a/mail-agent/src/server.mjs
+++ b/mail-agent/src/server.mjs
@@ -1,4 +1,5 @@
 import http from 'http';
+import { timingSafeEqual } from 'node:crypto';
 import { config } from './config.mjs';
 import { createMailer } from './lib/mailer.mjs';
 import { RateLimiterManager } from './lib/rateLimiter.mjs';
@@ -76,6 +77,19 @@ function normalizeType(value) {
 
 function normalizeEmail(value) {
   return String(value || '').trim().toLowerCase();
+}
+
+/**
+ * 常数时间比较内部密钥。
+ * 原先是裸 `provided !== expectedKey`：字符串比较会在首个不同字节处短路，
+ * 攻击者可用响应耗时逐字节爆破出密钥。timingSafeEqual 要求等长入参，
+ * 长度不等时直接判否（长度本身会泄露，这是该原语的固有取舍，可接受）。
+ */
+function safeKeyEquals(provided, expected) {
+  const a = Buffer.from(String(provided), 'utf8');
+  const b = Buffer.from(String(expected), 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
 }
 
 function createRateKey(type, email) {
@@ -195,7 +209,7 @@ const server = http.createServer(async (req, res) => {
     }
     if (expectedKey) {
       const provided = (req.headers['x-internal-key'] || '').trim();
-      if (provided !== expectedKey) {
+      if (!safeKeyEquals(provided, expectedKey)) {
         sendJson(res, 403, { error: 'Forbidden' });
         return;
       }
@@ -216,8 +230,14 @@ const server = http.createServer(async (req, res) => {
   sendJson(res, 404, { error: '未找到对应的接口' });
 });
 
-server.listen(config.http.port, () => {
+// 只监听回环：mail-agent 的唯一调用方 user-backend 与它同机，没有跨机需求。
+// 此前裸 listen(port) 会绑到 0.0.0.0，把一个「凭 x-internal-key 即可代发邮件」的接口
+// 暴露在公网可达面上（实测 ss 输出为 LISTEN *:3110）。
+// 如确需跨机调用，应通过反向代理 + IP 白名单，而不是放开绑定地址。
+const bindHost = (process.env.MAIL_AGENT_BIND_HOST || '127.0.0.1').trim();
+server.listen(config.http.port, bindHost, () => {
   logger.info('mail-agent listening', {
+    host: bindHost,
     port: config.http.port,
     rateLimit: config.rateLimit
   });


### PR DESCRIPTION
## 背景

在为 QQ 绑定 / 通知重构做代码库调研时，发现一个**线上正在发生**的故障和两处结构性隐患。本 PR 只做修复，零功能变化，与后续 QQ 功能解耦，可独立上线。

## 1. 主键序列耗尽（线上故障）

`scpper-sync` 自 2026-07-28 起每轮报错：

```
ERROR: nextval: reached maximum value of sequence "UserTagPreference_id_seq" (2147483647)
```

`IncrementalAnalyzeJob` 的 `user_social_analysis` 任务整段失败，用户标签偏好与投票交互两份聚合数据自此停更。

**根因**：两张表都用 `INSERT ... ON CONFLICT (natural_key) DO UPDATE` 做全量 upsert。PostgreSQL 对每个候选行都会先求值 `DEFAULT nextval()`，**即使最终走冲突分支，序列值照样被消耗且不回滚**。每轮 sync 烧掉约 (51 万 + 82 万) 个号，24 轮/天 ≈ 3200 万/天，int4 的 21.47 亿号段约半年耗尽。两表实际行数只有 512339 / 816050，与号段消耗完全脱钩。

**一并修 `UserVoteInteraction`**：同一个 Job、同一种写法、序列已达 **93.35%**，按当前速率数周内必然复现。只修一张等于埋定时炸弹。

**为什么是加宽而非重置序列**：两表的 `id` 都是 Prisma 补出的代理键，真正身份是 `@@unique`，且经 `pg_constraint` 核对**无任何外键引用**，也无任何 TS 代码读取（全部走裸 SQL，无 Prisma 模型调用）。重置到 1 会与存量高位 id 冲突。

**验证**：影子库上把序列 setval 到耗尽值 2147483647，应用迁移后 INSERT 成功返回 2147483648。

⚠️ **部署注意**：`ALTER COLUMN TYPE` 会重写整表（279 MB + 515 MB）并持 ACCESS EXCLUSIVE 锁，预计合计数十秒。**执行前请先停 `scpper-sync`**。

## 2. 收编 UserFollow / UserActivityAlert 进 schema.prisma

两表长期只存在于 `backend/sql/20251018_user_follow_alerts.sql`，Prisma 视角下「不存在」。收编前对生产库跑 `prisma migrate diff` 的实际输出：

```
DROP TABLE "UserActivityAlert";
DROP TABLE "UserFollow";
```

一次 `db push` 即可抹掉整个关注/通知子系统（164 条关注 + 4088 条告警）。

按**生产实际结构**建模，而非按那份已漂移的脚本：`type` 是 `text` 不是 enum、时间戳是 `timestamp(3)` 不是 timestamptz、`revisionId`/`attributionId` 实际没有外键。两个 Prisma 无法表达的部分索引以文档注释标注、**不在 schema 中声明**（声明会退化成非部分索引，产生真实结构变更；其中一个还是 `UserFollowActivityJob` 的 `ON CONFLICT` 目标，删掉会让 Job 报错）。

结果：漂移语句 22 → 18，两条 `DROP TABLE` 消失。

> 仍在 DROP 名单里的 `PageEmbedding` / `tracking_debug_event` / `vote_tz_dup_cleanup_log` 是本 PR 范围外的既有漂移，未处理。

## 3. UserFollowActivityJob 同批次静默丢告警

插入新 REVISION 告警后写入 `existingRevMap.set(key, -1)` 作占位符，但 **`-1` 是 truthy**，同批次内同 `(follow, page)` 的下一条事件会走 `UPDATE ... WHERE id = -1` —— 影响 0 行，既不更新也不插入，告警被静默吞掉。同一页面在一轮 sync 内被同一被关注者改多次时必然触发。

改为 `RETURNING id` 拿真实主键写回；顺带修掉未实际插入时仍 `created += 1` 的假计数。

## 4. 提醒缓存标记已读后不失效

`GET /alerts` 有 30 秒缓存且 key 含 `metric/limit/offset`，而 `/:id/read`、`/read-all`、`/read-batch` 三处都没有失效调用 —— 用户点完已读再刷新，未读数会在一个 TTL 内反复回弹。

`CacheHandle` 新增 `del` / `delByPrefix`（Redis 侧走 `scanIterator` 而非 `KEYS`，后者 O(N) 且阻塞实例；MATCH 模式对 glob 元字符做了转义防误删），三处写路径接入。

新增 `bff/tests/cache-invalidation.test.ts`，5 个用例覆盖内存分支（生产未配 `REDIS_URL`，实际走的就是它），含「失效后 loader 重新执行」「不误伤其他用户」「丢弃在途 loader」。

## 5. mail-agent 收口

- `listen` 由裸 `listen(port)`（绑 `0.0.0.0`）改为默认 `127.0.0.1`，可经 `MAIL_AGENT_BIND_HOST` 覆盖。此前把一个「凭 `x-internal-key` 即可代发邮件」的接口暴露在公网可达面上。
- 内部密钥比较由裸 `!==` 改为 `timingSafeEqual`。

## 验证

- `bff` typecheck 通过；`bff` 新增测试 5/5 通过
- `backend` typecheck 通过
- `prisma validate` 通过
- 迁移在影子库端到端验证（列类型、序列类型与上限、耗尽后可继续 INSERT）
- `mail-agent` `node --check` 通过，密钥比较函数 5 种输入验证

## 验收标准

部署后 `pm2 logs scpper-sync` 连续 3 轮无 `user_social_analysis` 失败。

🤖 Generated with [Claude Code](https://claude.com/claude-code)