### PR TITLE
fix(notify): 调整 QQ 摘要格式并合并同页多条变动

### DIFF
--- a/backend/src/jobs/NotificationDispatchJob.ts
+++ b/backend/src/jobs/NotificationDispatchJob.ts
@@ -130,6 +130,27 @@ interface Candidate {
   userId: number;
   detectedAt: Date;
   line: string;
+  /**
+   * 合并键。同一页面的多条指标变动、同一话题的多条回复会被并成一行 ——
+   * 一次推送里把同一个页面列三遍（评论 +2 / 投票 +5 / 编辑 +1）
+   * 既占篇幅又难读。
+   */
+  groupKey: string;
+  /** 组头，如「你的《SCP-CN-1000》」。仅当组内可拼接时提供。 */
+  mergeHead?: string;
+  /** 组内片段，如「投票 +12」。同组的片段用「、」连起来。 */
+  mergePart?: string;
+  /** 组尾（页面链接） */
+  mergeTail?: string;
+}
+
+/** 渲染合并所需的最小信息。重发时从 payload 还原出来的也是这个形状。 */
+interface MergeItem {
+  line: string;
+  groupKey?: string;
+  mergeHead?: string;
+  mergePart?: string;
+  mergeTail?: string;
 }
 
 type Row = Record<string, unknown>;
@@ -687,6 +708,12 @@ async function recordAll(
       payload: {
         source: c.source,
         line: c.line,
+        // 合并字段一并存下：重发时只有 payload，没有原始候选，
+        // 不存的话同一批重发出来的格式会和首次不一致
+        groupKey: c.groupKey,
+        ...(c.mergeHead ? { mergeHead: c.mergeHead } : {}),
+        ...(c.mergePart ? { mergePart: c.mergePart } : {}),
+        ...(c.mergeTail ? { mergeTail: c.mergeTail } : {}),
         detectedAt: c.detectedAt.toISOString(),
         runId: RUN_ID,
         ...(digestKey ? { digestKey } : {}),
@@ -1109,18 +1136,55 @@ async function countDigestsSentSince(
 }
 
 function renderDigest(items: Candidate[], overflow: number): string {
-  return renderDigestLines(items.map((c) => c.line), overflow);
+  return renderMerged(items, overflow);
 }
 
 /**
- * 从纯文本行渲染摘要。重发 SCHEDULED 批次时用得上 ——
- * 那时手上只有 payload 里存下来的 line，没有原始 Candidate。
+ * 从纯文本行渲染摘要（兼容旧数据）。
+ * 重发路径若碰到没有合并字段的历史行，退回逐行展示。
  */
 function renderDigestLines(itemLines: string[], overflow: number): string {
-  const lines = ['【SCPper CN】你有新的站点动态：', ''];
-  for (const line of itemLines) lines.push(`· ${line}`);
+  return renderMerged(itemLines.map((line) => ({ line })), overflow);
+}
+
+/**
+ * 把候选合并后渲染成一条私信。
+ *
+ * 合并规则按 groupKey 分组，组内两种情况：
+ *  - 可拼接（页面指标）：同一页面的不同指标并成
+ *    「你的《X》投票 +12、评论 +3  链接」，而不是三行各说一遍同一个页面
+ *  - 不可拼接（关注/论坛）：同组只出一行，末尾标「（N 条）」
+ *
+ * 保持首次出现的顺序 —— 候选本身按 detectedAt 排序，合并不该打乱时间感。
+ */
+export function renderMerged(items: MergeItem[], overflow: number): string {
+  const groups = new Map<string, MergeItem[]>();
+  for (const [i, it] of items.entries()) {
+    // 没有 groupKey 的（历史数据）各自成组，行为与合并前一致
+    const key = it.groupKey ?? `__solo:${i}`;
+    const g = groups.get(key);
+    if (g) g.push(it); else groups.set(key, [it]);
+  }
+
+  const rendered: string[] = [];
+  for (const group of groups.values()) {
+    const first = group[0]!;
+    const parts = group.map((g) => g.mergePart).filter((x): x is string => Boolean(x));
+    if (first.mergeHead && parts.length === group.length) {
+      // 同一页面的多个指标：去重后按出现顺序拼接
+      const uniq = [...new Set(parts)];
+      const tail = first.mergeTail ? `  ${first.mergeTail}` : '';
+      rendered.push(`${first.mergeHead}${uniq.join('、')}${tail}`);
+    } else if (group.length > 1) {
+      rendered.push(`${first.line}（${group.length} 条）`);
+    } else {
+      rendered.push(first.line);
+    }
+  }
+
+  const lines = ['【scpper-cn】', ''];
+  for (const line of rendered) lines.push(`· ${line}`);
   if (overflow > 0) lines.push(`· …另有 ${overflow} 条`);
-  lines.push('', `查看全部：${SITE_BASE}/account?tab=alerts`);
   return lines.join('\n');
 }
 
@@ -1171,7 +1235,13 @@ async function collectCandidates(
       dedupeKey: `pma:${r.id}:${r.newValue ?? 'n'}:${new Date(String(r.detectedAt)).getTime()}`,
       userId: Number(r.userId),
       detectedAt: new Date(String(r.detectedAt)),
-      line: `你的《${pageLabel(r)}》${label}有变化 ${delta}  ${pageUrl(r)}`
+      // 同一页面的不同指标要能并成一行，所以按页面分组，指标本身作为可拼接片段
+      groupKey: `page:${r.pageWikidotId ?? r.pageUrl ?? r.pageId}`,
+      mergeHead: `你的《${pageLabel(r)}》`,
+      mergePart: `${label} ${delta}`.trim(),
+      mergeTail: pageUrl(r),
+      // 单条时的形态；与合并后保持一致的措辞
+      line: `你的《${pageLabel(r)}》${`${label} ${delta}`.trim()}  ${pageUrl(r)}`
     });
   }
 
@@ -1198,6 +1268,8 @@ async function collectCandidates(
       dedupeKey: `uaa:${r.id}:${r.revisionId ?? r.pageVersionId ?? 'n'}`,
       userId: Number(r.followerId),
       detectedAt: new Date(String(r.detectedAt)),
+      // 同一作者对同一页面的多次动作合并成一条，末尾标条数
+      groupKey: `follow:${r.targetUserId ?? who}:${r.pageWikidotId ?? r.pageId}`,
       line: `${who} ${what}《${pageLabel(r)}》  ${pageUrl(r)}`
     });
   }
@@ -1222,6 +1294,8 @@ async function collectCandidates(
       dedupeKey: `fia:${r.id}`,
       userId: Number(r.recipientUserId),
       detectedAt: new Date(String(r.detectedAt)),
+      // 同一话题里的多条互动合并成一条，末尾标条数
+      groupKey: `forum:${r.threadId ?? r.postId}`,
       line: `${actor} ${verb} ${title}`.trim()
     });
   }

--- a/backend/src/jobs/NotificationDispatchJob.ts
+++ b/backend/src/jobs/NotificationDispatchJob.ts
@@ -982,13 +982,24 @@ async function resumeScheduledBatches(
     const replayKeys = stillPending.map((r) => r.dedupeKey);
     const shown = stillPending.slice(0, CIRCUIT_USER_MAX);
     const overflow = stillPending.length - shown.length;
-    const itemLines = shown.map((r) => {
+    // 从 payload 还原**完整的**合并信息，而不是只取 line。
+    // 只取 line 的话，首次已经合并成一行的内容在重发时会重新摊回多行 ——
+    // 用户会看到「同一批通知第二次来的时候变样了」。
+    // 这些字段正是占位时特意存下来的，不用就白存了。
+    const asStr = (v: unknown) => (typeof v === 'string' && v ? v : undefined);
+    const items: MergeItem[] = shown.map((r) => {
       const payload = (r.payload ?? {}) as Record<string, unknown>;
-      return typeof payload.line === 'string' ? payload.line : '(内容缺失)';
+      return {
+        line: asStr(payload.line) ?? '(内容缺失)',
+        groupKey: asStr(payload.groupKey),
+        mergeHead: asStr(payload.mergeHead),
+        mergePart: asStr(payload.mergePart),
+        mergeTail: asStr(payload.mergeTail)
+      };
     });
     // digestKey 保持不变：即使内容因取消已读而变短，机器人仍按 key 去重，
     // 「上次其实已送达」的情况照样能被挡住。
-    const message = renderDigestLines(itemLines, overflow);
+    const message = renderMerged(items, overflow);
 
     if (dryRun) {
       console.log(`[notify][dry-run] 重发 → ${target.wikidotId}（${stillPending.length} 条，第 ${resumeRound} 轮重发，今日第 ${sentToday + 1} 条）\n${message}\n`);
@@ -1250,6 +1261,7 @@ async function collectCandidates(
     SELECT ua.id, ua.type, ua."detectedAt", ua."followerId", ua."revisionId", ua."pageVersionId",
            p."wikidotId" AS "pageWikidotId", p."currentUrl" AS "pageUrl",
            pv.title AS "pageTitle", pv."alternateTitle" AS "pageAlternateTitle",
+           ua."targetUserId" AS "targetUserId",
            tu."displayName" AS "targetName"
     FROM "UserActivityAlert" ua
     JOIN "Page" p ON p.id = ua."pageId"
@@ -1269,7 +1281,9 @@ async function collectCandidates(
       userId: Number(r.followerId),
       detectedAt: new Date(String(r.detectedAt)),
       // 同一作者对同一页面的多次动作合并成一条，末尾标条数
-      groupKey: `follow:${r.targetUserId ?? who}:${r.pageWikidotId ?? r.pageId}`,
+      // 必须用 targetUserId 而非显示名：两个被关注者若同名（或都没有显示名），
+      // 在同一页面上的动态会被误合并成一条，后一个人的动态直接消失。
+      groupKey: `follow:${r.targetUserId ?? 'unknown'}:${r.pageWikidotId ?? r.pageId}`,
       line: `${who} ${what}《${pageLabel(r)}》  ${pageUrl(r)}`
     });
   }

--- a/backend/tests/digestMerge.test.ts
+++ b/backend/tests/digestMerge.test.ts
@@ -51,3 +51,31 @@ test('溢出提示仍保留', () => {
   const out = renderMerged([{ line: 'x' }], 5);
   assert.match(out, /…另有 5 条/);
 });
+
+test('重发路径还原 payload 后应与首次渲染一致（review P2）', () => {
+  // 模拟首次：三条同页指标
+  const first = renderMerged([
+    { line: 'l1', groupKey: 'page:1', mergeHead: '你的《X》', mergePart: '投票 +1', mergeTail: 'u' },
+    { line: 'l2', groupKey: 'page:1', mergeHead: '你的《X》', mergePart: '评论 +2', mergeTail: 'u' }
+  ], 0);
+  // 模拟重发：从 payload 还原（这正是 resumeScheduledBatches 现在做的）
+  const payloads = [
+    { line: 'l1', groupKey: 'page:1', mergeHead: '你的《X》', mergePart: '投票 +1', mergeTail: 'u' },
+    { line: 'l2', groupKey: 'page:1', mergeHead: '你的《X》', mergePart: '评论 +2', mergeTail: 'u' }
+  ];
+  const replay = renderMerged(payloads, 0);
+  assert.equal(replay, first, '重发渲染必须与首次一致，否则用户会看到同一批通知第二次变样');
+  assert.equal(replay.split('\n').filter((l) => l.startsWith('· ')).length, 1);
+});
+
+test('同名被关注者的动态不得被合并（review P2）', () => {
+  // groupKey 用稳定 id 区分；若退回用显示名，两条会并成一条且丢掉后者
+  const out = renderMerged([
+    { line: 'A 编辑了《P》', groupKey: 'follow:1001:9' },
+    { line: 'B 编辑了《P》', groupKey: 'follow:1002:9' }
+  ], 0);
+  const body = out.split('\n').filter((l) => l.startsWith('· '));
+  assert.equal(body.length, 2, '不同被关注者应各占一行');
+  assert.ok(body.some((l) => l.includes('A 编辑了')));
+  assert.ok(body.some((l) => l.includes('B 编辑了')));
+});

--- a/backend/tests/digestMerge.test.ts
+++ b/backend/tests/digestMerge.test.ts
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderMerged } from '../src/jobs/NotificationDispatchJob.js';
+
+const URL1 = 'https://scpper.mer.run/page/1234567';
+
+test('同一页面的多个指标合并成一行', () => {
+  const out = renderMerged([
+    { line: 'x', groupKey: 'page:1234567', mergeHead: '你的《SCP-CN-1000（大门）》', mergePart: '投票 +12', mergeTail: URL1 },
+    { line: 'x', groupKey: 'page:1234567', mergeHead: '你的《SCP-CN-1000（大门）》', mergePart: '评论 +3', mergeTail: URL1 },
+    { line: 'x', groupKey: 'page:1234567', mergeHead: '你的《SCP-CN-1000（大门）》', mergePart: '编辑 +1', mergeTail: URL1 }
+  ], 0);
+  const body = out.split('\n').filter((l) => l.startsWith('· '));
+  assert.equal(body.length, 1, '三条应合并为一行');
+  assert.match(body[0]!, /投票 \+12、评论 \+3、编辑 \+1/);
+  assert.ok(body[0]!.includes(URL1));
+});
+
+test('不同页面不合并', () => {
+  const out = renderMerged([
+    { line: 'a', groupKey: 'page:1', mergeHead: '你的《A》', mergePart: '投票 +1', mergeTail: 'u1' },
+    { line: 'b', groupKey: 'page:2', mergeHead: '你的《B》', mergePart: '投票 +2', mergeTail: 'u2' }
+  ], 0);
+  assert.equal(out.split('\n').filter((l) => l.startsWith('· ')).length, 2);
+});
+
+test('不可拼接的同组用「（N 条）」收敛', () => {
+  const out = renderMerged([
+    { line: 'Sven 回复了你 「话题」', groupKey: 'forum:9' },
+    { line: 'Sven 回复了你 「话题」', groupKey: 'forum:9' }
+  ], 0);
+  const body = out.split('\n').filter((l) => l.startsWith('· '));
+  assert.equal(body.length, 1);
+  assert.match(body[0]!, /（2 条）$/);
+});
+
+test('无 groupKey 的历史数据各自成行', () => {
+  const out = renderMerged([{ line: 'x' }, { line: 'y' }], 0);
+  assert.equal(out.split('\n').filter((l) => l.startsWith('· ')).length, 2);
+});
+
+test('文案要求：品牌小写、无「你有新的站点动态」、无「查看全部」', () => {
+  const out = renderMerged([{ line: 'x' }], 0);
+  assert.ok(out.includes('【scpper-cn】'), '应含小写品牌串');
+  assert.ok(!out.includes('SCPper CN'), '不应含旧的大写品牌串');
+  assert.ok(!out.includes('你有新的站点动态'), '不应含该提示语');
+  assert.ok(!out.includes('查看全部'), '不应含查看全部');
+});
+
+test('溢出提示仍保留', () => {
+  const out = renderMerged([{ line: 'x' }], 5);
+  assert.match(out, /…另有 5 条/);
+});


### PR DESCRIPTION
按使用反馈调整 QQ 推送摘要：

1. 去掉「查看全部：<url>」尾行
2. 品牌串改为小写 `scpper-cn`
3. 去掉「你有新的站点动态：」提示语
4. **同一页面的多条变动合并成一行**

第 4 项是结构性的。原先一个页面被评论、投票、编辑会各产生一条告警，
推送时三行都在说同一个页面：

```
· 你的《SCP-CN-1000》评论有变化 +3   链接
· 你的《SCP-CN-1000》投票有变化 +12  链接
· 你的《SCP-CN-1000》编辑有变化 +1   链接
```

现在按 groupKey 分组后：

```
【scpper-cn】

· 你的《SCP-CN-1000（大门）》投票 +12、评论 +3、编辑 +1  https://scpper.mer.run/page/1234567
· Sven 回复了你 「关于收容措施的讨论」（2 条）
```

- 页面指标**可拼接** → 同页不同指标并成一行
- 关注/论坛**不可拼接** → 同组只出一行，末尾标「（N 条）」

合并字段一并写进 `payload`，重发路径才能渲染出与首次一致的格式；
没有 `groupKey` 的历史行退回逐行展示，不影响已落库的数据。

新增 `tests/digestMerge.test.ts`（6 例）覆盖合并、不合并、计数收敛、
历史数据兼容，以及上述四项文案要求。

🤖 Generated with [Claude Code](https://claude.com/claude-code)