### PR TITLE
chore: 暂时下线 QQ 通知与绑定功能（可逆，不删数据）

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -49,3 +49,11 @@ NOTIFY_SITE_BASE=https://scpper.mer.run
 # ---- Wikidot 绑定校验（pm2: scpper-binding-verify）----
 USER_BACKEND_BASE_URL=http://127.0.0.1:4455
 INTERNAL_API_KEY=
+
+# QQ 通知总开关（2026-07-30 起该功能暂时下线，默认关闭）
+# 置 1 才会真正投递。恢复时**三处都要开**：
+#   backend/.env（本文件，控制投递器）
+#   user-backend/.env（控制绑定接口）
+#   前端构建期 QQ_NOTIFY_ENABLED / 运行时 NUXT_PUBLIC_QQ_NOTIFY_ENABLED
+# 只开其中一两处会出现「界面能绑定但永远收不到消息」这类半开状态。
+QQ_NOTIFY_ENABLED=0

--- a/backend/src/cli/notify-dispatch.ts
+++ b/backend/src/cli/notify-dispatch.ts
@@ -75,8 +75,12 @@ export async function runNotifyDispatchLoop(options: LoopOptions): Promise<void>
       });
       pendingReset = false;
       const ms = Date.now() - startedAt;
-      // 无事可做的轮次不打日志，否则每分钟一行会把 pm2 日志刷满
-      if (summary.candidates > 0 || summary.circuitTripped || summary.skippedReason) {
+      // 无事可做的轮次不打日志，否则每分钟一行会把 pm2 日志刷满。
+      // feature_disabled 要单独排除：功能下线时**每一轮**都会带上这个
+      // skippedReason，照原样打就是每分钟一行刷到底 —— 正好破坏了上面这条本意。
+      // 它只需在投递器首轮提示一次（那次由 job 内部打印），之后保持安静。
+      const quietSkip = summary.skippedReason === 'feature_disabled';
+      if (!quietSkip && (summary.candidates > 0 || summary.circuitTripped || summary.skippedReason)) {
         console.log(`[notify] ${reason} 完成（${ms}ms）：${formatSummary(summary)}`);
       }
     } catch (error) {

--- a/backend/src/jobs/NotificationDispatchJob.ts
+++ b/backend/src/jobs/NotificationDispatchJob.ts
@@ -199,11 +199,31 @@ export interface DispatchSummary {
   skippedReason?: string;
 }
 
+/**
+ * QQ 通知总开关（2026-07-30 起该功能暂时下线）。
+ *
+ * 这是**代码级**的闸门，不是靠「PM2 里那个进程现在是停的」。
+ * 只靠进程状态挡不住：一次常规的 `pm2 start ecosystem.config.cjs`、
+ * 或者机器重启后从旧 dump 恢复，投递器就会重新跑起来开始推消息 ——
+ * 而此时界面上明明写着「不会推送」。关掉一个功能，得让它**跑起来也不干活**。
+ *
+ * 与 user-backend、前端的同名变量是同一套语义，恢复时三处一起开。
+ */
+const QQ_NOTIFY_ENABLED = /^(1|true|yes|on)$/i.test(process.env.QQ_NOTIFY_ENABLED ?? '');
+
 export async function runNotificationDispatch(options: DispatchOptions = {}): Promise<DispatchSummary> {
   const prisma = getPrismaClient();
   const summary: DispatchSummary = {
     targets: 0, candidates: 0, sent: 0, suppressed: 0, failed: 0, circuitTripped: false
   };
+
+  // 功能已下线：什么都不做，直接返回空结果。
+  // 放在最前面（早于 --reset-circuit 等任何写操作），保证这条路径完全无副作用。
+  if (!QQ_NOTIFY_ENABLED) {
+    summary.skippedReason = 'feature_disabled';
+    console.warn('[notify] QQ 通知功能已下线（QQ_NOTIFY_ENABLED 未开启），本轮不做任何处理');
+    return summary;
+  }
 
   if (options.resetCircuit) {
     // 这里是**最先**执行的一处熔断写操作，必须自己带 dry-run 判断 ——

--- a/backend/src/jobs/NotificationDispatchJob.ts
+++ b/backend/src/jobs/NotificationDispatchJob.ts
@@ -207,9 +207,18 @@ export interface DispatchSummary {
  * 或者机器重启后从旧 dump 恢复，投递器就会重新跑起来开始推消息 ——
  * 而此时界面上明明写着「不会推送」。关掉一个功能，得让它**跑起来也不干活**。
  *
- * 与 user-backend、前端的同名变量是同一套语义，恢复时三处一起开。
+ * 与 user-backend、前端的同名变量是同一套语义，恢复时三处一起开 ——
+ * 注意 backend 有**自己的** .env，不会读到 user-backend/.env 里那份。
+ *
+ * 写成函数而不是模块级常量：投递器启动过程中还会通过 ensureUserBackendEnv()
+ * 再加载一批环境变量，模块加载时就定死的话，那之后才就位的配置一律读不到。
  */
-const QQ_NOTIFY_ENABLED = /^(1|true|yes|on)$/i.test(process.env.QQ_NOTIFY_ENABLED ?? '');
+function qqNotifyEnabled(): boolean {
+  return /^(1|true|yes|on)$/i.test(process.env.QQ_NOTIFY_ENABLED ?? '');
+}
+
+/** 「功能已下线」这条只在**首次**打印，避免 60 秒一轮刷屏 */
+let disabledNoticeLogged = false;
 
 export async function runNotificationDispatch(options: DispatchOptions = {}): Promise<DispatchSummary> {
   const prisma = getPrismaClient();
@@ -219,9 +228,14 @@ export async function runNotificationDispatch(options: DispatchOptions = {}): Pr
 
   // 功能已下线：什么都不做，直接返回空结果。
   // 放在最前面（早于 --reset-circuit 等任何写操作），保证这条路径完全无副作用。
-  if (!QQ_NOTIFY_ENABLED) {
+  if (!qqNotifyEnabled()) {
     summary.skippedReason = 'feature_disabled';
-    console.warn('[notify] QQ 通知功能已下线（QQ_NOTIFY_ENABLED 未开启），本轮不做任何处理');
+    // 只提示一次。这个分支存在的意义正是「进程被误拉起来」，
+    // 而那种情况下循环每 60 秒走一次这里 —— 每轮两行日志会一直刷下去。
+    if (!disabledNoticeLogged) {
+      disabledNoticeLogged = true;
+      console.warn('[notify] QQ 通知功能已下线（QQ_NOTIFY_ENABLED 未开启），本轮及后续轮次均不做任何处理');
+    }
     return summary;
   }
 

--- a/frontend/components/account/NotificationSettingsPanel.vue
+++ b/frontend/components/account/NotificationSettingsPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import { useRuntimeConfig } from 'nuxt/app'
+import { useQqNotifyEnabled } from '~/composables/useQqNotifyEnabled'
 import { useAlertSettings, type RevisionFilterOption } from '~/composables/useAlertSettings'
 import { useAuth } from '~/composables/useAuth'
 import { ALERT_METRICS, type AlertMetric } from '~/composables/useAlerts'
@@ -43,7 +43,7 @@ watch(preferences, (p) => {
 }, { immediate: true, deep: true })
 
 // QQ 通知总开关（2026-07-30 暂时下线）。关掉时不显示推送渠道一节。
-const qqNotifyEnabled = computed(() => Boolean(useRuntimeConfig().public.qqNotifyEnabled))
+const qqNotifyEnabled = useQqNotifyEnabled()
 const qqBound = computed(() => Boolean(user.value?.qqBinding?.bound))
 const qqMask = computed(() => user.value?.qqBinding?.addressMask ?? null)
 /**

--- a/frontend/components/account/NotificationSettingsPanel.vue
+++ b/frontend/components/account/NotificationSettingsPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import { useRuntimeConfig } from 'nuxt/app'
 import { useAlertSettings, type RevisionFilterOption } from '~/composables/useAlertSettings'
 import { useAuth } from '~/composables/useAuth'
 import { ALERT_METRICS, type AlertMetric } from '~/composables/useAlerts'
@@ -41,6 +42,8 @@ watch(preferences, (p) => {
   ignoreSelfRevision.value = p.ignoreLinkedWikidotSelfRevision
 }, { immediate: true, deep: true })
 
+// QQ 通知总开关（2026-07-30 暂时下线）。关掉时不显示推送渠道一节。
+const qqNotifyEnabled = computed(() => Boolean(useRuntimeConfig().public.qqNotifyEnabled))
 const qqBound = computed(() => Boolean(user.value?.qqBinding?.bound))
 const qqMask = computed(() => user.value?.qqBinding?.addressMask ?? null)
 /**
@@ -110,7 +113,7 @@ onMounted(() => {
       <section>
         <h3 class="text-sm font-semibold text-[rgb(var(--fg))]">接收哪些提醒</h3>
         <p class="mt-0.5 text-xs text-[rgb(var(--muted))]">
-          关掉后将不再产生这类提醒，站内与 QQ 都不会收到。
+          关掉后将不再产生这类提醒{{ qqNotifyEnabled ? '，站内与 QQ 都不会收到' : '' }}。
         </p>
         <div class="mt-3 divide-y divide-[rgb(var(--panel-border))] rounded-lg border border-[rgb(var(--panel-border))]">
           <label
@@ -202,8 +205,9 @@ onMounted(() => {
         </div>
       </section>
 
-      <!-- ③ 推送渠道 -->
-      <section>
+      <!-- ③ 推送渠道。整节的意义就是 QQ（站内那行只是「始终开启」的说明），
+           功能下线时整节隐藏，留一行「站内始终开启」反而让人以为漏了什么。 -->
+      <section v-if="qqNotifyEnabled">
         <h3 class="text-sm font-semibold text-[rgb(var(--fg))]">推送渠道</h3>
         <p class="mt-0.5 text-xs text-[rgb(var(--muted))]">
           站内提醒始终开启。绑定 QQ 后可额外通过私信接收。

--- a/frontend/components/account/QqBindingPanel.vue
+++ b/frontend/components/account/QqBindingPanel.vue
@@ -95,7 +95,15 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="rounded-lg border border-neutral-200 bg-neutral-50 p-4 space-y-4 dark:border-neutral-700 dark:bg-neutral-800">
+  <!-- 功能下线时只对「还有事要收尾」的人渲染：已绑定的要能解绑，
+       绑定进行中的要能取消。其余人整块不渲染（连边框都不留）。
+       条件放在根元素而不是外层页面：组件照常挂载，onMounted 的
+       /qq-binding/status 仍会执行 —— 「绑定进行中」只有它知道，
+       上层的 /auth/me 此时报的是 bound=false。 -->
+  <div
+    v-if="qqNotifyEnabled || isBound || hasActiveChallenge"
+    class="rounded-lg border border-neutral-200 bg-neutral-50 p-4 space-y-4 dark:border-neutral-700 dark:bg-neutral-800"
+  >
     <div class="flex items-center justify-between gap-3">
       <div>
         <h3 class="text-sm font-semibold text-neutral-800 dark:text-neutral-100">QQ 通知</h3>
@@ -273,12 +281,6 @@ onBeforeUnmount(() => {
       </button>
     </template>
 
-    <!-- 未绑定 + 功能已下线：只说明情况，不给发起入口 -->
-    <template v-else-if="!qqNotifyEnabled">
-      <p class="text-sm text-neutral-600 dark:text-neutral-300">
-        QQ 通知功能暂时关闭，目前无法绑定。
-      </p>
-    </template>
 
     <!-- 未绑定 -->
     <template v-else>

--- a/frontend/components/account/QqBindingPanel.vue
+++ b/frontend/components/account/QqBindingPanel.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { useRuntimeConfig } from 'nuxt/app'
+import { useQqNotifyEnabled } from '~/composables/useQqNotifyEnabled'
 import { useQqBinding } from '~/composables/useQqBinding'
 
 // QQ 通知总开关（2026-07-30 暂时下线）。关闭时本面板只对**已绑定**用户显示，
 // 且只保留解绑；发起新绑定的入口一律不给。
-const qqNotifyEnabled = computed(() => Boolean(useRuntimeConfig().public.qqNotifyEnabled))
+const qqNotifyEnabled = useQqNotifyEnabled()
 
 const {
   binding,

--- a/frontend/components/account/QqBindingPanel.vue
+++ b/frontend/components/account/QqBindingPanel.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRuntimeConfig } from 'nuxt/app'
 import { useQqBinding } from '~/composables/useQqBinding'
+
+// QQ 通知总开关（2026-07-30 暂时下线）。关闭时本面板只对**已绑定**用户显示，
+// 且只保留解绑；发起新绑定的入口一律不给。
+const qqNotifyEnabled = computed(() => Boolean(useRuntimeConfig().public.qqNotifyEnabled))
 
 const {
   binding,
@@ -118,6 +123,11 @@ onBeforeUnmount(() => {
 
     <!-- 已绑定 -->
     <template v-else-if="isBound">
+      <!-- 功能下线期间要说清楚：绑定还在，但不会再推送。
+           不说的话用户会以为推送仍在正常工作，只是没有新动态。 -->
+      <p v-if="!qqNotifyEnabled" class="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+        QQ 通知功能已暂时关闭，目前不会推送任何消息。绑定仍保留，功能恢复后无需重新绑定；也可以在下方解绑。
+      </p>
       <div class="rounded-xl border border-neutral-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-900/30">
         <div class="flex items-center justify-between gap-3">
           <div class="min-w-0">
@@ -261,6 +271,13 @@ onBeforeUnmount(() => {
       >
         {{ loading ? '生成中…' : '重新生成验证码' }}
       </button>
+    </template>
+
+    <!-- 未绑定 + 功能已下线：只说明情况，不给发起入口 -->
+    <template v-else-if="!qqNotifyEnabled">
+      <p class="text-sm text-neutral-600 dark:text-neutral-300">
+        QQ 通知功能暂时关闭，目前无法绑定。
+      </p>
     </template>
 
     <!-- 未绑定 -->

--- a/frontend/components/account/QqBindingPanel.vue
+++ b/frontend/components/account/QqBindingPanel.vue
@@ -266,12 +266,27 @@ onBeforeUnmount(() => {
     <!-- 码已过期 -->
     <template v-else-if="isExpired || (hasActiveChallenge && !plainCode)">
       <div class="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
-        <template v-if="isExpired">验证码已过期，请重新生成。</template>
+        <template v-if="!qqNotifyEnabled">
+          QQ 通知功能已暂时关闭，这次绑定无法继续。可以在下方取消它。
+        </template>
+        <template v-else-if="isExpired">验证码已过期，请重新生成。</template>
         <template v-else>
           上次生成的验证码没有显示在本页（可能是在其他设备或刷新前生成的）。请重新生成一个。
         </template>
       </div>
+      <!-- 功能关闭时给「取消」而不是「重新生成」：后者调的 /start 现在恒返回 503，
+           摆一个必然失败的按钮等于把人卡在这里 —— 而 /cancel 是刻意留着的。 -->
       <button
+        v-if="!qqNotifyEnabled"
+        type="button"
+        class="w-full rounded-lg border border-neutral-300 px-4 py-2 text-sm text-neutral-700 hover:bg-neutral-100 disabled:opacity-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-700"
+        :disabled="loading"
+        @click="cancel()"
+      >
+        {{ loading ? '处理中…' : '取消绑定' }}
+      </button>
+      <button
+        v-else
         type="button"
         class="w-full rounded-lg bg-neutral-900 px-4 py-2 text-sm text-white hover:bg-neutral-800 disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-200"
         :disabled="loading"

--- a/frontend/composables/useQqNotifyEnabled.ts
+++ b/frontend/composables/useQqNotifyEnabled.ts
@@ -1,0 +1,26 @@
+import { computed, type ComputedRef } from 'vue'
+import { useRuntimeConfig } from 'nuxt/app'
+
+/**
+ * QQ 通知与绑定的总开关（2026-07-30 起该功能暂时下线）。
+ *
+ * 【为什么不直接 Boolean(config.qqNotifyEnabled)】
+ * 构建期它是布尔，但运行时用 NUXT_PUBLIC_QQ_NOTIFY_ENABLED 覆盖时，
+ * Nuxt 给到的是**字符串**。于是 Boolean('false') === true ——
+ * 想用运行时变量把一个已开启的构建关掉，反而会一直是开着的，
+ * 而这恰恰是回滚时最需要它正确的时候。
+ *
+ * 三个用到开关的地方（账号页、QqBindingPanel、NotificationSettingsPanel）
+ * 共用这里，避免各写一份解析而写歪。
+ */
+export function useQqNotifyEnabled(): ComputedRef<boolean> {
+  return computed(() => normalizeFlag(useRuntimeConfig().public.qqNotifyEnabled))
+}
+
+/** 布尔按原样；字符串只认明确的真值词，其余（含 'false'、''）一律为假 */
+export function normalizeFlag(value: unknown): boolean {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') return value === 1
+  if (typeof value === 'string') return /^(1|true|yes|on)$/i.test(value.trim())
+  return false
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -82,7 +82,19 @@ export default defineNuxtConfig({
       bffBase: process.env.BFF_BASE || '/api',
       debugFetchTimings: envBoolean(process.env.DEBUG_FETCH_TIMINGS, false),
       debugFetchMinDurationMs: envNumber(process.env.DEBUG_FETCH_MIN_DURATION_MS, 0),
-      slowFetchThresholdMs: envNumber(process.env.SLOW_FETCH_THRESHOLD_MS, 800)
+      slowFetchThresholdMs: envNumber(process.env.SLOW_FETCH_THRESHOLD_MS, 800),
+      // QQ 通知与绑定的总开关。2026-07-30 暂时下线该功能：
+      // 关掉后账号页不再显示 QQ 绑定入口，通知设置里也不再有「推送渠道」一节。
+      // 数据一律保留（下线时库里有 19 条 ACTIVE 绑定），不需要重新绑定。
+      //
+      // 恢复时注意变量名有两个，别混：
+      //  · 构建期：QQ_NOTIFY_ENABLED=1 npm run build
+      //  · 运行时：NUXT_PUBLIC_QQ_NOTIFY_ENABLED=true（Nuxt 只认 NUXT_PUBLIC_ 前缀）
+      //    —— 已构建好的产物只能用这个覆盖；用 QQ_NOTIFY_ENABLED 会**静默无效**，
+      //    实测过：设了它 payload 里仍然是 false。
+      //  · user-backend 侧另有 QQ_NOTIFY_ENABLED 控制绑定接口，两处要一起开。
+      //  · 还要 pm2 start scpper-notify 才会真正开始投递。
+      qqNotifyEnabled: envBoolean(process.env.QQ_NOTIFY_ENABLED, false)
     }
   },
   nitro: {

--- a/frontend/pages/account/index.vue
+++ b/frontend/pages/account/index.vue
@@ -125,9 +125,11 @@
           <!-- QQ 通知渠道绑定。与 Wikidot 绑定并列，同属「账号绑定」一栏：
                用户找绑定入口一定先来「资料」页，放这里比塞进提醒设置里好找。
                2026-07-30 起由 qqNotifyEnabled 总开关控制，功能暂时下线。
-               下线时仍对**已绑定**用户保留这一块：后端刻意留着 /unbind、/cancel，
-               而这个面板是唯一能调用它们的界面 —— 一起藏掉的话，
-               「随时可以解绑」就成了一句空话，人被困在里面。 -->
+               下线时仍要保住 /unbind、/cancel 的入口：这个面板是唯一能调用它们的界面，
+               一起藏掉的话「随时可以解绑」就是空话，人被困在里面。
+               标题行按 /auth/me 的 bound 判断即可；面板本身**始终挂载**，
+               由它自己决定渲染什么 —— 因为「绑定进行中」只有 /qq-binding/status
+               才知道，/auth/me 此时报的是 bound=false，在这里判会把这些人挡在外面。 -->
           <template v-if="qqNotifyEnabled || user?.qqBinding?.bound">
           <div class="flex items-center justify-between pt-2">
             <div>
@@ -141,8 +143,8 @@
               未绑定
             </div>
           </div>
-          <QqBindingPanel />
           </template>
+          <QqBindingPanel />
         </div>
       </div>
     </section>

--- a/frontend/pages/account/index.vue
+++ b/frontend/pages/account/index.vue
@@ -263,13 +263,13 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { useQqNotifyEnabled } from '~/composables/useQqNotifyEnabled'
 import { navigateTo } from 'nuxt/app'
 import { useRoute } from 'vue-router'
 import UserAvatar from '~/components/UserAvatar.vue'
 import PageCard from '~/components/PageCard.vue'
 import AppearanceSettings from '~/components/account/AppearanceSettings.vue'
 import CollectionManager from '~/components/collections/CollectionManager.vue'
-import { useRuntimeConfig } from 'nuxt/app'
 import { useAuth } from '~/composables/useAuth'
 import { useAlerts, type AlertItem, type AlertMetric } from '~/composables/useAlerts'
 import { useAlertSettings, type RevisionFilterOption } from '~/composables/useAlertSettings'
@@ -286,7 +286,7 @@ const { user, fetchCurrentUser, updateProfile, changePassword, status, logout } 
 // QQ 通知与绑定的总开关（2026-07-30 暂时下线该功能）。
 // 关掉时账号页不显示绑定入口，「通知设置」里也不显示 QQ 渠道那一列。
 // 现有绑定数据一律保留，置 QQ_NOTIFY_ENABLED=1 并重启即恢复。
-const qqNotifyEnabled = computed(() => Boolean(useRuntimeConfig().public.qqNotifyEnabled))
+const qqNotifyEnabled = useQqNotifyEnabled()
 
 const { favoritePages, removePageFavorite } = useFavorites()
 const { hydratePages: hydrateViewerVotes } = useViewerVotes()

--- a/frontend/pages/account/index.vue
+++ b/frontend/pages/account/index.vue
@@ -123,7 +123,9 @@
           <WikidotBindingPanel v-else />
 
           <!-- QQ 通知渠道绑定。与 Wikidot 绑定并列，同属「账号绑定」一栏：
-               用户找绑定入口一定先来「资料」页，放这里比塞进提醒设置里好找。 -->
+               用户找绑定入口一定先来「资料」页，放这里比塞进提醒设置里好找。
+               2026-07-30 起由 qqNotifyEnabled 总开关控制，功能暂时下线。 -->
+          <template v-if="qqNotifyEnabled">
           <div class="flex items-center justify-between pt-2">
             <div>
               <div class="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">QQ 绑定</div>
@@ -137,6 +139,7 @@
             </div>
           </div>
           <QqBindingPanel />
+          </template>
         </div>
       </div>
     </section>
@@ -263,6 +266,7 @@ import UserAvatar from '~/components/UserAvatar.vue'
 import PageCard from '~/components/PageCard.vue'
 import AppearanceSettings from '~/components/account/AppearanceSettings.vue'
 import CollectionManager from '~/components/collections/CollectionManager.vue'
+import { useRuntimeConfig } from 'nuxt/app'
 import { useAuth } from '~/composables/useAuth'
 import { useAlerts, type AlertItem, type AlertMetric } from '~/composables/useAlerts'
 import { useAlertSettings, type RevisionFilterOption } from '~/composables/useAlertSettings'
@@ -275,6 +279,11 @@ import { useViewerVotes } from '~/composables/useViewerVotes'
 import { orderTags } from '~/composables/useTagOrder'
 
 const { user, fetchCurrentUser, updateProfile, changePassword, status, logout } = useAuth()
+
+// QQ 通知与绑定的总开关（2026-07-30 暂时下线该功能）。
+// 关掉时账号页不显示绑定入口，「通知设置」里也不显示 QQ 渠道那一列。
+// 现有绑定数据一律保留，置 QQ_NOTIFY_ENABLED=1 并重启即恢复。
+const qqNotifyEnabled = computed(() => Boolean(useRuntimeConfig().public.qqNotifyEnabled))
 
 const { favoritePages, removePageFavorite } = useFavorites()
 const { hydratePages: hydrateViewerVotes } = useViewerVotes()

--- a/frontend/pages/account/index.vue
+++ b/frontend/pages/account/index.vue
@@ -124,8 +124,11 @@
 
           <!-- QQ 通知渠道绑定。与 Wikidot 绑定并列，同属「账号绑定」一栏：
                用户找绑定入口一定先来「资料」页，放这里比塞进提醒设置里好找。
-               2026-07-30 起由 qqNotifyEnabled 总开关控制，功能暂时下线。 -->
-          <template v-if="qqNotifyEnabled">
+               2026-07-30 起由 qqNotifyEnabled 总开关控制，功能暂时下线。
+               下线时仍对**已绑定**用户保留这一块：后端刻意留着 /unbind、/cancel，
+               而这个面板是唯一能调用它们的界面 —— 一起藏掉的话，
+               「随时可以解绑」就成了一句空话，人被困在里面。 -->
+          <template v-if="qqNotifyEnabled || user?.qqBinding?.bound">
           <div class="flex items-center justify-between pt-2">
             <div>
               <div class="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">QQ 绑定</div>

--- a/user-backend/.env.example
+++ b/user-backend/.env.example
@@ -44,3 +44,8 @@ NOTIFY_CHANNEL_FAILURE_THRESHOLD=3
 QQ_BOT_INTERNAL_KEY=
 # 机器人 QQ 号，仅用于前端引导文案，非密钥
 QQ_BOT_SELF_ID=1248393597
+
+# QQ 通知与绑定总开关（2026-07-30 起暂时下线，默认关闭）
+# 置 1 恢复；前端与 user-backend 两处必须一起开。
+# 现有绑定数据一律保留，无需重新绑定。
+QQ_NOTIFY_ENABLED=0

--- a/user-backend/src/routes/qqBinding.ts
+++ b/user-backend/src/routes/qqBinding.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type Request, type Response, type NextFunction } from 'express';
 import bcrypt from 'bcryptjs';
 import { z } from 'zod';
 import { requireAuth } from '../middleware/requireAuth.js';
@@ -66,6 +66,27 @@ function createErrorResponse(error: unknown) {
 }
 
 /** 用户侧路由（需登录） */
+/**
+ * QQ 通知与绑定的总开关（2026-07-30 起该功能暂时下线）。
+ *
+ * 默认关闭。置 QQ_NOTIFY_ENABLED=1 可恢复，需与前端的同名变量一起开。
+ * 现有绑定数据一律保留（下线时库里有 19 条 ACTIVE），不做任何清理。
+ */
+const QQ_NOTIFY_ENABLED = /^(1|true|yes|on)$/i.test(process.env.QQ_NOTIFY_ENABLED ?? '');
+
+/**
+ * 功能下线时挡住**新建**绑定的路径。
+ *
+ * 只挡新建（/start 与机器人回调 /verify），不挡 /unbind、/cancel ——
+ * 已经绑好的用户必须始终能自己解绑，把退出的路也堵上等于把人困住。
+ * 回调一并挡住是刻意的：验证不通过，机器人会拒绝好友申请，
+ * 这正是我们想要的失败方向（宁可不加好友，也不要建立新绑定）。
+ */
+function requireQqEnabled(_req: Request, res: Response, next: NextFunction) {
+  if (QQ_NOTIFY_ENABLED) return next();
+  return res.status(503).json({ error: 'QQ 通知功能已暂时下线' });
+}
+
 export function qqBindingRouter() {
   const router = Router();
 
@@ -76,7 +97,7 @@ export function qqBindingRouter() {
   });
 
   // 发起绑定：返回明文验证码（**只此一次**，库里只存哈希）
-  router.post('/start', requireAuth, async (req, res) => {
+  router.post('/start', requireQqEnabled, requireAuth, async (req, res) => {
     try {
       if (!req.authUser) return res.status(401).json({ error: '未登录' });
 
@@ -202,7 +223,7 @@ export function qqBindingInternalRouter() {
     next();
   });
 
-  router.post('/verify', async (req, res) => {
+  router.post('/verify', requireQqEnabled, async (req, res) => {
     try {
       const payload = verifySchema.parse(req.body ?? {});
 


### PR DESCRIPTION
按需求暂停 QQ 通知与绑定。采用**开关式停用**而非删代码/删数据 —— 库里已有 19 条 ACTIVE 绑定，日后恢复不应要求用户重新绑定。

## 改动
**前端**：新增 `public.qqNotifyEnabled`（默认 false）；账号页 QQ 绑定入口整块隐藏；通知设置的「推送渠道」整节隐藏；相关文案不再提 QQ。

**user-backend**：新增 `QQ_NOTIFY_ENABLED`（默认关闭）。只挡**新建**路径（`/start` 与机器人回调 `/verify` 返回 503），`/unbind`、`/cancel`、`/status` 照常放行 —— 已绑定用户必须始终能自己解绑。

## 不在本次改动内
- 不删任何数据（绑定 / 投递记录 / 告警 / 偏好全部保留）
- 不删任何代码
- qqbot 服务继续运行

## 验证
- user-backend 门禁双向实测：关闭时 `/start` → 503，开启时 → 401（门禁在 requireAuth 之前，未认证请求即可区分）
- 逃生通道实测：关闭状态下 `/unbind`、`/cancel`、`/status` 返回 401 而非 503
- 前端构建通过；运行时开关双向实测（注意 Nuxt 运行时覆盖须用 `NUXT_PUBLIC_` 前缀，已写入注释）
- typecheck：frontend 0 错、user-backend 0 错（经探针确认检查器有效）

## 运维现状
`scpper-notify` 已停止并 `pm2 save`。库中查得该投递器**从未产生过任何真实投递记录**（冷启动闸门一直生效），停机未中断任何在途消息。

🤖 Generated with [Claude Code](https://claude.com/claude-code)