### PR TITLE
fix: 恢复 SCPPER 站内通知并保持 QQ 关闭

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,12 +7,11 @@ DEBUG_FETCH_TIMINGS=false
 DEBUG_FETCH_MIN_DURATION_MS=0
 SLOW_FETCH_THRESHOLD_MS=800
 
-# 站内提醒阅读界面总开关（默认关闭）
-# 关闭时隐藏铃铛、收件箱与设置入口，并停止前端预取；后端仍保留告警生成，
-# 这样恢复界面后不会丢失暂停期间的历史。QQ 外部投递由下面的独立闸门阻止。
-NOTIFICATIONS_ENABLED=0
+# 站内提醒总开关（默认开启）
+# QQ 绑定与站外投递由下面的独立开关控制，关闭 QQ 不影响站内提醒。
+NOTIFICATIONS_ENABLED=1
 # 已构建产物的运行时覆盖：
-NUXT_PUBLIC_NOTIFICATIONS_ENABLED=false
+NUXT_PUBLIC_NOTIFICATIONS_ENABLED=true
 
 # QQ 新绑定与消息投递总开关（默认关闭）
 # 恢复时还必须同步开启 user-backend/.env、backend/.env，并单独启动投递器。

--- a/frontend/ecosystem.config.cjs
+++ b/frontend/ecosystem.config.cjs
@@ -13,6 +13,9 @@ module.exports = {
         NITRO_PRESET: 'node-server',
         BFF_BASE: process.env.BFF_BASE || '/api',
         BFF_PROXY_TARGET: process.env.BFF_PROXY_TARGET || 'http://127.0.0.1:4396',
+        // 站内提醒默认开启；QQ 绑定与站外投递保持独立关闭。
+        NUXT_PUBLIC_NOTIFICATIONS_ENABLED: process.env.NUXT_PUBLIC_NOTIFICATIONS_ENABLED || 'true',
+        NUXT_PUBLIC_QQ_NOTIFY_ENABLED: process.env.NUXT_PUBLIC_QQ_NOTIFY_ENABLED || 'false',
       },
       instances: 1,
       exec_mode: 'fork',

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -83,14 +83,13 @@ export default defineNuxtConfig({
       debugFetchTimings: envBoolean(process.env.DEBUG_FETCH_TIMINGS, false),
       debugFetchMinDurationMs: envNumber(process.env.DEBUG_FETCH_MIN_DURATION_MS, 0),
       slowFetchThresholdMs: envNumber(process.env.SLOW_FETCH_THRESHOLD_MS, 800),
-      // 站内提醒功能总开关。暂时关闭时隐藏顶栏铃铛，并停止页面、关注和论坛
-      // 提醒的预取与重验证；底层接口和数据保留，便于之后直接恢复。
-      // 后端告警生成会刻意继续运行，以保留暂停期间的历史；QQ 外部投递由
-      // 独立的 QQ_NOTIFY_ENABLED 代码级闸门阻止。
+      // 站内提醒功能总开关，默认开启。仅在站内提醒本身需要紧急维护时才关闭；
+      // QQ 绑定与站外投递由独立的 QQ_NOTIFY_ENABLED 控制，关闭 QQ 不应影响
+      // 顶栏铃铛、提醒收件箱或通知设置。
       //
       //  · 构建期：NOTIFICATIONS_ENABLED=1 npm run build
       //  · 运行时：NUXT_PUBLIC_NOTIFICATIONS_ENABLED=true
-      notificationsEnabled: envBoolean(process.env.NOTIFICATIONS_ENABLED, false),
+      notificationsEnabled: envBoolean(process.env.NOTIFICATIONS_ENABLED, true),
       // QQ 通知与绑定的总开关。2026-07-30 暂时下线该功能：
       // 关掉后账号页不再显示 QQ 绑定入口，通知设置里也不再有「推送渠道」一节。
       // 数据一律保留（下线时库里有 19 条 ACTIVE 绑定），不需要重新绑定。

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -1,14 +1,14 @@
 # Account 浏览器回归
 
 `account-refactor.smoke.cjs` 使用 Playwright 拦截 `/api/*`，验证账号中心的登录边界、
-跨标签账号切换、QQ 暂停状态、收藏夹和移动端交互。测试不会读写真实用户数据。
+跨标签账号切换、站内通知、QQ 暂停状态、收藏夹和移动端交互。测试不会读写真实用户数据。
 
 首次运行：
 
 ```bash
 npm install
 npx playwright install chromium
-NOTIFICATIONS_ENABLED=0 QQ_NOTIFY_ENABLED=0 npm run build
+NOTIFICATIONS_ENABLED=1 QQ_NOTIFY_ENABLED=0 npm run build
 PORT=19876 HOST=127.0.0.1 npm run start
 ```
 
@@ -21,18 +21,15 @@ npm run test:expected-user
 npm run test:expected-user:browser
 ```
 
-恢复功能路径使用同一份构建产物的运行时开关：
+默认矩阵是“站内通知开启、QQ 绑定与投递关闭”。`npm run test:account`
+会验证铃铛、收件箱和通知设置可用，同时 QQ 模块对已绑定用户也完全隐藏。
+
+QQ 恢复路径可使用同一份构建产物的运行时开关单独验证：
 
 ```bash
-NUXT_PUBLIC_NOTIFICATIONS_ENABLED=true \
 NUXT_PUBLIC_QQ_NOTIFY_ENABLED=true \
 PORT=19876 HOST=127.0.0.1 npm run start
 
-ACCOUNT_TEST_NOTIFICATIONS_ENABLED=1 \
-SCENARIO=notification-settings-account-switch-isolated \
-npm run test:account
-
-ACCOUNT_TEST_NOTIFICATIONS_ENABLED=1 \
 ACCOUNT_TEST_QQ_ENABLED=1 \
 SCENARIO=notification-qq-capability-is-server-authoritative \
 npm run test:account
@@ -46,3 +43,7 @@ npm run test:account
 `NUXT_PUBLIC_QQ_NOTIFY_ENABLED=true` 的运行时使用；默认关闭运行时会反向验证服务端
 capability 不能绕过前端总开关。可用 `ACCOUNT_TEST_BASE_URL` 指向其他隔离端口，
 或用 `SCENARIO` 只运行一个场景。
+
+只有在专门验证站内通知紧急维护开关时，才使用
+`NUXT_PUBLIC_NOTIFICATIONS_ENABLED=false` 启动服务，并配合
+`ACCOUNT_TEST_NOTIFICATIONS_ENABLED=0 SCENARIO=legacy-and-paused-routes`。

--- a/frontend/tests/account-refactor.smoke.cjs
+++ b/frontend/tests/account-refactor.smoke.cjs
@@ -5,7 +5,7 @@ const { chromium } = require('playwright')
 
 const baseUrl = process.env.ACCOUNT_TEST_BASE_URL || 'http://127.0.0.1:19876'
 const outputDir = process.env.ACCOUNT_TEST_OUTPUT_DIR || '/tmp/scpper-account-refactor-evidence'
-const notificationsEnabled = process.env.ACCOUNT_TEST_NOTIFICATIONS_ENABLED === '1'
+const notificationsEnabled = process.env.ACCOUNT_TEST_NOTIFICATIONS_ENABLED !== '0'
 const qqFrontendEnabled = process.env.ACCOUNT_TEST_QQ_ENABLED === '1'
 const iso = '2026-07-30T08:00:00.000Z'
 const transparentPng = Buffer.from(
@@ -460,6 +460,15 @@ async function login(page) {
   await page.getByRole('button', { name: '登录', exact: true }).click()
 }
 
+async function settledProfileNameInput(page) {
+  const input = page.getByLabel('昵称', { exact: true })
+  await input.waitFor()
+  // 账号页通过客户端鉴权后才挂载表单。等初始会话与头像等请求稳定，
+  // 避免测试在 hydration/身份重验证尚未结束时抢先填写后被可信快照覆盖。
+  await page.waitForLoadState('networkidle')
+  return input
+}
+
 async function main() {
   fs.mkdirSync(outputDir, { recursive: true })
   const browser = await chromium.launch({ headless: true })
@@ -473,9 +482,23 @@ async function main() {
         await page.goto(`${baseUrl}/account`, { waitUntil: 'domcontentloaded' })
         await page.getByText('playwright@example.com', { exact: true }).waitFor()
         await page.getByRole('heading', { name: '账号概览' }).waitFor()
-        assert.equal(await page.locator('a[href="/notifications"]').count(), 0)
-        assert.equal(await page.locator('a[href="/settings/notifications"]').count(), 0)
-        assert.equal(await page.getByText('通知设置', { exact: true }).count(), 0)
+        const expectedNotificationEntries = notificationsEnabled ? 1 : 0
+        assert.equal(
+          await page.locator('a[href="/notifications"]').count(),
+          expectedNotificationEntries
+        )
+        assert.equal(
+          await page.locator('a[href="/settings/notifications"]').count(),
+          expectedNotificationEntries
+        )
+        assert.equal(
+          await page.locator('option[value="/notifications"]').count(),
+          expectedNotificationEntries
+        )
+        assert.equal(
+          await page.locator('option[value="/settings/notifications"]').count(),
+          expectedNotificationEntries
+        )
         const sectionNavigation = page.locator('#account-section-navigation')
         assert.equal(await sectionNavigation.inputValue(), '/account')
         assert.ok((await sectionNavigation.boundingBox()).height >= 44)
@@ -694,9 +717,8 @@ async function main() {
       { linked: true },
       async (page) => {
         await page.goto(`${baseUrl}/account/profile`, { waitUntil: 'domcontentloaded' })
-        const input = page.getByLabel('昵称', { exact: true })
+        const input = await settledProfileNameInput(page)
         const button = page.getByRole('button', { name: '保存昵称' })
-        await input.waitFor()
         assert.equal(await button.isDisabled(), true)
         await input.fill('新的验收昵称')
         await button.click()
@@ -714,7 +736,7 @@ async function main() {
       { linked: true, malformedProfile: true },
       async (page, requests) => {
         await page.goto(`${baseUrl}/account/profile`, { waitUntil: 'domcontentloaded' })
-        const input = page.getByLabel('昵称', { exact: true })
+        const input = await settledProfileNameInput(page)
         await input.fill('重查后确认的昵称')
         const authReadsBefore = requests.filter(entry => entry.path === '/auth/me').length
         await page.getByRole('button', { name: '保存昵称' }).click()
@@ -733,7 +755,7 @@ async function main() {
       { linked: true, profileResponseLost: true },
       async (page, requests) => {
         await page.goto(`${baseUrl}/account/profile`, { waitUntil: 'domcontentloaded' })
-        const input = page.getByLabel('昵称', { exact: true })
+        const input = await settledProfileNameInput(page)
         const authReadsBefore = requests.filter(entry => entry.path === '/auth/me').length
         const broadcastBefore = await page.evaluate(() => (
           localStorage.getItem('scpper:auth-session-version')
@@ -761,7 +783,7 @@ async function main() {
       { linked: true, profileNetworkSwitch: true },
       async (page) => {
         await page.goto(`${baseUrl}/account/profile`, { waitUntil: 'domcontentloaded' })
-        const input = page.getByLabel('昵称', { exact: true })
+        const input = await settledProfileNameInput(page)
         await input.fill('两个账号碰巧相同的昵称')
         await page.getByRole('button', { name: '保存昵称' }).click()
         await page.getByText('second@example.com', { exact: true }).waitFor()
@@ -808,6 +830,55 @@ async function main() {
     if (notificationsEnabled) {
       await scenario(
         browser,
+        'site-notifications-available-with-qq-hidden',
+        { linked: true, qqBound: true, qqFeatureEnabled: true, qqStatusError: true },
+        async (page, requests) => {
+          await page.goto(`${baseUrl}/account`, { waitUntil: 'domcontentloaded' })
+          await page.getByRole('heading', { name: '账号概览' }).waitFor()
+          const bell = page.getByRole('button', { name: '查看提醒' })
+          await bell.waitFor()
+          await bell.click()
+          await page.locator('#alerts-menu').waitFor()
+          await page.getByRole('heading', { name: '信息提醒' }).waitFor()
+          const accountNavigation = page.getByRole('navigation', {
+            name: '账号中心导航'
+          })
+          assert.equal(
+            await accountNavigation.locator('a[href="/notifications"]').count(),
+            1
+          )
+          assert.equal(
+            await accountNavigation.locator('a[href="/settings/notifications"]').count(),
+            1
+          )
+
+          await page.goto(`${baseUrl}/notifications`, { waitUntil: 'domcontentloaded' })
+          await page.getByRole('heading', { name: '提醒收件箱' }).waitFor()
+          assert.equal(new URL(page.url()).pathname, '/notifications')
+
+          await page.goto(`${baseUrl}/settings/notifications`, {
+            waitUntil: 'domcontentloaded'
+          })
+          await page.getByRole('heading', { name: '页面提醒偏好' }).waitFor()
+          assert.equal(new URL(page.url()).pathname, '/settings/notifications')
+          assert.ok(requests.some(entry => entry.path === '/alerts/preferences'))
+          assert.equal(await page.getByText('推送渠道', { exact: true }).count(), 0)
+          assert.equal(await page.getByText('QQ 私信', { exact: true }).count(), 0)
+
+          await page.goto(`${baseUrl}/account/connections`, {
+            waitUntil: 'domcontentloaded'
+          })
+          await page.getByRole('heading', { name: 'Wikidot 身份', exact: true }).waitFor()
+          assert.equal(await page.getByRole('heading', { name: 'QQ 连接' }).count(), 0)
+          assert.equal(
+            requests.filter(entry => entry.path.startsWith('/qq-binding/')).length,
+            0
+          )
+        }
+      )
+
+      await scenario(
+        browser,
         'notification-settings-account-switch-isolated',
         { linked: true, switchAccount: true, delayFirstPreferences: 900 },
         async (page, requests, context) => {
@@ -833,19 +904,27 @@ async function main() {
         }
       )
 
-      await scenario(
-        browser,
-        'notification-qq-capability-is-server-authoritative',
-        { linked: true, qqBound: true, qqFeatureEnabled: false },
-        async (page) => {
-          await page.goto(`${baseUrl}/settings/notifications`, { waitUntil: 'domcontentloaded' })
-          await page.getByText('功能暂停（当前不会通过 QQ 投递）', { exact: true }).waitFor()
-          assert.equal(
-            await page.getByText('通常在事件发生后一小时内送达。', { exact: false }).count(),
-            0
-          )
-        }
-      )
+      if (qqFrontendEnabled) {
+        await scenario(
+          browser,
+          'notification-qq-capability-is-server-authoritative',
+          { linked: true, qqBound: true, qqFeatureEnabled: false },
+          async (page) => {
+            await page.goto(`${baseUrl}/settings/notifications`, {
+              waitUntil: 'domcontentloaded'
+            })
+            await page.getByText('功能暂停（当前不会通过 QQ 投递）', {
+              exact: true
+            }).waitFor()
+            assert.equal(
+              await page.getByText('通常在事件发生后一小时内送达。', {
+                exact: false
+              }).count(),
+              0
+            )
+          }
+        )
+      }
     }
 
     await scenario(
@@ -1161,7 +1240,7 @@ async function main() {
         assert.equal(await page.getByText('playwright@example.com', { exact: true }).count(), 0)
         assert.equal(await page.getByLabel('昵称', { exact: true }).count(), 0)
         await page.getByText('second@example.com', { exact: true }).waitFor()
-        const input = page.getByLabel('昵称', { exact: true })
+        const input = await settledProfileNameInput(page)
         await input.fill('第二位用户的新昵称')
         await page.getByRole('button', { name: '保存昵称' }).click()
         await page.getByText('昵称已保存。', { exact: true }).waitFor()
@@ -1181,7 +1260,8 @@ async function main() {
       async (page, requests) => {
         await page.goto(`${baseUrl}/account/profile`, { waitUntil: 'domcontentloaded' })
         await page.getByText('playwright@example.com', { exact: true }).waitFor()
-        await page.getByLabel('昵称', { exact: true }).fill('不应写给 B 的昵称')
+        const input = await settledProfileNameInput(page)
+        await input.fill('不应写给 B 的昵称')
 
         // 模拟另一标签页已把共享 Cookie 切到 B，但 storage/focus 通知尚未到达。
         staleWriteOptions.forceServerAccount = 'B'


### PR DESCRIPTION
## Summary

- What changed:
  - 将 SCPPER 站内通知默认值恢复为开启，重新提供顶栏铃铛、提醒收件箱和通知设置。
  - 保持 QQ 绑定与 QQ 站外投递默认关闭；已绑定或 pending 用户也不显示 QQ 模块。
  - 在 Nuxt 构建配置、示例环境变量和 PM2 ecosystem 中显式固定“站内开 / QQ 关”的独立边界。
  - 增加 Playwright 回归，验证站内通知可用、QQ UI 隐藏且不会请求 `/qq-binding/*`。
- Why:
  - PR #181 将 `notificationsEnabled` 的默认值误设为 `false`。生产环境未设置该变量，因此整个站内通知 UI 被错误关闭；实际只应停用 QQ 通知。

## Validation

- [x] Relevant lint / typecheck / tests were run
- [x] Manual verification steps are documented below
- [x] Config / migration / data risks are explained below

Validation completed:

- `NOTIFICATIONS_ENABLED=1 QQ_NOTIFY_ENABLED=0 npm run build`
- `npm run typecheck`
- `npx eslint nuxt.config.ts`
- `npm run test:expected-user`（5/5）
- `npm run test:account` 默认矩阵（站内通知 on / QQ off，完整通过）
- `npm run test:auth-race`（3/3）
- `npm run test:expected-user:browser`（1/1）
- 站内通知紧急关闭路径与 QQ 显式恢复路径单独通过
- SSR runtime payload 验证：`notificationsEnabled:true`、`qqNotifyEnabled:false`
- 浏览器验证：铃铛可打开；`/notifications`、`/settings/notifications` 可访问；已绑定 QQ 的用户仍无 QQ UI，且 0 次 `/qq-binding/*` 请求

已知仓库既有问题：前端全量 lint 仍被 `TagCheckTool.vue` 和 `pages/user/[wikidotId].vue` 的 3 个历史错误阻挡；本 PR 修改文件的定向检查通过。

## Review

- [x] Codex review completed
- [x] Claude Code review completed
- [x] Review findings were resolved or explicitly accepted

Codex 本地独立审查和 PR 级审查均为 CLEAN。Claude Code 已对精确 head `d8f7f8e965c5e8a841811c2317eb251c3c538b52` 完成直接只读复审，结论为 CLEAN；默认、站内紧急关闭与 QQ 显式恢复三组 flag 矩阵均独立通过。

## Deployment

- [ ] This change does not require deployment coordination
- [x] This change will be deployed from the protected `main` checkout
- [x] PM2 target services are listed below if deployment is needed

部署仅影响 `scpper-nuxt`：

1. 从受保护 `main` 构建 frontend，显式使用 `NOTIFICATIONS_ENABLED=1 QQ_NOTIFY_ENABLED=0`。
2. 通过 `frontend/ecosystem.config.cjs` 执行 `pm2 startOrRestart ... --only scpper-nuxt --update-env`，随后 `pm2 save`。
3. 不重启 BFF、user-backend 或 `scpper-sync`；`scpper-notify` 继续保持 stopped。
4. 验证生产 HTML runtime flags、两个通知页面、QQ UI/请求、PM2 状态和健康检查。

## Notes

- Risk: 前端运行时配置与账号导航可见性；无数据库迁移、无数据写入或删除。
- Rollback: 回滚本 PR 并从受保护 `main` 重建/重启 `scpper-nuxt`；QQ 投递器始终保持停止。
- Follow-up: 无。