### PR TITLE
fix: 避免账号页返回前台时出现刷新感

### DIFF
--- a/frontend/components/account/AccountAuthGate.vue
+++ b/frontend/components/account/AccountAuthGate.vue
@@ -8,7 +8,6 @@ const {
   status,
   state,
   loading,
-  sessionVerifying,
   error,
   fetchCurrentUser
 } = useAuth()
@@ -134,29 +133,8 @@ onMounted(() => {
         重试
       </button>
     </div>
-    <div
-      :key="user.id"
-      class="relative"
-      :aria-busy="sessionVerifying"
-    >
-      <div
-        v-if="sessionVerifying"
-        class="absolute inset-0 z-20 flex cursor-wait items-start justify-center rounded-lg bg-[rgb(var(--bg)_/_0.72)] px-4 pt-6 backdrop-blur-[1px]"
-        role="status"
-        aria-live="polite"
-      >
-        <div class="sticky top-24 inline-flex items-center gap-2 rounded-full border border-[rgb(var(--panel-border))] bg-[rgb(var(--panel))] px-4 py-2 text-sm font-medium text-[rgb(var(--muted-strong))] shadow-lg">
-          <LucideIcon
-            name="LoaderCircle"
-            class="h-4 w-4 animate-spin"
-            aria-hidden="true"
-          />
-          正在确认当前账号…
-        </div>
-      </div>
-      <div :inert="sessionVerifying || undefined">
-        <slot :user="user" />
-      </div>
+    <div :key="user.id">
+      <slot :user="user" />
     </div>
   </template>
 

--- a/frontend/composables/useAuth.ts
+++ b/frontend/composables/useAuth.ts
@@ -41,6 +41,15 @@ interface AuthFetchInflight {
   promise: Promise<AuthUser | null>
 }
 
+interface AuthFetchOptions {
+  /**
+   * Passive foreground checks must not replace an already-rendered error card
+   * with the initial loading skeleton. Keep the last error visible until the
+   * request either succeeds or produces a new result.
+   */
+  preserveErrorWhileLoading?: boolean
+}
+
 interface AuthRuntime {
   epoch: number
   activeRequestsByEpoch: Map<number, number>
@@ -94,8 +103,7 @@ function useAuthState() {
   const status = useState<AuthStatus>('auth-status', () => 'unknown')
   const loading = useState<boolean>('auth-loading', () => false)
   const error = useState<string | null>('auth-error', () => null)
-  const sessionVerifying = useState<boolean>('auth-session-verifying', () => false)
-  return { user, status, loading, error, sessionVerifying }
+  return { user, status, loading, error }
 }
 
 const AUTH_SYNC_STORAGE_KEY = 'scpper:auth-session-version'
@@ -269,8 +277,7 @@ export function useAuth() {
     user,
     status,
     loading,
-    error: authError,
-    sessionVerifying
+    error: authError
   } = useAuthState()
   const runtime = getAuthRuntime(nuxtApp)
 
@@ -312,7 +319,7 @@ export function useAuth() {
    * 已在网络中的旧请求仍可结束，但只有当前世代的响应能写入共享状态。
    *
    * mutation 的优先级高于普通 focus/pageshow 验证：它开始时会同步撤销旧验证的
-   * UI 所有权，避免已经被新世代忽略的慢 GET 继续让账号页保持 inert。
+   * 运行时所有权，避免已经被新世代忽略的慢 GET 清理或覆盖后续验证状态。
    */
   function beginIdentityMutation() {
     if (runtime.sessionRevalidation) {
@@ -327,7 +334,6 @@ export function useAuth() {
     runtime.sessionValidationGeneration += 1
     runtime.sessionRevalidation = null
     runtime.sessionRevalidationInvalidatesSnapshot = false
-    sessionVerifying.value = false
 
     const epoch = supersedeCurrentEpoch()
     runtime.activeIdentityMutationEpoch = epoch
@@ -400,7 +406,11 @@ export function useAuth() {
     return responseStatus !== null && responseStatus >= 400 && responseStatus < 500
   }
 
-  async function fetchCurrentUser(force = false, identityMutationEpoch: number | null = null) {
+  async function fetchCurrentUser(
+    force = false,
+    identityMutationEpoch: number | null = null,
+    options: AuthFetchOptions = {}
+  ) {
     if (status.value === 'authenticated' && !authError.value && !force) {
       authDebug('[auth] fetchCurrentUser skip (already authenticated)')
       return user.value
@@ -425,7 +435,9 @@ export function useAuth() {
       return existing.promise
     }
     const requestEpoch = runtime.epoch
-    authError.value = null
+    if (!options.preserveErrorWhileLoading) {
+      authError.value = null
+    }
     beginRequest(requestEpoch)
 
     const requestPromise = (async () => {
@@ -496,9 +508,10 @@ export function useAuth() {
   /**
    * 重新验证浏览器当前 Cookie 对应的账号。
    *
-   * 普通前台恢复会保留最后一次可信快照，但用 sessionVerifying 暂停账号页交互；
+   * 普通前台恢复会在后台保留并校验最后一次可信快照，不遮挡页面或中断用户输入；
    * 收到其他标签页的身份变更通知时则立即清空快照，避免 A 的界面拿 B 的 Cookie
-   * 发出写请求。新通知会开启新世代，旧验证响应无法覆盖最新身份。
+   * 发出写请求。新通知会开启新世代，旧验证响应无法覆盖最新身份。所有私有写
+   * 仍由 expected-user 边界兜底，静默校验期间发生账号切换也不会写入错误账号。
    */
   async function revalidateSession(invalidateSnapshot = false) {
     if (!import.meta.client) return fetchCurrentUser(true)
@@ -528,9 +541,10 @@ export function useAuth() {
     runtime.sessionValidationGeneration += 1
     const validationGeneration = runtime.sessionValidationGeneration
     if (invalidateSnapshot) markSessionUnknown()
-    sessionVerifying.value = true
 
-    const verification = fetchCurrentUser(true)
+    const verification = fetchCurrentUser(true, null, {
+      preserveErrorWhileLoading: !invalidateSnapshot
+    })
     runtime.sessionRevalidation = verification
     runtime.sessionRevalidationInvalidatesSnapshot = invalidateSnapshot
     try {
@@ -539,7 +553,6 @@ export function useAuth() {
       if (runtime.sessionValidationGeneration === validationGeneration) {
         runtime.sessionRevalidation = null
         runtime.sessionRevalidationInvalidatesSnapshot = false
-        sessionVerifying.value = false
       }
     }
   }
@@ -861,6 +874,9 @@ export function useAuth() {
   const state = computed<AuthState>(() => {
     // 强制刷新失败时，最后一份可信用户快照仍可继续使用；error 可用于非阻断提示。
     if (isAuthenticated.value) return 'ready'
+    // 已确认未登录也是一份稳定快照。普通前台校验期间继续显示登录入口，
+    // 只有 hard revalidation 先把 status 置回 unknown 时才进入初始 loading。
+    if (status.value === 'unauthenticated') return 'unauthenticated'
     if (authError.value) return 'error'
     if (loading.value || status.value === 'unknown') return 'loading'
     return 'unauthenticated'
@@ -874,7 +890,6 @@ export function useAuth() {
     status,
     state,
     loading,
-    sessionVerifying,
     error: authError,
     authError,
     isAuthenticated,

--- a/frontend/tests/auth-session-race.cjs
+++ b/frontend/tests/auth-session-race.cjs
@@ -116,6 +116,95 @@ async function prepareProfilePage(browser, apiHandler) {
   return { context, page, pageErrors }
 }
 
+async function verifyResolvedGateStaysStableOnForeground(
+  browser,
+  { label, heading, responseBody, responseStatus }
+) {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  const pageErrors = []
+  const delayedReadStarted = deferred()
+  const delayedReadCompleted = deferred()
+  const releaseDelayedRead = deferred()
+  let delayNextAuthRead = false
+
+  page.on('pageerror', error => pageErrors.push(error))
+  await page.route('**/api/**', async route => {
+    const request = route.request()
+    const apiPath = new URL(request.url()).pathname.slice('/api'.length)
+    if (apiPath === '/auth/me' && request.method() === 'GET') {
+      const shouldDelay = delayNextAuthRead
+      delayNextAuthRead = false
+      if (shouldDelay) {
+        delayedReadStarted.resolve()
+        await releaseDelayedRead.promise
+      }
+      await fulfillJson(route, responseBody, responseStatus)
+      if (shouldDelay) delayedReadCompleted.resolve()
+      return
+    }
+    await fulfillJson(route, { ok: false, error: `Unexpected API request: ${apiPath}` }, 404)
+  })
+
+  try {
+    await page.goto(`${baseUrl}/account`, { waitUntil: 'domcontentloaded' })
+    const gateHeading = page.getByRole('heading', { name: heading, exact: true })
+    await gateHeading.waitFor()
+    const documentState = await page.evaluate(() => {
+      window.__accountGateDocumentToken = Math.random().toString(36)
+      return {
+        timeOrigin: performance.timeOrigin,
+        navigationCount: performance.getEntriesByType('navigation').length,
+        token: window.__accountGateDocumentToken,
+        url: window.location.href
+      }
+    })
+    await gateHeading.evaluate(element => {
+      window.__accountGateBeforeForeground = element.closest('section')
+    })
+
+    delayNextAuthRead = true
+    await dispatchForegroundEvent(page)
+    await waitForSignal(delayedReadStarted, `${label} foreground /auth/me`)
+
+    assert.equal(await gateHeading.count(), 1)
+    assert.equal(await page.getByText('正在确认登录状态…', { exact: true }).count(), 0)
+    assert.equal(
+      await gateHeading.evaluate(element => (
+        window.__accountGateBeforeForeground === element.closest('section')
+      )),
+      true,
+      `${label} gate must remain mounted while passive validation is pending`
+    )
+
+    releaseDelayedRead.resolve()
+    await waitForSignal(delayedReadCompleted, `${label} foreground /auth/me completion`)
+    await page.waitForTimeout(50)
+
+    assert.equal(await gateHeading.count(), 1)
+    assert.equal(
+      await gateHeading.evaluate(element => (
+        window.__accountGateBeforeForeground === element.closest('section')
+      )),
+      true,
+      `${label} gate must remain mounted after passive validation completes`
+    )
+    assert.deepEqual(
+      await page.evaluate(() => ({
+        timeOrigin: performance.timeOrigin,
+        navigationCount: performance.getEntriesByType('navigation').length,
+        token: window.__accountGateDocumentToken,
+        url: window.location.href
+      })),
+      documentState
+    )
+    assert.equal(pageErrors.length, 0, pageErrors.map(error => error.stack).join('\n'))
+  } finally {
+    releaseDelayedRead.resolve()
+    await context.close()
+  }
+}
+
 async function verifyPassiveForegroundCannotSupersedeMutation(browser) {
   const postStarted = deferred()
   const releasePost = deferred()
@@ -213,23 +302,38 @@ async function verifyMutationTakesOverSlowValidation(browser) {
   )
 
   try {
-    await page.getByLabel('昵称', { exact: true }).fill('写入接管慢验证')
+    const profileInput = page.getByLabel('昵称', { exact: true })
+    await profileInput.fill('写入接管慢验证')
+    const documentTimeOrigin = await page.evaluate(() => performance.timeOrigin)
+    await profileInput.evaluate(input => {
+      window.__accountProfileInputBeforeForeground = input
+    })
     delayNextAuthRead = true
+    // Playwright 的无头模式不会稳定更新真实标签页的 document.hidden，
+    // 直接派发同一 foreground 回调依赖的 pageshow 事件来覆盖该路径。
     await dispatchForegroundEvent(page)
     await waitForSignal(slowGetStarted, 'foreground /auth/me')
 
     const verifyingStatus = page.getByText('正在确认当前账号…', { exact: true })
-    await verifyingStatus.waitFor()
+    assert.equal(
+      await verifyingStatus.count(),
+      0,
+      'passive foreground validation must not cover the account page'
+    )
+    assert.equal(await profileInput.isEnabled(), true)
+    assert.equal(await profileInput.inputValue(), '写入接管慢验证')
+    assert.equal(
+      await page.evaluate(() => (
+        window.__accountProfileInputBeforeForeground
+        === document.querySelector('#account-display-name')
+      )),
+      true,
+      'passive foreground validation must keep the existing account form mounted'
+    )
+    assert.equal(await page.evaluate(() => performance.timeOrigin), documentTimeOrigin)
 
-    // AccountAuthGate 在验证期间会让表单 inert；直接派发 submit 模拟已经进入
-    // Vue 事件队列的 mutation，验证 composable 的状态接管，而不是浏览器点击行为。
-    await page.getByLabel('昵称', { exact: true }).evaluate(input => {
-      input.form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
-    })
+    await page.getByRole('button', { name: '保存昵称' }).click()
     await waitForSignal(postStarted, 'profile POST taking over session validation')
-
-    // 慢 GET 尚未释放；mutation 开始后必须立即撤销旧验证的 overlay/inert 所有权。
-    await verifyingStatus.waitFor({ state: 'hidden', timeout: 1_000 })
 
     releasePost.resolve()
     await page.getByText('昵称已保存。', { exact: true }).waitFor()
@@ -326,6 +430,20 @@ async function verifySupersededLoginRevalidatesFinalCookie(browser) {
 async function main() {
   const browser = await chromium.launch({ headless: true })
   try {
+    await verifyResolvedGateStaysStableOnForeground(browser, {
+      label: 'unauthenticated',
+      heading: '登录后继续',
+      responseBody: { ok: false, error: '未登录' },
+      responseStatus: 401
+    })
+    process.stdout.write('PASS unauthenticated gate stays stable during foreground validation\n')
+    await verifyResolvedGateStaysStableOnForeground(browser, {
+      label: 'error',
+      heading: '暂时无法读取账号信息',
+      responseBody: { ok: false, error: '认证服务暂时不可用' },
+      responseStatus: 503
+    })
+    process.stdout.write('PASS error gate stays stable during foreground validation\n')
     await verifyPassiveForegroundCannotSupersedeMutation(browser)
     process.stdout.write('PASS passive foreground validation yields to identity mutation\n')
     await verifyMutationTakesOverSlowValidation(browser)


### PR DESCRIPTION
## 问题

PR #181 引入了前台会话重验证。用户切换标签页或窗口后返回时，前端会正常请求 `/api/auth/me`，但同时用全区遮罩、`inert` 或初始骨架替换账号内容，视觉上像整页刷新。

Playwright 已确认这并非真实 document reload：`performance.timeOrigin`、Navigation Timing、document token 与主 DOM 均未变化。

## 修改

- 普通 focus/pageshow/visibility 恢复继续在后台校验会话，但不遮挡、禁用或重挂载已登录账号内容。
- 已确认未登录与认证错误状态在被动校验期间保留当前卡片，不闪回初始骨架。
- 保留跨标签登录状态广播和 expected-user 409 的 hard revalidation：真实账号变化仍会立即卸载旧账号 UI，防止串号写入。
- 扩充 Playwright 会话竞态测试，覆盖已登录、未登录、错误态、未保存草稿、DOM identity 与文档导航稳定性。

## 用户影响

离开并返回账号相关页面时不再出现全页“刷新”感；通知和会话数据仍会正常后台更新。真正发生登录账号变化时，安全隔离行为保持不变。

## 验证

- `npm run typecheck`
- targeted ESLint
- `NOTIFICATIONS_ENABLED=1 QQ_NOTIFY_ENABLED=0 npm run build`
- `npm run test:auth-race`（5/5）
- `npm run test:account`（完整矩阵）
- `npm run test:expected-user`（5/5）
- `npm run test:expected-user:browser`
- 本地 production build Playwright 生命周期复验
- Codex review：CLEAN
- Claude Code review：CLEAN