### PR TITLE
fix(frontend): prevent passive auth page remounts

### DIFF
--- a/frontend/components/account/ProfileSettingsPanel.vue
+++ b/frontend/components/account/ProfileSettingsPanel.vue
@@ -7,21 +7,119 @@ const props = defineProps<{
   user: AuthUser
 }>()
 
+type ProfileSaveMessage = { tone: 'success' | 'error'; text: string }
+interface ProfileSaveState {
+  requestId: string | null
+  saving: boolean
+  message: ProfileSaveMessage | null
+}
+
 const { updateProfile, status } = useAuth()
-const displayName = ref('')
-const saving = ref(false)
-const message = ref<{ tone: 'success' | 'error'; text: string } | null>(null)
+const profileUserId = props.user.id
+const displayNameDrafts = useState<Record<string, string>>(
+  'account-profile-display-name-drafts',
+  () => ({})
+)
+const displayNameSaveStates = useState<Record<string, ProfileSaveState>>(
+  'account-profile-display-name-save-states',
+  () => ({})
+)
+
+function normalizeDisplayName(value: string | null | undefined) {
+  return (value || '').trim()
+}
+
+const displayName = ref(
+  displayNameDrafts.value[profileUserId] ?? (props.user.displayName || '')
+)
+const saving = computed(() => (
+  displayNameSaveStates.value[profileUserId]?.saving === true
+))
+const message = computed(() => (
+  displayNameSaveStates.value[profileUserId]?.message ?? null
+))
+let lastServerDisplayName = normalizeDisplayName(props.user.displayName)
+
+function saveDisplayNameDraft(value: string) {
+  const serverValue = normalizeDisplayName(props.user.displayName)
+  const nextDrafts = { ...displayNameDrafts.value }
+  if (normalizeDisplayName(value) === serverValue) delete nextDrafts[profileUserId]
+  else nextDrafts[profileUserId] = value
+  displayNameDrafts.value = nextDrafts
+}
+
+function clearSubmittedDisplayNameDraft(submittedValue: string) {
+  const savedDraft = displayNameDrafts.value[profileUserId]
+  if (
+    savedDraft !== undefined
+    && normalizeDisplayName(savedDraft) !== submittedValue
+  ) {
+    return
+  }
+
+  const nextDrafts = { ...displayNameDrafts.value }
+  delete nextDrafts[profileUserId]
+  displayNameDrafts.value = nextDrafts
+}
+
+function beginDisplayNameSave() {
+  if (displayNameSaveStates.value[profileUserId]?.saving) return null
+  const requestId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  displayNameSaveStates.value = {
+    ...displayNameSaveStates.value,
+    [profileUserId]: { requestId, saving: true, message: null }
+  }
+  return requestId
+}
+
+function finishDisplayNameSave(
+  requestId: string,
+  nextMessage: ProfileSaveMessage | null
+) {
+  const current = displayNameSaveStates.value[profileUserId]
+  if (!current || current.requestId !== requestId) return
+  displayNameSaveStates.value = {
+    ...displayNameSaveStates.value,
+    [profileUserId]: { requestId, saving: false, message: nextMessage }
+  }
+}
+
+function clearDisplayNameMessage() {
+  const current = displayNameSaveStates.value[profileUserId]
+  if (!current?.message) return
+  displayNameSaveStates.value = {
+    ...displayNameSaveStates.value,
+    [profileUserId]: { ...current, message: null }
+  }
+}
 
 watch(
   () => props.user.displayName,
   value => {
-    displayName.value = value || ''
+    const nextServerDisplayName = normalizeDisplayName(value)
+    const savedDraft = displayNameDrafts.value[profileUserId]
+    const currentDisplayName = normalizeDisplayName(displayName.value)
+
+    // A passive /auth/me response may carry an updated server profile. Never
+    // overwrite a local draft merely because the browser tab became active.
+    // If there is no draft, keep the input synchronized with the server.
+    if (currentDisplayName === nextServerDisplayName) {
+      displayName.value = nextServerDisplayName
+      saveDisplayNameDraft(displayName.value)
+    } else if (savedDraft !== undefined) {
+      displayName.value = savedDraft
+    } else if (currentDisplayName === lastServerDisplayName) {
+      displayName.value = nextServerDisplayName
+    }
+    lastServerDisplayName = nextServerDisplayName
   },
   { immediate: true }
 )
 
-const normalizedDisplayName = computed(() => displayName.value.trim())
-const isDirty = computed(() => normalizedDisplayName.value !== (props.user.displayName || ''))
+const normalizedDisplayName = computed(() => normalizeDisplayName(displayName.value))
+const isDirty = computed(() => (
+  normalizedDisplayName.value !== normalizeDisplayName(props.user.displayName)
+))
 const canSave = computed(() => (
   normalizedDisplayName.value.length >= 1
   && normalizedDisplayName.value.length <= 64
@@ -35,26 +133,39 @@ const avatarId = computed(() => {
 
 function resetDisplayName() {
   displayName.value = props.user.displayName || ''
-  message.value = null
+  saveDisplayNameDraft(displayName.value)
+  clearDisplayNameMessage()
 }
 
 function handleDisplayNameInput() {
   // 成功或失败提示只描述上一次提交。用户再次编辑后立即清除，避免把尚未
   // 保存的新值误报为“已保存”。
-  message.value = null
+  clearDisplayNameMessage()
+  saveDisplayNameDraft(displayName.value)
 }
 
 async function handleSubmit() {
   if (!canSave.value) return
-  saving.value = true
-  message.value = null
-  const result = await updateProfile({ displayName: normalizedDisplayName.value })
-  saving.value = false
+  const submittedDisplayName = normalizedDisplayName.value
+  const requestId = beginDisplayNameSave()
+  if (!requestId) return
+
+  let result: Awaited<ReturnType<typeof updateProfile>>
+  try {
+    result = await updateProfile({ displayName: submittedDisplayName })
+  } catch {
+    finishDisplayNameSave(requestId, {
+      tone: 'error',
+      text: '保存失败，请稍后重试。'
+    })
+    return
+  }
 
   // "unknown" is a temporary verification/error state, not proof that the
   // session ended. Redirecting here can race account-mismatch recovery and
   // send an otherwise authenticated user to the login page.
   if (!result.ok && status.value === 'unauthenticated') {
+    finishDisplayNameSave(requestId, null)
     await navigateTo({
       path: '/auth/login',
       query: {
@@ -65,9 +176,21 @@ async function handleSubmit() {
     return
   }
 
-  message.value = result.ok
-    ? { tone: 'success', text: '昵称已保存。' }
-    : { tone: 'error', text: result.error || '保存失败，请稍后重试。' }
+  if (result.ok) {
+    // The API stores the canonical trimmed value. Clear only the draft that
+    // belongs to this submission, so a newer edit can never be discarded by a
+    // late response from an older request.
+    clearSubmittedDisplayNameDraft(submittedDisplayName)
+    if (normalizeDisplayName(displayName.value) === submittedDisplayName) {
+      displayName.value = submittedDisplayName
+    }
+    finishDisplayNameSave(requestId, { tone: 'success', text: '昵称已保存。' })
+  } else {
+    finishDisplayNameSave(requestId, {
+      tone: 'error',
+      text: result.error || '保存失败，请稍后重试。'
+    })
+  }
 }
 </script>
 

--- a/frontend/composables/useAuth.ts
+++ b/frontend/composables/useAuth.ts
@@ -48,6 +48,14 @@ interface AuthFetchOptions {
    * request either succeeds or produces a new result.
    */
   preserveErrorWhileLoading?: boolean
+  /**
+   * Same-account foreground session checks are a background safety net. They
+   * must not flip the shared loading flag: several authenticated tools use that
+   * flag as an initial-auth gate and would otherwise destroy and recreate their
+   * entire UI whenever the browser tab becomes active again. A response for a
+   * different identity is escalated to the hard path before it is applied.
+   */
+  background?: boolean
 }
 
 interface AuthRuntime {
@@ -270,6 +278,23 @@ function parseAuthUser(
   }
 }
 
+function authUsersEqual(left: AuthUser | null, right: AuthUser): boolean {
+  if (!left) return false
+  return left.id === right.id
+    && left.email === right.email
+    && left.displayName === right.displayName
+    && left.linkedWikidotId === right.linkedWikidotId
+    && left.lastLoginAt === right.lastLoginAt
+    && left.qqBinding.bound === right.qqBinding.bound
+    && left.qqBinding.addressMask === right.qqBinding.addressMask
+    && left.qqBinding.status === right.qqBinding.status
+    && left.qqBinding.pendingChallenge === right.qqBinding.pendingChallenge
+    && left.qqBinding.capabilities.featureEnabled === right.qqBinding.capabilities.featureEnabled
+    && left.qqBinding.capabilities.createBinding === right.qqBinding.capabilities.createBinding
+    && left.qqBinding.capabilities.deliverNotifications === right.qqBinding.capabilities.deliverNotifications
+    && left.qqBinding.capabilities.manageExistingBinding === right.qqBinding.capabilities.manageExistingBinding
+}
+
 export function useAuth() {
   const nuxtApp = useNuxtApp()
   const { $bff } = nuxtApp
@@ -395,6 +420,15 @@ export function useAuth() {
     }
   }
 
+  function preserveResolvedSnapshotOnBackgroundError(cause: unknown) {
+    const hasResolvedSnapshot = status.value === 'unauthenticated'
+      || (status.value === 'authenticated' && Boolean(user.value))
+    if (!hasResolvedSnapshot) return false
+
+    authDebug('[auth] passive session validation kept the last resolved snapshot', cause)
+    return true
+  }
+
   function markSessionUnknown() {
     user.value = null
     status.value = 'unknown'
@@ -435,10 +469,11 @@ export function useAuth() {
       return existing.promise
     }
     const requestEpoch = runtime.epoch
+    const trackLoading = !options.background
     if (!options.preserveErrorWhileLoading) {
       authError.value = null
     }
-    beginRequest(requestEpoch)
+    if (trackLoading) beginRequest(requestEpoch)
 
     const requestPromise = (async () => {
       try {
@@ -467,19 +502,46 @@ export function useAuth() {
           if (!parsedUser.ok) {
             console.warn('[auth] fetchCurrentUser received an invalid user payload')
             authDebug('[auth] invalid /auth/me user payload', parsedUser.reason)
-            markAuthResolutionError(new Error('认证服务返回了无效的用户资料'))
+            const cause = new Error('认证服务返回了无效的用户资料')
+            if (!options.background || !preserveResolvedSnapshotOnBackgroundError(cause)) {
+              markAuthResolutionError(cause)
+            }
             return user.value
           }
-          user.value = parsedUser.value
+          const nextUser = parsedUser.value
+          if (
+            options.background
+            && status.value === 'authenticated'
+            && user.value
+            && user.value.id !== nextUser.id
+          ) {
+            // A missed cross-tab broadcast can leave account A rendered while
+            // the shared cookie already belongs to account B. Same-account
+            // foreground checks stay invisible, but a real identity change
+            // must take the hard path so every private view drops A's data
+            // before B becomes interactive.
+            authDebug('[auth] passive validation detected an identity change', {
+              previousId: user.value.id,
+              nextId: nextUser.id
+            })
+            void revalidateSession(true)
+            return user.value
+          }
+          if (!authUsersEqual(user.value, nextUser)) {
+            user.value = nextUser
+          }
           status.value = 'authenticated'
           authError.value = null
           authDebug('[auth] fetchCurrentUser success', {
-            id: user.value.id,
-            linkedWikidotId: user.value.linkedWikidotId
+            id: nextUser.id,
+            linkedWikidotId: nextUser.linkedWikidotId
           })
         } else {
           console.warn('[auth] fetchCurrentUser received an unexpected response')
-          markAuthResolutionError(new Error(res?.error || '认证服务返回了无效响应'))
+          const cause = new Error(res?.error || '认证服务返回了无效响应')
+          if (!options.background || !preserveResolvedSnapshotOnBackgroundError(cause)) {
+            markAuthResolutionError(cause)
+          }
         }
       } catch (cause: unknown) {
         if (!isCurrent(requestEpoch)) {
@@ -491,10 +553,12 @@ export function useAuth() {
           authDebug('[auth] fetchCurrentUser 401 (unauthenticated)')
         } else {
           console.warn('[auth] failed to fetch current user:', cause)
-          markAuthResolutionError(cause)
+          if (!options.background || !preserveResolvedSnapshotOnBackgroundError(cause)) {
+            markAuthResolutionError(cause)
+          }
         }
       } finally {
-        endRequest(requestEpoch)
+        if (trackLoading) endRequest(requestEpoch)
         if (runtime.fetchInflight?.epoch === requestEpoch) {
           runtime.fetchInflight = null
         }
@@ -508,7 +572,8 @@ export function useAuth() {
   /**
    * 重新验证浏览器当前 Cookie 对应的账号。
    *
-   * 普通前台恢复会在后台保留并校验最后一次可信快照，不遮挡页面或中断用户输入；
+   * 普通前台恢复会在后台保留并校验同一账号的最后一次可信快照，不遮挡页面或中断
+   * 用户输入；若响应属于另一账号，则升级为强制校验并先清除旧账号私有界面。
    * 收到其他标签页的身份变更通知时则立即清空快照，避免 A 的界面拿 B 的 Cookie
    * 发出写请求。新通知会开启新世代，旧验证响应无法覆盖最新身份。所有私有写
    * 仍由 expected-user 边界兜底，静默校验期间发生账号切换也不会写入错误账号。
@@ -523,6 +588,13 @@ export function useAuth() {
       authDebug('[auth] passive session validation skipped (identity mutation in-flight)')
       runtime.pendingPassiveSessionValidation = true
       return user.value
+    }
+
+    // An explicit/initial auth read already in flight has stronger ownership
+    // than a foreground hint. Reuse it instead of superseding its epoch and
+    // clearing the loading state that its caller intentionally exposed.
+    if (!invalidateSnapshot && runtime.fetchInflight) {
+      return runtime.fetchInflight.promise
     }
 
     if (!invalidateSnapshot && runtime.sessionRevalidation) {
@@ -543,7 +615,8 @@ export function useAuth() {
     if (invalidateSnapshot) markSessionUnknown()
 
     const verification = fetchCurrentUser(true, null, {
-      preserveErrorWhileLoading: !invalidateSnapshot
+      preserveErrorWhileLoading: !invalidateSnapshot,
+      background: !invalidateSnapshot
     })
     runtime.sessionRevalidation = verification
     runtime.sessionRevalidationInvalidatesSnapshot = invalidateSnapshot
@@ -575,8 +648,20 @@ export function useAuth() {
     if (!import.meta.client || runtime.sessionSyncListenersInstalled) return
     runtime.sessionSyncListenersInstalled = true
 
-    const validateOnForeground = () => {
+    const validateOnForeground = (event?: Event) => {
       if (document.hidden) return
+      // The browser also emits pageshow for the initial navigation. Initial
+      // session discovery already owns that phase; only a bfcache restoration
+      // is a genuine foreground return.
+      if (
+        event?.type === 'pageshow'
+        && (!('persisted' in event) || event.persisted !== true)
+      ) {
+        return
+      }
+      // Do not race the first session read, but allow a resolved error card to
+      // retry quietly when the user returns to the tab.
+      if (status.value === 'unknown' && !authError.value) return
       const now = Date.now()
       if (now - runtime.lastForegroundValidationAt < FOREGROUND_VALIDATION_DEBOUNCE_MS) {
         return

--- a/frontend/tests/auth-session-race.cjs
+++ b/frontend/tests/auth-session-race.cjs
@@ -30,6 +30,10 @@ async function waitForSignal(signal, label) {
   }
 }
 
+async function waitForNuxtHydration(page) {
+  await page.waitForFunction(() => Boolean(document.querySelector('#__nuxt')?.__vue_app__))
+}
+
 function authUser(displayName) {
   return authIdentity('race-user-1', 'race@example.com', displayName)
 }
@@ -69,15 +73,10 @@ async function fulfillJson(route, body, status = 200) {
 
 async function dispatchForegroundEvent(page) {
   await page.evaluate(() => {
-    // 将这一次事件移出应用内部的 1 秒防抖窗口，避免浏览器自身 pageshow/focus
-    // 调度时机让竞态测试偶发地只测到 debounce。
-    const realDateNow = Date.now
-    Date.now = () => realDateNow() + 60_000
-    try {
-      window.dispatchEvent(new Event('pageshow'))
-    } finally {
-      Date.now = realDateNow
-    }
+    // Initial navigation also emits pageshow. A persisted pageshow represents
+    // an actual bfcache foreground return and exercises the same production
+    // callback without corrupting the page clock used by later debounce checks.
+    window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }))
   })
 }
 
@@ -90,6 +89,7 @@ async function prepareProfilePage(browser, apiHandler) {
   await page.route('**/api/**', async route => {
     const request = route.request()
     const url = new URL(request.url())
+    if (!url.pathname.startsWith('/api/')) return route.continue()
     const apiPath = url.pathname.slice('/api'.length)
 
     if (apiPath.startsWith('/avatar/')) {
@@ -110,15 +110,547 @@ async function prepareProfilePage(browser, apiHandler) {
   })
 
   await page.goto(`${baseUrl}/account/profile`, { waitUntil: 'domcontentloaded' })
+  await waitForNuxtHydration(page)
   await page.getByText('race@example.com', { exact: true }).waitFor()
   await page.getByLabel('昵称', { exact: true }).waitFor()
 
   return { context, page, pageErrors }
 }
 
+async function verifyPassiveForegroundDoesNotEnterGlobalLoading(browser) {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  const pageErrors = []
+  const foregroundReadStarted = deferred()
+  const foregroundReadCompleted = deferred()
+  const releaseForegroundRead = deferred()
+  let delayNextAuthRead = false
+  let authReadCount = 0
+
+  page.on('pageerror', error => pageErrors.push(error))
+  await page.route('**/api/**', async route => {
+    const request = route.request()
+    const url = new URL(request.url())
+    if (!url.pathname.startsWith('/api/')) return route.continue()
+    const apiPath = url.pathname.slice('/api'.length)
+
+    if (apiPath.startsWith('/avatar/')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'image/png',
+        body: transparentPng
+      })
+    }
+    if (apiPath === '/auth/me' && request.method() === 'GET') {
+      authReadCount += 1
+      const shouldDelay = delayNextAuthRead
+      delayNextAuthRead = false
+      if (shouldDelay) {
+        foregroundReadStarted.resolve()
+        await releaseForegroundRead.promise
+      }
+      await fulfillJson(route, authUser('全局加载回归用户'))
+      if (shouldDelay) foregroundReadCompleted.resolve()
+      return
+    }
+    if (apiPath === '/ftml-projects' && request.method() === 'GET') {
+      return fulfillJson(route, {
+        projects: [{
+          id: 'foreground-project-1',
+          title: '前台恢复不能卸载的项目',
+          pageTitle: null,
+          pageTags: [],
+          isArchived: false,
+          createdAt: iso,
+          updatedAt: iso
+        }]
+      })
+    }
+    if (apiPath === '/alerts') {
+      return fulfillJson(route, { ok: true, alerts: [], unreadCount: 0 })
+    }
+    if (apiPath === '/alerts/forum' || apiPath === '/alerts/follow') {
+      return fulfillJson(route, { ok: true, alerts: [], unreadCount: 0 })
+    }
+    await fulfillJson(route, { ok: false, error: `Unexpected API request: ${apiPath}` }, 404)
+  })
+
+  try {
+    await page.goto(`${baseUrl}/ftml-projects`, { waitUntil: 'domcontentloaded' })
+    await waitForNuxtHydration(page)
+    const projectTitle = page.getByText('前台恢复不能卸载的项目', { exact: true })
+    await projectTitle.waitFor()
+    const documentState = await page.evaluate(() => {
+      window.__ftmlForegroundDocumentToken = Math.random().toString(36)
+      return {
+        timeOrigin: performance.timeOrigin,
+        navigationCount: performance.getEntriesByType('navigation').length,
+        token: window.__ftmlForegroundDocumentToken,
+        url: window.location.href
+      }
+    })
+    await projectTitle.evaluate(element => {
+      window.__ftmlProjectBeforeForeground = element.closest('.project-item')
+    })
+
+    delayNextAuthRead = true
+    await dispatchForegroundEvent(page)
+    await waitForSignal(foregroundReadStarted, 'FTML foreground /auth/me')
+
+    assert.equal(authReadCount, 2)
+    assert.equal(await page.getByText('正在验证登录状态...', { exact: true }).count(), 0)
+    assert.equal(await projectTitle.count(), 1)
+    assert.equal(
+      await projectTitle.evaluate(element => (
+        window.__ftmlProjectBeforeForeground === element.closest('.project-item')
+      )),
+      true,
+      'passive validation must not replace an authenticated tool with its initial auth gate'
+    )
+
+    releaseForegroundRead.resolve()
+    await waitForSignal(foregroundReadCompleted, 'FTML foreground /auth/me completion')
+    await page.waitForTimeout(50)
+
+    assert.equal(await page.getByText('正在验证登录状态...', { exact: true }).count(), 0)
+    assert.equal(
+      await projectTitle.evaluate(element => (
+        window.__ftmlProjectBeforeForeground === element.closest('.project-item')
+      )),
+      true,
+      'the authenticated tool must retain its DOM after passive validation completes'
+    )
+    assert.deepEqual(
+      await page.evaluate(() => ({
+        timeOrigin: performance.timeOrigin,
+        navigationCount: performance.getEntriesByType('navigation').length,
+        token: window.__ftmlForegroundDocumentToken,
+        url: window.location.href
+      })),
+      documentState
+    )
+    assert.equal(pageErrors.length, 0, pageErrors.map(error => error.stack).join('\n'))
+  } finally {
+    releaseForegroundRead.resolve()
+    await context.close()
+  }
+}
+
+async function verifyForegroundIdentityChangeClearsPrivateView(browser) {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  const pageErrors = []
+  const hardReadStarted = deferred()
+  const releaseHardRead = deferred()
+  const accountA = authIdentity('account-a', 'a@example.com', '账号 A')
+  const accountB = authIdentity('account-b', 'b@example.com', '账号 B')
+  let authReadCount = 0
+  let projectReadCount = 0
+
+  page.on('pageerror', error => pageErrors.push(error))
+  await page.route('**/api/**', async route => {
+    const request = route.request()
+    const url = new URL(request.url())
+    if (!url.pathname.startsWith('/api/')) return route.continue()
+    const apiPath = url.pathname.slice('/api'.length)
+
+    if (apiPath.startsWith('/avatar/')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'image/png',
+        body: transparentPng
+      })
+    }
+    if (apiPath === '/auth/me' && request.method() === 'GET') {
+      authReadCount += 1
+      if (authReadCount === 1) return fulfillJson(route, accountA)
+      if (authReadCount === 2) return fulfillJson(route, accountB)
+      if (authReadCount === 3) {
+        hardReadStarted.resolve()
+        await releaseHardRead.promise
+      }
+      return fulfillJson(route, accountB)
+    }
+    if (apiPath === '/ftml-projects' && request.method() === 'GET') {
+      projectReadCount += 1
+      const isAccountARead = projectReadCount === 1
+      return fulfillJson(route, {
+        projects: [{
+          id: isAccountARead ? 'account-a-project' : 'account-b-project',
+          title: isAccountARead ? '账号 A 的私有项目' : '账号 B 的私有项目',
+          pageTitle: null,
+          pageTags: [],
+          isArchived: false,
+          createdAt: iso,
+          updatedAt: iso
+        }]
+      })
+    }
+    if (apiPath === '/alerts') {
+      return fulfillJson(route, { ok: true, alerts: [], unreadCount: 0 })
+    }
+    if (apiPath === '/alerts/forum' || apiPath === '/alerts/follow') {
+      return fulfillJson(route, { ok: true, alerts: [], unreadCount: 0 })
+    }
+    await fulfillJson(route, { ok: false, error: `Unexpected API request: ${apiPath}` }, 404)
+  })
+
+  try {
+    await page.goto(`${baseUrl}/ftml-projects`, { waitUntil: 'domcontentloaded' })
+    await waitForNuxtHydration(page)
+    const accountAProject = page.getByText('账号 A 的私有项目', { exact: true })
+    await accountAProject.waitFor()
+    const documentState = await page.evaluate(() => {
+      window.__identityChangeDocumentToken = Math.random().toString(36)
+      return {
+        timeOrigin: performance.timeOrigin,
+        navigationCount: performance.getEntriesByType('navigation').length,
+        token: window.__identityChangeDocumentToken,
+        url: window.location.href
+      }
+    })
+
+    await dispatchForegroundEvent(page)
+    await waitForSignal(hardReadStarted, 'hard /auth/me after identity change')
+    await page.getByText('正在验证登录状态...', { exact: true }).waitFor()
+
+    assert.equal(authReadCount, 3)
+    assert.equal(await accountAProject.count(), 0)
+    assert.deepEqual(
+      await page.evaluate(() => ({
+        timeOrigin: performance.timeOrigin,
+        navigationCount: performance.getEntriesByType('navigation').length,
+        token: window.__identityChangeDocumentToken,
+        url: window.location.href
+      })),
+      documentState,
+      'identity invalidation must clear private UI without reloading the document'
+    )
+
+    releaseHardRead.resolve()
+    await page.getByText('账号 B 的私有项目', { exact: true }).waitFor()
+
+    assert.equal(projectReadCount, 2)
+    assert.equal(await accountAProject.count(), 0)
+    assert.equal(pageErrors.length, 0, pageErrors.map(error => error.stack).join('\n'))
+  } finally {
+    releaseHardRead.resolve()
+    await context.close()
+  }
+}
+
+async function verifyForegroundProfileUpdatePreservesDraft(browser) {
+  const foregroundReadStarted = deferred()
+  const foregroundReadCompleted = deferred()
+  const releaseForegroundRead = deferred()
+  let authReadCount = 0
+  let delayNextAuthRead = false
+
+  const { context, page, pageErrors } = await prepareProfilePage(
+    browser,
+    async (route, apiPath, request) => {
+      if (apiPath === '/auth/me' && request.method() === 'GET') {
+        authReadCount += 1
+        const shouldDelay = delayNextAuthRead
+        delayNextAuthRead = false
+        if (shouldDelay) {
+          foregroundReadStarted.resolve()
+          await releaseForegroundRead.promise
+        }
+        await fulfillJson(route, authUser(shouldDelay ? '其他标签页的新昵称' : '服务端旧昵称'))
+        if (shouldDelay) foregroundReadCompleted.resolve()
+        return true
+      }
+      return false
+    }
+  )
+
+  try {
+    const profileInput = page.getByLabel('昵称', { exact: true })
+    await profileInput.fill('不能被覆盖的本地草稿')
+    await profileInput.evaluate(input => {
+      window.__profileDraftInputBeforeForeground = input
+    })
+
+    delayNextAuthRead = true
+    await dispatchForegroundEvent(page)
+    await waitForSignal(foregroundReadStarted, 'profile update foreground /auth/me')
+    releaseForegroundRead.resolve()
+    await waitForSignal(foregroundReadCompleted, 'profile update foreground /auth/me completion')
+    await page.waitForTimeout(50)
+
+    assert.equal(authReadCount, 2)
+    assert.equal(await profileInput.inputValue(), '不能被覆盖的本地草稿')
+    assert.equal(
+      await page.evaluate(() => (
+        window.__profileDraftInputBeforeForeground
+        === document.querySelector('#account-display-name')
+      )),
+      true,
+      'same-account profile refresh must keep the existing input mounted'
+    )
+    await page.getByRole('button', { name: '撤销更改', exact: true }).click()
+    assert.equal(
+      await profileInput.inputValue(),
+      '其他标签页的新昵称',
+      'undo must reveal the server snapshot applied by passive validation'
+    )
+    assert.equal(pageErrors.length, 0, pageErrors.map(error => error.stack).join('\n'))
+  } finally {
+    releaseForegroundRead.resolve()
+    await context.close()
+  }
+}
+
+async function verifyProfileRouteRoundTripPreservesDraft(browser) {
+  let authReadCount = 0
+  const { context, page, pageErrors } = await prepareProfilePage(
+    browser,
+    async (route, apiPath, request) => {
+      if (apiPath === '/auth/me' && request.method() === 'GET') {
+        authReadCount += 1
+        await fulfillJson(route, authUser('往返路由服务端昵称'))
+        return true
+      }
+      return false
+    }
+  )
+
+  try {
+    const profileInput = page.getByLabel('昵称', { exact: true })
+    await profileInput.fill('跨账号子页保留的草稿')
+    const documentState = await page.evaluate(() => {
+      window.__profileRoundTripDocumentToken = Math.random().toString(36)
+      return {
+        timeOrigin: performance.timeOrigin,
+        navigationCount: performance.getEntriesByType('navigation').length,
+        token: window.__profileRoundTripDocumentToken
+      }
+    })
+
+    await page.getByRole('link', { name: /账号连接/ }).first().click()
+    await page.getByRole('heading', { name: 'Wikidot 身份', exact: true }).waitFor()
+    await page.goBack()
+    await page.getByLabel('昵称', { exact: true }).waitFor()
+
+    assert.equal(await page.getByLabel('昵称', { exact: true }).inputValue(), '跨账号子页保留的草稿')
+    assert.equal(authReadCount, 1, 'SPA route round-trip must reuse the resolved auth snapshot')
+    assert.deepEqual(
+      await page.evaluate(() => ({
+        timeOrigin: performance.timeOrigin,
+        navigationCount: performance.getEntriesByType('navigation').length,
+        token: window.__profileRoundTripDocumentToken
+      })),
+      documentState
+    )
+    assert.equal(pageErrors.length, 0, pageErrors.map(error => error.stack).join('\n'))
+  } finally {
+    await context.close()
+  }
+}
+
+async function verifyNormalizedProfileSaveClearsDraft(browser) {
+  const remoteReadStarted = deferred()
+  const remoteReadCompleted = deferred()
+  const releaseRemoteRead = deferred()
+  let displayName = '规范化前昵称'
+  let delayNextAuthRead = false
+  let authReadCount = 0
+  const submittedNames = []
+
+  const { context, page, pageErrors } = await prepareProfilePage(
+    browser,
+    async (route, apiPath, request) => {
+      if (apiPath === '/auth/me' && request.method() === 'GET') {
+        authReadCount += 1
+        const shouldDelay = delayNextAuthRead
+        delayNextAuthRead = false
+        if (shouldDelay) {
+          remoteReadStarted.resolve()
+          await releaseRemoteRead.promise
+        }
+        await fulfillJson(route, authUser(displayName))
+        if (shouldDelay) remoteReadCompleted.resolve()
+        return true
+      }
+      if (apiPath === '/auth/profile' && request.method() === 'PATCH') {
+        const submittedName = request.postDataJSON().displayName
+        submittedNames.push(submittedName)
+        displayName = submittedName.trim()
+        await fulfillJson(route, authUser(displayName))
+        return true
+      }
+      return false
+    }
+  )
+
+  try {
+    const profileInput = page.getByLabel('昵称', { exact: true })
+    await profileInput.fill('  已规范化昵称  ')
+    await page.getByRole('button', { name: '保存昵称', exact: true }).click()
+    await page.getByText('昵称已保存。', { exact: true }).waitFor()
+
+    assert.deepEqual(submittedNames, ['已规范化昵称'])
+    assert.equal(await profileInput.inputValue(), '已规范化昵称')
+
+    await page.getByRole('link', { name: /账号连接/ }).first().click()
+    await page.getByRole('heading', { name: 'Wikidot 身份', exact: true }).waitFor()
+    await page.goBack()
+    await page.getByLabel('昵称', { exact: true }).waitFor()
+    assert.equal(
+      await page.getByLabel('昵称', { exact: true }).inputValue(),
+      '已规范化昵称',
+      'a successful canonical save must not restore its raw whitespace draft'
+    )
+
+    displayName = '其他标签页后续昵称'
+    delayNextAuthRead = true
+    await dispatchForegroundEvent(page)
+    await waitForSignal(remoteReadStarted, 'post-save foreground /auth/me')
+    releaseRemoteRead.resolve()
+    await waitForSignal(remoteReadCompleted, 'post-save foreground /auth/me completion')
+    await page.getByLabel('昵称', { exact: true }).waitFor({
+      state: 'visible'
+    })
+    await page.waitForFunction(() => (
+      document.querySelector('#account-display-name')?.value === '其他标签页后续昵称'
+    ))
+
+    assert.equal(authReadCount, 2)
+    assert.equal(pageErrors.length, 0, pageErrors.map(error => error.stack).join('\n'))
+  } finally {
+    releaseRemoteRead.resolve()
+    await context.close()
+  }
+}
+
+async function verifyProfileSavingSurvivesRouteRemount(browser) {
+  const profileWriteStarted = deferred()
+  const releaseProfileWrite = deferred()
+  let displayName = '保存状态服务端昵称'
+  let profileWriteCount = 0
+
+  const { context, page, pageErrors } = await prepareProfilePage(
+    browser,
+    async (route, apiPath, request) => {
+      if (apiPath === '/auth/me' && request.method() === 'GET') {
+        await fulfillJson(route, authUser(displayName))
+        return true
+      }
+      if (apiPath === '/auth/profile' && request.method() === 'PATCH') {
+        profileWriteCount += 1
+        const submittedName = request.postDataJSON().displayName
+        profileWriteStarted.resolve()
+        await releaseProfileWrite.promise
+        displayName = submittedName
+        await fulfillJson(route, authUser(displayName))
+        return true
+      }
+      return false
+    }
+  )
+
+  try {
+    await page.getByLabel('昵称', { exact: true }).fill('路由往返中的在途保存')
+    await page.getByRole('button', { name: '保存昵称', exact: true }).click()
+    await waitForSignal(profileWriteStarted, 'profile write before route remount')
+
+    await page.getByRole('link', { name: /账号连接/ }).first().click()
+    await page.getByRole('heading', { name: 'Wikidot 身份', exact: true }).waitFor()
+    await page.goBack()
+
+    const remountedInput = page.getByLabel('昵称', { exact: true })
+    const remountedSave = page.getByRole('button', { name: '保存中…', exact: true })
+    await remountedInput.waitFor()
+    assert.equal(await remountedInput.isDisabled(), true)
+    assert.equal(await remountedSave.isDisabled(), true)
+
+    // Even a programmatic submit from the remounted form must not start a
+    // second PATCH while the first request still owns this user's save state.
+    await page.evaluate(() => {
+      document.querySelector('#account-display-name')
+        ?.closest('form')
+        ?.requestSubmit()
+    })
+    await page.waitForTimeout(100)
+    assert.equal(profileWriteCount, 1)
+
+    releaseProfileWrite.resolve()
+    await page.waitForFunction(() => (
+      document.querySelector('#account-display-name')?.disabled === false
+    ))
+    assert.equal(await remountedInput.inputValue(), '路由往返中的在途保存')
+    assert.equal(profileWriteCount, 1)
+    assert.equal(pageErrors.length, 0, pageErrors.map(error => error.stack).join('\n'))
+  } finally {
+    releaseProfileWrite.resolve()
+    await context.close()
+  }
+}
+
+async function verifyProfileFailureSurvivesRouteRemount(browser) {
+  const profileWriteStarted = deferred()
+  const releaseProfileWrite = deferred()
+  let profileWriteCount = 0
+
+  const { context, page, pageErrors } = await prepareProfilePage(
+    browser,
+    async (route, apiPath, request) => {
+      if (apiPath === '/auth/me' && request.method() === 'GET') {
+        await fulfillJson(route, authUser('失败反馈服务端昵称'))
+        return true
+      }
+      if (apiPath === '/auth/profile' && request.method() === 'PATCH') {
+        profileWriteCount += 1
+        profileWriteStarted.resolve()
+        await releaseProfileWrite.promise
+        await fulfillJson(route, { ok: false, error: '跨路由保存失败' }, 503)
+        return true
+      }
+      return false
+    }
+  )
+
+  try {
+    await page.getByLabel('昵称', { exact: true }).fill('失败后必须保留的草稿')
+    await page.getByRole('button', { name: '保存昵称', exact: true }).click()
+    await waitForSignal(profileWriteStarted, 'failing profile write before route remount')
+
+    await page.getByRole('link', { name: /账号连接/ }).first().click()
+    await page.getByRole('heading', { name: 'Wikidot 身份', exact: true }).waitFor()
+    await page.goBack()
+
+    const remountedInput = page.getByLabel('昵称', { exact: true })
+    await remountedInput.waitFor()
+    assert.equal(await remountedInput.isDisabled(), true)
+    assert.equal(
+      await page.getByRole('button', { name: '保存中…', exact: true }).isDisabled(),
+      true
+    )
+
+    releaseProfileWrite.resolve()
+    await page.getByText('跨路由保存失败', { exact: true }).waitFor()
+
+    assert.equal(await remountedInput.isEnabled(), true)
+    assert.equal(await remountedInput.inputValue(), '失败后必须保留的草稿')
+    assert.equal(profileWriteCount, 1)
+    assert.equal(pageErrors.length, 0, pageErrors.map(error => error.stack).join('\n'))
+  } finally {
+    releaseProfileWrite.resolve()
+    await context.close()
+  }
+}
+
 async function verifyResolvedGateStaysStableOnForeground(
   browser,
-  { label, heading, responseBody, responseStatus }
+  {
+    label,
+    heading,
+    responseBody,
+    responseStatus,
+    foregroundResponseBody = responseBody,
+    foregroundResponseStatus = responseStatus
+  }
 ) {
   const context = await browser.newContext()
   const page = await context.newPage()
@@ -131,7 +663,9 @@ async function verifyResolvedGateStaysStableOnForeground(
   page.on('pageerror', error => pageErrors.push(error))
   await page.route('**/api/**', async route => {
     const request = route.request()
-    const apiPath = new URL(request.url()).pathname.slice('/api'.length)
+    const url = new URL(request.url())
+    if (!url.pathname.startsWith('/api/')) return route.continue()
+    const apiPath = url.pathname.slice('/api'.length)
     if (apiPath === '/auth/me' && request.method() === 'GET') {
       const shouldDelay = delayNextAuthRead
       delayNextAuthRead = false
@@ -139,7 +673,11 @@ async function verifyResolvedGateStaysStableOnForeground(
         delayedReadStarted.resolve()
         await releaseDelayedRead.promise
       }
-      await fulfillJson(route, responseBody, responseStatus)
+      await fulfillJson(
+        route,
+        shouldDelay ? foregroundResponseBody : responseBody,
+        shouldDelay ? foregroundResponseStatus : responseStatus
+      )
       if (shouldDelay) delayedReadCompleted.resolve()
       return
     }
@@ -148,6 +686,7 @@ async function verifyResolvedGateStaysStableOnForeground(
 
   try {
     await page.goto(`${baseUrl}/account`, { waitUntil: 'domcontentloaded' })
+    await waitForNuxtHydration(page)
     const gateHeading = page.getByRole('heading', { name: heading, exact: true })
     await gateHeading.waitFor()
     const documentState = await page.evaluate(() => {
@@ -370,7 +909,9 @@ async function verifySupersededLoginRevalidatesFinalCookie(browser) {
 
   await page.route('**/api/**', async route => {
     const request = route.request()
-    const apiPath = new URL(request.url()).pathname.slice('/api'.length)
+    const url = new URL(request.url())
+    if (!url.pathname.startsWith('/api/')) return route.continue()
+    const apiPath = url.pathname.slice('/api'.length)
 
     if (apiPath === '/auth/me' && request.method() === 'GET') {
       if (!cookieIdentity) {
@@ -398,6 +939,11 @@ async function verifySupersededLoginRevalidatesFinalCookie(browser) {
 
   try {
     await page.goto(`${baseUrl}/auth/login`, { waitUntil: 'domcontentloaded' })
+    await waitForNuxtHydration(page)
+    // Wait for the initial /auth/me result to finish hydrating the shared
+    // layout before typing; otherwise dev-mode Suspense can replace the inputs
+    // after Playwright fills them.
+    await page.getByRole('link', { name: '登录', exact: true }).first().waitFor()
     await page.getByLabel('邮箱', { exact: true }).fill('b1@example.com')
     await page.getByLabel('密码', { exact: true }).fill('password-for-race-test')
     await page.getByRole('button', { name: '登录', exact: true }).click()
@@ -430,6 +976,20 @@ async function verifySupersededLoginRevalidatesFinalCookie(browser) {
 async function main() {
   const browser = await chromium.launch({ headless: true })
   try {
+    await verifyPassiveForegroundDoesNotEnterGlobalLoading(browser)
+    process.stdout.write('PASS passive foreground validation does not enter global auth loading\n')
+    await verifyForegroundIdentityChangeClearsPrivateView(browser)
+    process.stdout.write('PASS foreground identity change clears private view before switching accounts\n')
+    await verifyForegroundProfileUpdatePreservesDraft(browser)
+    process.stdout.write('PASS foreground same-account profile update preserves local draft\n')
+    await verifyProfileRouteRoundTripPreservesDraft(browser)
+    process.stdout.write('PASS profile route round-trip preserves local draft\n')
+    await verifyNormalizedProfileSaveClearsDraft(browser)
+    process.stdout.write('PASS normalized profile save clears its persisted draft\n')
+    await verifyProfileSavingSurvivesRouteRemount(browser)
+    process.stdout.write('PASS profile saving state survives route remount\n')
+    await verifyProfileFailureSurvivesRouteRemount(browser)
+    process.stdout.write('PASS profile save failure survives route remount\n')
     await verifyResolvedGateStaysStableOnForeground(browser, {
       label: 'unauthenticated',
       heading: '登录后继续',
@@ -437,6 +997,15 @@ async function main() {
       responseStatus: 401
     })
     process.stdout.write('PASS unauthenticated gate stays stable during foreground validation\n')
+    await verifyResolvedGateStaysStableOnForeground(browser, {
+      label: 'unauthenticated transient error',
+      heading: '登录后继续',
+      responseBody: { ok: false, error: '未登录' },
+      responseStatus: 401,
+      foregroundResponseBody: { ok: false, error: '认证服务暂时不可用' },
+      foregroundResponseStatus: 503
+    })
+    process.stdout.write('PASS passive foreground error preserves resolved unauthenticated gate\n')
     await verifyResolvedGateStaysStableOnForeground(browser, {
       label: 'error',
       heading: '暂时无法读取账号信息',

--- a/frontend/tests/expected-user-mismatch-recovery.cjs
+++ b/frontend/tests/expected-user-mismatch-recovery.cjs
@@ -73,7 +73,9 @@ async function main() {
 
   await page.route('**/api/**', async route => {
     const request = route.request()
-    const apiPath = new URL(request.url()).pathname.slice('/api'.length)
+    const url = new URL(request.url())
+    if (!url.pathname.startsWith('/api/')) return route.continue()
+    const apiPath = url.pathname.slice('/api'.length)
 
     if (apiPath.startsWith('/avatar/')) {
       return route.fulfill({


### PR DESCRIPTION
## What changed

- run same-account foreground `/auth/me` checks without flipping the shared auth loading state, so authenticated pages keep their DOM and local interaction state
- escalate a real account-id change to hard revalidation before applying the new identity, preventing account A private data from remaining visible under account B
- preserve profile nickname drafts across account sub-route navigation and passive profile refreshes
- canonicalize nickname drafts and share request-token/save/result state across remounts, preventing duplicate PATCH requests and lost success/error feedback
- harden Playwright interception and add focused foreground, identity-switch, draft, and save-race regressions

## Root cause

Foreground `focus` / `visibilitychange` / bfcache `pageshow` validation reused the global initial-auth loading flag. Several authenticated tools treat that flag as a top-level gate, so returning to a tab destroyed and recreated the page body even though the browser document never reloaded.

## User impact

Normal same-account tab returns no longer blank or visually refresh the page, and local drafts remain intact. A genuine cross-account cookie change still clears the old account's private UI and safely reloads data for the new account.

QQ binding/QQ notification UI remains disabled and hidden. SCPper in-site notifications remain enabled and unchanged.

## Validation

- production Nuxt build with `NOTIFICATIONS_ENABLED=1 QQ_NOTIFY_ENABLED=0`
- `npm run typecheck`
- targeted ESLint
- `npm run test:auth-race` — 13/13
- `npm run test:account` — full matrix pass
- `npm run test:expected-user` — 5/5
- `npm run test:expected-user:browser` — pass
- independent Codex code/runtime/test reviews — clean
- Claude Code final read-only review — CLEAN FOR MERGE
