### PR TITLE
feat: 账号页 Wikidot 徽章显示用户名并可跳转用户页

### DIFF
--- a/frontend/components/account/AccountOverview.vue
+++ b/frontend/components/account/AccountOverview.vue
@@ -38,7 +38,7 @@ const { data: linkedWikidotProfile } = useAsyncData(
   async () => {
     if (!linkedWikidotId.value) return null
     try {
-      return await $bff<{ displayName: string | null; username: string | null }>(
+      return await $bff<{ wikidotId: number; displayName: string | null; username: string | null }>(
         '/users/by-wikidot-id',
         { params: { wikidotId: linkedWikidotId.value } }
       )
@@ -49,11 +49,12 @@ const { data: linkedWikidotProfile } = useAsyncData(
   { server: false, lazy: true }
 )
 
-const linkedWikidotName = computed(() => (
-  linkedWikidotProfile.value?.displayName
-  || linkedWikidotProfile.value?.username
-  || null
-))
+// 换绑瞬间 data 可能仍是上一个 key 的旧值，用响应里的 wikidotId 再校验一次
+const linkedWikidotName = computed(() => {
+  const profile = linkedWikidotProfile.value
+  if (!profile || Number(profile.wikidotId) !== linkedWikidotId.value) return null
+  return profile.displayName || profile.username || null
+})
 
 const links = computed<OverviewLink[]>(() => [
   {

--- a/frontend/components/account/AccountOverview.vue
+++ b/frontend/components/account/AccountOverview.vue
@@ -32,8 +32,9 @@ const wikidotStatus = computed(() => (
 
 // AuthUser 只带 linkedWikidotId，展示用户名需要回查 BFF 的公开用户资料。
 // 不 await：用户名只是徽章的可选补充，查询慢或失败不能挂起整个概览面板
+// key 按 linkedWikidotId 区分：换绑或切换账号后不会复用上一个用户的缓存
 const { data: linkedWikidotProfile } = useAsyncData(
-  () => 'account-overview-wikidot-profile',
+  () => `account-overview-wikidot-profile-${linkedWikidotId.value ?? 'none'}`,
   async () => {
     if (!linkedWikidotId.value) return null
     try {
@@ -45,7 +46,7 @@ const { data: linkedWikidotProfile } = useAsyncData(
       return null
     }
   },
-  { server: false, lazy: true, watch: [linkedWikidotId] }
+  { server: false, lazy: true }
 )
 
 const linkedWikidotName = computed(() => (

--- a/frontend/components/account/AccountOverview.vue
+++ b/frontend/components/account/AccountOverview.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useNuxtApp, useAsyncData } from 'nuxt/app'
 import UserAvatar from '~/components/UserAvatar.vue'
 import type { AuthUser } from '~/composables/useAuth'
 
@@ -7,6 +8,8 @@ const props = defineProps<{
   user: AuthUser
   showNotificationsPausedNotice?: boolean
 }>()
+
+const { $bff } = useNuxtApp()
 
 interface OverviewLink {
   title: string
@@ -17,13 +20,37 @@ interface OverviewLink {
 }
 
 const displayName = computed(() => props.user.displayName || '未设置昵称')
-const avatarId = computed(() => {
+const linkedWikidotId = computed(() => {
   const id = Number(props.user.linkedWikidotId)
-  return Number.isFinite(id) && id > 0 ? id : '0'
+  return Number.isFinite(id) && id > 0 ? id : null
 })
+const avatarId = computed(() => linkedWikidotId.value ?? '0')
 
 const wikidotStatus = computed(() => (
   props.user.linkedWikidotId ? '已连接' : '未连接'
+))
+
+// AuthUser 只带 linkedWikidotId，展示用户名需要回查 BFF 的公开用户资料
+const { data: linkedWikidotProfile } = await useAsyncData(
+  () => 'account-overview-wikidot-profile',
+  async () => {
+    if (!linkedWikidotId.value) return null
+    try {
+      return await $bff<{ displayName: string | null; username: string | null }>(
+        '/users/by-wikidot-id',
+        { params: { wikidotId: linkedWikidotId.value } }
+      )
+    } catch {
+      return null
+    }
+  },
+  { server: false, watch: [linkedWikidotId] }
+)
+
+const linkedWikidotName = computed(() => (
+  linkedWikidotProfile.value?.displayName
+  || linkedWikidotProfile.value?.username
+  || null
 ))
 
 const links = computed<OverviewLink[]>(() => [
@@ -119,14 +146,36 @@ function formatLastLogin(value: string | null): string {
             {{ user.email }}
           </p>
           <div class="mt-3 flex flex-wrap gap-2 text-xs">
-            <span
-              class="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1"
-              :class="user.linkedWikidotId
-                ? 'border-emerald-300/70 bg-emerald-50 text-emerald-800 dark:border-emerald-800/70 dark:bg-emerald-950/40 dark:text-emerald-200'
-                : 'border-[rgb(var(--panel-border))] bg-[rgb(var(--bg))] text-[rgb(var(--muted))]'"
+            <NuxtLink
+              v-if="linkedWikidotId"
+              :to="`/user/${linkedWikidotId}`"
+              class="inline-flex items-center gap-1.5 rounded-md border border-emerald-300/70 bg-emerald-50 px-2.5 py-1 text-emerald-800 transition hover:border-emerald-400 hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-400/60 dark:border-emerald-800/70 dark:bg-emerald-950/40 dark:text-emerald-200 dark:hover:border-emerald-700 dark:hover:bg-emerald-900/50"
+              :aria-label="`查看已绑定的 Wikidot 用户${linkedWikidotName ? ` ${linkedWikidotName} ` : ''}的用户页`"
             >
               <LucideIcon
-                :name="user.linkedWikidotId ? 'CircleCheck' : 'CircleDashed'"
+                name="CircleCheck"
+                class="h-3.5 w-3.5"
+                aria-hidden="true"
+              />
+              Wikidot {{ wikidotStatus }}
+              <span
+                v-if="linkedWikidotName"
+                class="font-semibold"
+              >
+                {{ linkedWikidotName }}
+              </span>
+              <LucideIcon
+                name="ArrowUpRight"
+                class="h-3 w-3"
+                aria-hidden="true"
+              />
+            </NuxtLink>
+            <span
+              v-else
+              class="inline-flex items-center gap-1.5 rounded-md border border-[rgb(var(--panel-border))] bg-[rgb(var(--bg))] px-2.5 py-1 text-[rgb(var(--muted))]"
+            >
+              <LucideIcon
+                name="CircleDashed"
                 class="h-3.5 w-3.5"
                 aria-hidden="true"
               />

--- a/frontend/components/account/AccountOverview.vue
+++ b/frontend/components/account/AccountOverview.vue
@@ -30,8 +30,9 @@ const wikidotStatus = computed(() => (
   props.user.linkedWikidotId ? '已连接' : '未连接'
 ))
 
-// AuthUser 只带 linkedWikidotId，展示用户名需要回查 BFF 的公开用户资料
-const { data: linkedWikidotProfile } = await useAsyncData(
+// AuthUser 只带 linkedWikidotId，展示用户名需要回查 BFF 的公开用户资料。
+// 不 await：用户名只是徽章的可选补充，查询慢或失败不能挂起整个概览面板
+const { data: linkedWikidotProfile } = useAsyncData(
   () => 'account-overview-wikidot-profile',
   async () => {
     if (!linkedWikidotId.value) return null
@@ -44,7 +45,7 @@ const { data: linkedWikidotProfile } = await useAsyncData(
       return null
     }
   },
-  { server: false, watch: [linkedWikidotId] }
+  { server: false, lazy: true, watch: [linkedWikidotId] }
 )
 
 const linkedWikidotName = computed(() => (


### PR DESCRIPTION
## 背景

账号页重构后，从 /account 进入自己的 scpper 用户页变得困难。

## 改动

- /account 概览的「Wikidot 已连接」徽章在绑定后追加显示 Wikidot 用户名，整个徽章可点击跳转 `/user/[wikidotId]`
- 用户名通过 BFF `/users/by-wikidot-id`（BFF 侧有 300s 缓存）在客户端回查；`AuthUser` 只携带 `linkedWikidotId`，不改 user-backend
- 未绑定状态外观保持不变

## 验证

- `npm run lint`：本文件通过（TagCheckTool.vue / user/[wikidotId].vue 的 3 个报错为 main 上已存在的历史问题）
- `npm run typecheck`：main 上本来就因 npx 缓存的 vue-tsc/typescript 不兼容而失败（ERR_PACKAGE_PATH_NOT_EXPORTED），与本次改动无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)