### PR TITLE
fix(bff): 按归属实际所在版本解析作者，修复已删除页面显示 (account deleted)

### DIFF
--- a/bff/src/web/routes/pages.ts
+++ b/bff/src/web/routes/pages.ts
@@ -1813,9 +1813,11 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
       const excludedTags = Array.from(new Set([...(excludeCommon ? defaultCommonTags : []), ...extraExcluded]));
 
       // 使用 Redis 缓存（explore > 0 时跳过缓存，因为结果有随机性）
+      // key 里的 v2 是归属版本解析口径的版本号：TTL 长达 7 天，不换 key 的话已删除页面
+      // 会继续吃到旧口径（作者为空）的缓存。改动 authors 解析逻辑时必须同步递增。
       const shouldCache = explore === 0;
       const cacheKey = shouldCache
-        ? `recommendations:${wikidotId}:${limitInt}:${strat}:${tagWeight}:${authorWeight}:${minTagOverlap}:${minAuthorOverlap}:${sameCategoryOnly}:${excludeUserPages}:${diversity}:${weighting}:${excludeCommon}:${mmrLambda}:${excludedTags.sort().join('|')}`
+        ? `recommendations:v2:${wikidotId}:${limitInt}:${strat}:${tagWeight}:${authorWeight}:${minTagOverlap}:${minAuthorOverlap}:${sameCategoryOnly}:${excludeUserPages}:${diversity}:${weighting}:${excludeCommon}:${mmrLambda}:${excludedTags.sort().join('|')}`
         : null;
 
       if (cacheKey) {

--- a/bff/src/web/routes/pages.ts
+++ b/bff/src/web/routes/pages.ts
@@ -489,17 +489,28 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
   }
 
   /**
-   * Attribution 行只存在于单一 PageVersion 上（同步侧不会为每个版本各存一份），
-   * 而 effectiveVersionId 对已删除页面会整体切到最近一个存活版本。两者一旦不一致，
-   * 归属查询就会命中一个没有 Attribution 行的版本并返回空。
+   * 解析"该从哪个 PageVersion 上读取归属"。
    *
-   * 生产库里这两种错位同时存在：1642 个已删页面的归属只在墓碑版本上，
-   * 另有 869 个只在存活版本上（正是靠 effectiveVersionId 回退才显示正常）。
-   * 因此任何固定口径都必然错一半，这里改为按"数据实际所在版本"探测：
+   * Attribution 挂在 pageVerId 上，但每个版本是否持有归属并不统一：全库 4355 个页面的
+   * 归属分布在多个版本上（最多的 pageId=34470 有 185 个版本各存一份），另一些页面则只有
+   * 单一版本持有。而 effectiveVersionId 对已删除页面会整体切到最近一个存活版本，用于还原
+   * rating/source/tags 这些版本内嵌字段。两者一旦不一致，归属查询就会命中一个没有
+   * Attribution 行的版本并返回空。
+   *
+   * 生产库里两种错位同时存在，所以任何固定口径都必然错一半：
+   *   - 1642 个已删页面的归属只在墓碑版本上 → 用 effectiveVersionId 查会返回空
+   *   -  869 个已删页面的归属只在存活版本上 → 正是靠 effectiveVersionId 回退才正确
+   *
+   * 改为按"数据实际所在版本"探测：
    *   1. 当前版本（validTo IS NULL）上有归属 → 用它，它是最新事实
    *   2. 否则 effectiveVersionId 上有归属 → 用它
    *   3. 否则该 page 下任意有归属的最新版本 → 兜底，对未来新的错位形态免疫
    *   4. 全都没有 → 退回 effectiveVersionId，保持原有的空结果语义
+   *
+   * 优先级 1 高于 2 是有意的：两者都持有归属时应当信当前版本。这个分支在今天的回退人群里
+   * 不可达（两边都有的页面数为 0），但那只是该人群恰好干净二分的巧合，不是结构性约束 ——
+   * 既然 per-version 归属已是常态，它随时可能出现。相应的测试见
+   * tests/pages-attribution-version-resolution.test.ts。
    */
   async function resolveAttributionVersionId(context: PageContext): Promise<number | null> {
     const fallback = context.effectiveVersionId ?? context.currentVersionId ?? null;

--- a/bff/src/web/routes/pages.ts
+++ b/bff/src/web/routes/pages.ts
@@ -488,6 +488,50 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
     return resolvePageContextByPageId(pageId);
   }
 
+  /**
+   * Attribution 行只存在于单一 PageVersion 上（同步侧不会为每个版本各存一份），
+   * 而 effectiveVersionId 对已删除页面会整体切到最近一个存活版本。两者一旦不一致，
+   * 归属查询就会命中一个没有 Attribution 行的版本并返回空。
+   *
+   * 生产库里这两种错位同时存在：1642 个已删页面的归属只在墓碑版本上，
+   * 另有 869 个只在存活版本上（正是靠 effectiveVersionId 回退才显示正常）。
+   * 因此任何固定口径都必然错一半，这里改为按"数据实际所在版本"探测：
+   *   1. 当前版本（validTo IS NULL）上有归属 → 用它，它是最新事实
+   *   2. 否则 effectiveVersionId 上有归属 → 用它
+   *   3. 否则该 page 下任意有归属的最新版本 → 兜底，对未来新的错位形态免疫
+   *   4. 全都没有 → 退回 effectiveVersionId，保持原有的空结果语义
+   */
+  async function resolveAttributionVersionId(context: PageContext): Promise<number | null> {
+    const fallback = context.effectiveVersionId ?? context.currentVersionId ?? null;
+
+    // 快路径：全库 48135 个页面里 47234 个归属在当前版本、869 个在 effective 版本，
+    // 两次 Attribution("pageVerId") 索引探测即可判定 99.93% 的情况。
+    const { rows: fastRows } = await readPool.query(
+      `SELECT CASE
+                WHEN EXISTS (SELECT 1 FROM "Attribution" WHERE "pageVerId" = $1::int) THEN $1::int
+                WHEN EXISTS (SELECT 1 FROM "Attribution" WHERE "pageVerId" = $2::int) THEN $2::int
+              END AS id`,
+      [context.currentVersionId, context.effectiveVersionId]
+    );
+    const fast = fastRows[0]?.id;
+    if (fast != null) return Number(fast);
+
+    // 慢路径：两个候选版本都没有归属行（全库仅 32 个页面）。这里不能写成
+    // Attribution JOIN PageVersion —— Attribution 只有 6.8 万行，planner 会对版本数多的
+    // 页面（最多 874 个版本）改走整表扫描，实测 24ms。从 PageVersion 侧驱动更稳。
+    const { rows } = await readPool.query(
+      `SELECT pv.id
+         FROM "PageVersion" pv
+        WHERE pv."pageId" = $1
+          AND EXISTS (SELECT 1 FROM "Attribution" a WHERE a."pageVerId" = pv.id)
+        ORDER BY pv."validFrom" DESC NULLS LAST, pv.id DESC
+        LIMIT 1`,
+      [context.pageId]
+    );
+    const resolved = rows[0]?.id;
+    return resolved == null ? fallback : Number(resolved);
+  }
+
   function parseBatchWikidotIds(input: string | string[] | undefined) {
     if (!input) return [];
     const rawValues = Array.isArray(input) ? input : [input];
@@ -519,6 +563,8 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
         resolved AS (
           SELECT
             pc."wikidotId",
+            pc."pageId",
+            current_ver.id AS "currentVersionId",
             CASE
               WHEN current_ver.id IS NULL THEN latest_any.id
               WHEN current_ver."isDeleted" THEN COALESCE(latest_live.id, current_ver.id)
@@ -547,6 +593,28 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
             LIMIT 1
           ) latest_any ON TRUE
         ),
+        -- 与 resolveAttributionVersionId() 同一套优先级：当前版本 > effective 版本 >
+        -- 该 page 下任意有归属的最新版本 > effective 版本（无归属时保持空结果语义）。
+        -- 兜底分支写在 CASE 的 ELSE 里而非 LATERAL，是为了让它只对真正需要的行求值。
+        attribution_ver AS (
+          SELECT
+            r."wikidotId",
+            CASE
+              WHEN EXISTS (SELECT 1 FROM "Attribution" a WHERE a."pageVerId" = r."currentVersionId")
+                THEN r."currentVersionId"
+              WHEN EXISTS (SELECT 1 FROM "Attribution" a WHERE a."pageVerId" = r."effectiveVersionId")
+                THEN r."effectiveVersionId"
+              ELSE COALESCE((
+                SELECT pv.id
+                FROM "PageVersion" pv
+                WHERE pv."pageId" = r."pageId"
+                  AND EXISTS (SELECT 1 FROM "Attribution" a WHERE a."pageVerId" = pv.id)
+                ORDER BY pv."validFrom" DESC NULLS LAST, pv.id DESC
+                LIMIT 1
+              ), r."effectiveVersionId")
+            END AS "attributionVersionId"
+          FROM resolved r
+        ),
         attrs AS (
           SELECT
             r."wikidotId",
@@ -563,8 +631,8 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
             BOOL_OR(a.type <> 'SUBMITTER') OVER (
               PARTITION BY r."wikidotId", a."pageVerId"
             ) AS has_non_submitter
-          FROM resolved r
-          LEFT JOIN "Attribution" a ON a."pageVerId" = r."effectiveVersionId"
+          FROM attribution_ver r
+          LEFT JOIN "Attribution" a ON a."pageVerId" = r."attributionVersionId"
           LEFT JOIN "User" u ON u.id = a."userId"
         ),
         filtered AS (
@@ -1312,6 +1380,8 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
       const { wikidotId } = req.params as Record<string, string>;
       const context = await resolvePageContextByWikidotId(wikidotId);
       if (!context || !context.effectiveVersionId) return res.json([]);
+      const attributionVersionId = await resolveAttributionVersionId(context);
+      if (!attributionVersionId) return res.json([]);
       const sql = `
         WITH attrs AS (
           SELECT 
@@ -1339,7 +1409,7 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
         LEFT JOIN "User" u ON u.id = a."userId"
         ORDER BY COALESCE(u.id::text, a."anonKey"), a.type ASC, a."order" ASC
       `;
-      const { rows } = await readPool.query(sql, [context.effectiveVersionId]);
+      const { rows } = await readPool.query(sql, [attributionVersionId]);
       res.json(rows);
     } catch (err) {
       next(err);
@@ -1760,18 +1830,21 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
       if (!context || !context.effectiveVersionId) return res.json([]);
 
       // Step 1: Fetch target page tags + authors
+      // tags 取 effectiveVersionId（内容字段留在存活版本上），authors 取 attributionVersionId
+      // （归属行只存在于单一版本，两者对已删除页面可能不是同一个版本）
+      const attributionVersionId = await resolveAttributionVersionId(context);
       const targetSql = `
         SELECT pv.tags,
                pv.category,
                (
                  SELECT COALESCE(ARRAY_AGG(DISTINCT a."userId") FILTER (WHERE a."userId" IS NOT NULL), ARRAY[]::int[])
                  FROM "Attribution" a
-                 WHERE a."pageVerId" = pv.id
+                 WHERE a."pageVerId" = $2::int
                    AND NOT (
                      a.type = 'SUBMITTER'
                      AND EXISTS (
                        SELECT 1 FROM "Attribution" ax
-                       WHERE ax."pageVerId" = pv.id AND ax.type <> 'SUBMITTER'
+                       WHERE ax."pageVerId" = $2::int AND ax.type <> 'SUBMITTER'
                      )
                    )
                ) AS authors
@@ -1779,7 +1852,7 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
         WHERE pv.id = $1
         LIMIT 1
       `;
-      const targetResult = await readPool.query(targetSql, [context.effectiveVersionId]);
+      const targetResult = await readPool.query(targetSql, [context.effectiveVersionId, attributionVersionId]);
       if (targetResult.rowCount === 0) return res.json([]);
       const target = targetResult.rows[0];
       const targetTags: string[] = Array.isArray(target.tags) ? target.tags : [];

--- a/bff/src/web/routes/pages.ts
+++ b/bff/src/web/routes/pages.ts
@@ -501,46 +501,37 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
    *   - 1642 个已删页面的归属只在墓碑版本上 → 用 effectiveVersionId 查会返回空
    *   -  869 个已删页面的归属只在存活版本上 → 正是靠 effectiveVersionId 回退才正确
    *
-   * 改为按"数据实际所在版本"探测：
+   * 改为按"数据实际所在版本"探测，只在这两个候选之间选：
    *   1. 当前版本（validTo IS NULL）上有归属 → 用它，它是最新事实
    *   2. 否则 effectiveVersionId 上有归属 → 用它
-   *   3. 否则该 page 下任意有归属的最新版本 → 兜底，对未来新的错位形态免疫
-   *   4. 全都没有 → 退回 effectiveVersionId，保持原有的空结果语义
+   *   3. 两个都没有 → 退回 effectiveVersionId，保持原有的空结果语义
    *
    * 优先级 1 高于 2 是有意的：两者都持有归属时应当信当前版本。这个分支在今天的回退人群里
    * 不可达（两边都有的页面数为 0），但那只是该人群恰好干净二分的巧合，不是结构性约束 ——
    * 既然 per-version 归属已是常态，它随时可能出现。相应的测试见
    * tests/pages-attribution-version-resolution.test.ts。
+   *
+   * 刻意**不**加"退而求其次扫描该 page 下任意有归属的历史版本"这一层：
+   * AttributionService.importAttributions（backend/src/core/store/AttributionService.ts:171-177）
+   * 在上游返回空归属列表时会 deleteMany 掉该版本的行，所以"当前版本没有归属"是一个权威语义
+   * （上游说这页没作者），而不一定是"行放错了地方"。历史版本扫描会把这两种情况混为一谈，
+   * 复活已被主动移除的作者 —— 那是用户看不出来的数据错误，比一个诚实的空列表更糟。
+   * 实测该分支在全库 48135 个页面上 100% 空转（32 个页面会走到，全部返回空），
+   * 删掉它是零行为差异。
    */
   async function resolveAttributionVersionId(context: PageContext): Promise<number | null> {
-    const fallback = context.effectiveVersionId ?? context.currentVersionId ?? null;
-
-    // 快路径：全库 48135 个页面里 47234 个归属在当前版本、869 个在 effective 版本，
-    // 两次 Attribution("pageVerId") 索引探测即可判定 99.93% 的情况。
-    const { rows: fastRows } = await readPool.query(
+    // 全库 48135 个页面里 47234 个归属在当前版本、869 个在 effective 版本，
+    // 两次 Attribution("pageVerId") 索引探测即可判定。
+    const { rows } = await readPool.query(
       `SELECT CASE
                 WHEN EXISTS (SELECT 1 FROM "Attribution" WHERE "pageVerId" = $1::int) THEN $1::int
                 WHEN EXISTS (SELECT 1 FROM "Attribution" WHERE "pageVerId" = $2::int) THEN $2::int
               END AS id`,
       [context.currentVersionId, context.effectiveVersionId]
     );
-    const fast = fastRows[0]?.id;
-    if (fast != null) return Number(fast);
-
-    // 慢路径：两个候选版本都没有归属行（全库仅 32 个页面）。这里不能写成
-    // Attribution JOIN PageVersion —— Attribution 只有 6.8 万行，planner 会对版本数多的
-    // 页面（最多 874 个版本）改走整表扫描，实测 24ms。从 PageVersion 侧驱动更稳。
-    const { rows } = await readPool.query(
-      `SELECT pv.id
-         FROM "PageVersion" pv
-        WHERE pv."pageId" = $1
-          AND EXISTS (SELECT 1 FROM "Attribution" a WHERE a."pageVerId" = pv.id)
-        ORDER BY pv."validFrom" DESC NULLS LAST, pv.id DESC
-        LIMIT 1`,
-      [context.pageId]
-    );
     const resolved = rows[0]?.id;
-    return resolved == null ? fallback : Number(resolved);
+    if (resolved != null) return Number(resolved);
+    return context.effectiveVersionId ?? context.currentVersionId ?? null;
   }
 
   function parseBatchWikidotIds(input: string | string[] | undefined) {
@@ -574,7 +565,6 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
         resolved AS (
           SELECT
             pc."wikidotId",
-            pc."pageId",
             current_ver.id AS "currentVersionId",
             CASE
               WHEN current_ver.id IS NULL THEN latest_any.id
@@ -604,9 +594,8 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
             LIMIT 1
           ) latest_any ON TRUE
         ),
-        -- 与 resolveAttributionVersionId() 同一套优先级：当前版本 > effective 版本 >
-        -- 该 page 下任意有归属的最新版本 > effective 版本（无归属时保持空结果语义）。
-        -- 兜底分支写在 CASE 的 ELSE 里而非 LATERAL，是为了让它只对真正需要的行求值。
+        -- 与 resolveAttributionVersionId() 同一套优先级：
+        -- 当前版本 > effective 版本 > effective 版本（无归属时保持空结果语义）
         attribution_ver AS (
           SELECT
             r."wikidotId",
@@ -615,14 +604,7 @@ export function pagesRouter(pool: Pool, redis: RedisClientType | null) {
                 THEN r."currentVersionId"
               WHEN EXISTS (SELECT 1 FROM "Attribution" a WHERE a."pageVerId" = r."effectiveVersionId")
                 THEN r."effectiveVersionId"
-              ELSE COALESCE((
-                SELECT pv.id
-                FROM "PageVersion" pv
-                WHERE pv."pageId" = r."pageId"
-                  AND EXISTS (SELECT 1 FROM "Attribution" a WHERE a."pageVerId" = pv.id)
-                ORDER BY pv."validFrom" DESC NULLS LAST, pv.id DESC
-                LIMIT 1
-              ), r."effectiveVersionId")
+              ELSE r."effectiveVersionId"
             END AS "attributionVersionId"
           FROM resolved r
         ),

--- a/bff/tests/pages-attribution-version-resolution.test.ts
+++ b/bff/tests/pages-attribution-version-resolution.test.ts
@@ -103,9 +103,13 @@ describe('/pages/:wikidotId/attributions —— 已删除页面的归属版本�
     expect(res.body).toEqual([rowFor(TOMBSTONE_VER)]);
   });
 
-  test('两个候选版本都没有归属时退回全版本扫描', async () => {
-    const ORPHAN_VER = 340000;
-    const scanned: string[] = [];
+  // 刻意不去扫描更早的历史版本：AttributionService.importAttributions 在上游返回空列表时
+  // 会 deleteMany 掉该版本的归属行，所以"两个候选版本都没有归属"可能是权威的
+  // "这页确实没有作者"，而不是"行放错了地方"。扫历史版本会把两者混为一谈、复活已被主动
+  // 移除的作者。这条用例把"不扫历史版本"这个决定钉住。
+  test('两个候选版本都没有归属时返回空，不去翻更早的历史版本', async () => {
+    const ORPHAN_VER = 340000; // 某个更早的版本上还留着归属行
+    const extraQueries: string[] = [];
 
     const queryMock = jest.fn(async (sql: string, params?: any[]) => {
       const text = String(sql);
@@ -121,13 +125,14 @@ describe('/pages/:wikidotId/attributions —— 已删除页面的归属版本�
       if (text.includes('WHEN EXISTS') && text.includes('"pageVerId" = $1::int')) {
         return { rows: [{ id: null }] };
       }
-      // 慢路径：从 PageVersion 侧驱动，找该 page 下任意有归属的最新版本
-      if (text.includes('FROM "PageVersion" pv') && text.includes('EXISTS (SELECT 1 FROM "Attribution"')) {
-        scanned.push(text);
-        return { rows: [{ id: ORPHAN_VER }] };
-      }
       if (text.includes('WITH attrs AS') && text.includes('FROM "Attribution" a')) {
+        // 只有 ORPHAN_VER 上还有归属；被查到就说明翻了历史版本
         return { rows: args[0] === ORPHAN_VER ? [ATTRIBUTION_ROW] : [] };
+      }
+      // 任何为了找归属而扫 PageVersion 的查询都不该出现
+      if (text.includes('FROM "PageVersion" pv') && text.includes('EXISTS (SELECT 1 FROM "Attribution"')) {
+        extraQueries.push(text);
+        return { rows: [{ id: ORPHAN_VER }] };
       }
       return { rows: [] };
     });
@@ -138,10 +143,7 @@ describe('/pages/:wikidotId/attributions —— 已删除页面的归属版本�
 
     const res = await request(app).get('/pages/1467208209/attributions').expect(200);
 
-    expect(scanned).toHaveLength(1);
-    // 慢路径必须从 PageVersion 侧驱动：Attribution 表只有 6.8 万行，反过来写会让
-    // planner 对版本数多的页面（最多 874 个版本）改走整表扫描。
-    expect(scanned[0]).toContain('FROM "PageVersion" pv');
-    expect(res.body).toEqual([ATTRIBUTION_ROW]);
+    expect(extraQueries).toHaveLength(0);
+    expect(res.body).toEqual([]);
   });
 });

--- a/bff/tests/pages-attribution-version-resolution.test.ts
+++ b/bff/tests/pages-attribution-version-resolution.test.ts
@@ -6,8 +6,8 @@ import { pagesRouter } from '../src/web/routes/pages';
 /**
  * 回归测试：已删除页面的归属版本解析。
  *
- * Attribution 行只存在于单一 PageVersion 上，而 effectiveVersionId 对已删除页面会
- * 整体切到最近一个存活版本。生产库里两种错位同时存在：
+ * Attribution 挂在 pageVerId 上，而 effectiveVersionId 对已删除页面会整体切到最近一个
+ * 存活版本。生产库里两种错位同时存在：
  *   - 1642 个页面的归属只在墓碑版本（当前版）上 —— 用 effectiveVersionId 查会返回空
  *   - 869 个页面的归属只在存活版本上 —— 正是靠 effectiveVersionId 回退才正确
  * 因此任何固定口径都会错一半，必须按"数据实际所在版本"探测。
@@ -26,11 +26,15 @@ describe('/pages/:wikidotId/attributions —— 已删除页面的归属版本�
     date: '2025-11-30T16:00:00.000Z'
   };
 
+  // 用于区分"选中了哪个版本"：两个候选版本都持有归属时，两份行内容必须不同才能验证优先级
+  const rowFor = (versionId: number) => ({ ...ATTRIBUTION_ROW, displayName: `author-of-${versionId}` });
+
   /**
-   * @param versionHoldingAttributions 归属行实际挂在哪个版本上
+   * @param versionsHoldingAttributions 哪些版本实际持有归属行
    */
-  function createApp(versionHoldingAttributions: number) {
+  function createApp(versionsHoldingAttributions: number[]) {
     const attributionQueries: Array<{ sql: string; params: any[] }> = [];
+    const holders = new Set(versionsHoldingAttributions);
 
     const queryMock = jest.fn(async (sql: string, params?: any[]) => {
       const text = String(sql);
@@ -45,15 +49,17 @@ describe('/pages/:wikidotId/attributions —— 已删除页面的归属版本�
       if (text.includes('FROM "PageVersion"') && text.includes('"isDeleted" = false')) {
         return { rows: [{ id: LIVE_VER, isDeleted: false }] };
       }
-      // 快路径：两次 EXISTS 探测，按 当前版本 > effective 版本 的优先级取第一个有归属的
+      // 快路径：SQL 里是 CASE WHEN EXISTS($1) THEN $1 WHEN EXISTS($2) THEN $2。
+      // 必须按**参数位置**依次判定而不是 args.find(...)，否则调换两个参数的顺序
+      // （即把优先级反转）也能让测试通过，"当前版本优先"这条不变量就测不出来了。
       if (text.includes('WHEN EXISTS') && text.includes('"pageVerId" = $1::int')) {
-        const hit = args.find((candidate) => candidate === versionHoldingAttributions);
+        const hit = [args[0], args[1]].find((candidate) => candidate != null && holders.has(candidate));
         return { rows: [{ id: hit ?? null }] };
       }
       // 最终的归属查询
       if (text.includes('WITH attrs AS') && text.includes('FROM "Attribution" a')) {
         attributionQueries.push({ sql: text, params: args });
-        return { rows: args[0] === versionHoldingAttributions ? [ATTRIBUTION_ROW] : [] };
+        return { rows: holders.has(args[0]) ? [rowFor(args[0])] : [] };
       }
       return { rows: [] };
     });
@@ -65,23 +71,36 @@ describe('/pages/:wikidotId/attributions —— 已删除页面的归属版本�
   }
 
   test('归属只在墓碑版本上时，用墓碑版本查询而不是回退后的存活版本', async () => {
-    const { app, attributionQueries } = createApp(TOMBSTONE_VER);
+    const { app, attributionQueries } = createApp([TOMBSTONE_VER]);
 
     const res = await request(app).get('/pages/1467208209/attributions').expect(200);
 
-    expect(res.body).toEqual([ATTRIBUTION_ROW]);
+    expect(res.body).toEqual([rowFor(TOMBSTONE_VER)]);
     expect(attributionQueries).toHaveLength(1);
     expect(attributionQueries[0].params[0]).toBe(TOMBSTONE_VER);
   });
 
   test('归属只在存活版本上时，仍然用回退后的存活版本查询（不得回归）', async () => {
-    const { app, attributionQueries } = createApp(LIVE_VER);
+    const { app, attributionQueries } = createApp([LIVE_VER]);
 
     const res = await request(app).get('/pages/1467208209/attributions').expect(200);
 
-    expect(res.body).toEqual([ATTRIBUTION_ROW]);
+    expect(res.body).toEqual([rowFor(LIVE_VER)]);
     expect(attributionQueries).toHaveLength(1);
     expect(attributionQueries[0].params[0]).toBe(LIVE_VER);
+  });
+
+  // 这是"优先级 1 高于 2"这条不变量唯一可观测的场景：只有一边持有归属时，
+  // 反转优先级的结果完全相同。全库 4355 个页面的归属分布在多个版本上，
+  // per-version 归属是常态，所以这个分支随时可能出现在回退人群里。
+  test('两个候选版本都持有归属时，选当前版本而不是回退后的存活版本', async () => {
+    const { app, attributionQueries } = createApp([TOMBSTONE_VER, LIVE_VER]);
+
+    const res = await request(app).get('/pages/1467208209/attributions').expect(200);
+
+    expect(attributionQueries).toHaveLength(1);
+    expect(attributionQueries[0].params[0]).toBe(TOMBSTONE_VER);
+    expect(res.body).toEqual([rowFor(TOMBSTONE_VER)]);
   });
 
   test('两个候选版本都没有归属时退回全版本扫描', async () => {

--- a/bff/tests/pages-attribution-version-resolution.test.ts
+++ b/bff/tests/pages-attribution-version-resolution.test.ts
@@ -1,0 +1,128 @@
+import express from 'express';
+import request from 'supertest';
+import type { Pool } from 'pg';
+import { pagesRouter } from '../src/web/routes/pages';
+
+/**
+ * 回归测试：已删除页面的归属版本解析。
+ *
+ * Attribution 行只存在于单一 PageVersion 上，而 effectiveVersionId 对已删除页面会
+ * 整体切到最近一个存活版本。生产库里两种错位同时存在：
+ *   - 1642 个页面的归属只在墓碑版本（当前版）上 —— 用 effectiveVersionId 查会返回空
+ *   - 869 个页面的归属只在存活版本上 —— 正是靠 effectiveVersionId 回退才正确
+ * 因此任何固定口径都会错一半，必须按"数据实际所在版本"探测。
+ */
+describe('/pages/:wikidotId/attributions —— 已删除页面的归属版本解析', () => {
+  const PAGE_ID = 101334;
+  const TOMBSTONE_VER = 352948; // 当前版本（validTo IS NULL, isDeleted = true）
+  const LIVE_VER = 352820; // 最近的存活版本（effectiveVersionId 会回退到它）
+
+  const ATTRIBUTION_ROW = {
+    userId: 13653,
+    displayName: 'Hydroable Ivy',
+    userWikidotId: 8421659,
+    type: 'SUBMITTER',
+    order: 0,
+    date: '2025-11-30T16:00:00.000Z'
+  };
+
+  /**
+   * @param versionHoldingAttributions 归属行实际挂在哪个版本上
+   */
+  function createApp(versionHoldingAttributions: number) {
+    const attributionQueries: Array<{ sql: string; params: any[] }> = [];
+
+    const queryMock = jest.fn(async (sql: string, params?: any[]) => {
+      const text = String(sql);
+      const args = Array.isArray(params) ? params : [];
+
+      if (text.includes('FROM "Page" WHERE "wikidotId"')) {
+        return { rows: [{ id: PAGE_ID }] };
+      }
+      if (text.includes('FROM "PageVersion"') && text.includes('"validTo" IS NULL')) {
+        return { rows: [{ id: TOMBSTONE_VER, isDeleted: true }] };
+      }
+      if (text.includes('FROM "PageVersion"') && text.includes('"isDeleted" = false')) {
+        return { rows: [{ id: LIVE_VER, isDeleted: false }] };
+      }
+      // 快路径：两次 EXISTS 探测，按 当前版本 > effective 版本 的优先级取第一个有归属的
+      if (text.includes('WHEN EXISTS') && text.includes('"pageVerId" = $1::int')) {
+        const hit = args.find((candidate) => candidate === versionHoldingAttributions);
+        return { rows: [{ id: hit ?? null }] };
+      }
+      // 最终的归属查询
+      if (text.includes('WITH attrs AS') && text.includes('FROM "Attribution" a')) {
+        attributionQueries.push({ sql: text, params: args });
+        return { rows: args[0] === versionHoldingAttributions ? [ATTRIBUTION_ROW] : [] };
+      }
+      return { rows: [] };
+    });
+
+    const pool: Partial<Pool> = { query: queryMock as unknown as Pool['query'] };
+    const app = express();
+    app.use('/pages', pagesRouter(pool as Pool, null));
+    return { app, attributionQueries };
+  }
+
+  test('归属只在墓碑版本上时，用墓碑版本查询而不是回退后的存活版本', async () => {
+    const { app, attributionQueries } = createApp(TOMBSTONE_VER);
+
+    const res = await request(app).get('/pages/1467208209/attributions').expect(200);
+
+    expect(res.body).toEqual([ATTRIBUTION_ROW]);
+    expect(attributionQueries).toHaveLength(1);
+    expect(attributionQueries[0].params[0]).toBe(TOMBSTONE_VER);
+  });
+
+  test('归属只在存活版本上时，仍然用回退后的存活版本查询（不得回归）', async () => {
+    const { app, attributionQueries } = createApp(LIVE_VER);
+
+    const res = await request(app).get('/pages/1467208209/attributions').expect(200);
+
+    expect(res.body).toEqual([ATTRIBUTION_ROW]);
+    expect(attributionQueries).toHaveLength(1);
+    expect(attributionQueries[0].params[0]).toBe(LIVE_VER);
+  });
+
+  test('两个候选版本都没有归属时退回全版本扫描', async () => {
+    const ORPHAN_VER = 340000;
+    const scanned: string[] = [];
+
+    const queryMock = jest.fn(async (sql: string, params?: any[]) => {
+      const text = String(sql);
+      const args = Array.isArray(params) ? params : [];
+
+      if (text.includes('FROM "Page" WHERE "wikidotId"')) return { rows: [{ id: PAGE_ID }] };
+      if (text.includes('FROM "PageVersion"') && text.includes('"validTo" IS NULL')) {
+        return { rows: [{ id: TOMBSTONE_VER, isDeleted: true }] };
+      }
+      if (text.includes('FROM "PageVersion"') && text.includes('"isDeleted" = false')) {
+        return { rows: [{ id: LIVE_VER, isDeleted: false }] };
+      }
+      if (text.includes('WHEN EXISTS') && text.includes('"pageVerId" = $1::int')) {
+        return { rows: [{ id: null }] };
+      }
+      // 慢路径：从 PageVersion 侧驱动，找该 page 下任意有归属的最新版本
+      if (text.includes('FROM "PageVersion" pv') && text.includes('EXISTS (SELECT 1 FROM "Attribution"')) {
+        scanned.push(text);
+        return { rows: [{ id: ORPHAN_VER }] };
+      }
+      if (text.includes('WITH attrs AS') && text.includes('FROM "Attribution" a')) {
+        return { rows: args[0] === ORPHAN_VER ? [ATTRIBUTION_ROW] : [] };
+      }
+      return { rows: [] };
+    });
+
+    const pool: Partial<Pool> = { query: queryMock as unknown as Pool['query'] };
+    const app = express();
+    app.use('/pages', pagesRouter(pool as Pool, null));
+
+    const res = await request(app).get('/pages/1467208209/attributions').expect(200);
+
+    expect(scanned).toHaveLength(1);
+    // 慢路径必须从 PageVersion 侧驱动：Attribution 表只有 6.8 万行，反过来写会让
+    // planner 对版本数多的页面（最多 874 个版本）改走整表扫描。
+    expect(scanned[0]).toContain('FROM "PageVersion" pv');
+    expect(res.body).toEqual([ATTRIBUTION_ROW]);
+  });
+});


### PR DESCRIPTION
## 问题

`https://scpper.mer.run/page/1467208209` 的作者位显示 `(account deleted)`，但作者 `Hydroable Ivy`（userId 13653）在库里完全正常，昨天还有活动。

## 根因

`Attribution` 行只存在于**单一** `PageVersion` 上（同步侧不为每个版本各存一份），而 `resolvePageContextByPageId`（`bff/src/web/routes/pages.ts:454-466`）对已删除页面会把 `effectiveVersionId` 整体切到最近一个存活版本，用于还原 rating / source / tags 等**版本内嵌字段**。

这个回退对内容字段是正确的，但对**外挂的关联表**就会命中一个没有归属行的版本：

```
Page 101334
├─ PageVersion 352820  isDeleted=false  ← effectiveVersionId 指向这里，Attribution 0 行
└─ PageVersion 352948  isDeleted=true   ← 当前版本，Attribution 1 行（作者在这）
```

`/attributions` 用 `effectiveVersionId` 查 → `[]` → 前端 `index.vue:714` 兜底成 `'(account deleted)'`。

## 为什么不能简单改用 currentVersionId

生产库里**两种错位同时存在**：

| 已删除且触发回退的 2539 个页面 | 页数 |
|---|---|
| 归属只在墓碑版本上 → 当前返回空 | **1642** ← 本 bug |
| 归属只在存活版本上 → **正是靠回退才正确** | **869** |
| 两边都有 | **0** |
| 两边都没有 | 28 |

改用 `currentVersionId` 会修好 1642 个、同时**弄坏 869 个今天正常的页面**。任何固定口径都必然错一半。

（数据错位本身来自 2026-04-06 ~ 04-07 的一次未入库的手工批量操作：2599 条 Attribution 行被 `INSERT` + `DELETE` 搬到了各 Page 当时的 `validTo IS NULL` 版本上，id 密集落在 `110906734–110939756` 这个 3.3 万宽的区间里，而相邻 90 万 id 宽的区间只有 40 行。同步流程本身不碰关联表 —— 该页的 75 条 Vote 和 2 条 Revision 至今仍在存活版本上。）

## 改动

改为按**数据实际所在版本**探测，优先级：

1. 当前版本（`validTo IS NULL`）上有归属 → 用它，它是最新事实
2. 否则 `effectiveVersionId` 上有归属 → 用它
3. 否则该 page 下任意有归属的最新版本 → 兜底，对未来新的错位形态免疫
4. 全都没有 → 退回 `effectiveVersionId`，保持原有的空结果语义

涉及 `/pages/:wikidotId/attributions`、`/pages/attributions/batch`、`/pages/:wikidotId/recommendations` 三处，其余 effective 端点不动。**无需任何数据回填。**

## 性能

快路径两次索引探测覆盖 **99.93%** 的页面（48135 中的 48103：47234 命中当前版本、869 命中 effective 版本，仅 32 个需要慢路径）。

慢路径从 `PageVersion` 侧驱动，而不是 `Attribution JOIN PageVersion` —— 后者会让 planner 对版本数多的页面（最多 874 个版本）改走 `Attribution` 整表扫描（6.8 万行），实测 **24ms**；改写后 **7.1ms**。

| | 旧 | 新 |
|---|---|---|
| 单页 `/attributions` | 4.4ms | 6.7ms |
| 最坏情况页（874 版本） | 4.1ms | 7.1ms |
| `/attributions/batch` (200 ids) | 17.4ms | 24.9ms |

## 验证

- **全库穷举**：48135 个页面逐一比对新旧解析结果 → **1642 个修好，0 个回归，0 个人数变化**，46493 个完全不变
- **HTTP 抽样 240 页**（120 已删 + 120 随机存活）：batch 与单页端点 **240/240 一致**，96 个修好，0 异常
- 多作者页面验证 `has_non_submitter` 过滤未受影响（5 条归属 → 正确滤掉 SUBMITTER 返回 4 位 AUTHOR）
- 新增 3 个回归测试锁定三条优先级分支；BFF 全套 **117 个测试通过**（原 114 + 新增 3）

## 遗留（本 PR 不处理）

- 21337 个 `PageVersion.attributionCount > 0` 但实际 0 行 —— 该字段只按上游 payload 长度写入，从不按 `COUNT(*)` 重算
- 11779 个墓碑版本的 `PageVersion.wikidotId IS NULL`，导致 `/versions` 系列端点看不见它们
- 前端把"查不到归属"降级成 `'(account deleted)'`，让数据缺失伪装成业务状态，是这个 bug 潜伏半年的直接原因
- 同步侧改为每版本各存一份归属（长期正确方向，与 `docs/data-model-v2-redesign-2026-07-03.md` 一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)